### PR TITLE
Ensure consistent stack/thread handling between invocations.

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/node/InvokeNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/node/InvokeNode.java
@@ -79,7 +79,7 @@ public class InvokeNode<V> extends AbstractControlNode<InvokeToken> implements I
     @Override
     public InvokeToken getValue(Context context) {
         MethodDefinition<V> m = this.methodDescriptor.getOwner().findMethod(this.methodDescriptor);
-        CallResult<V> result = m.call(context.heap(), this.arguments.stream().map(e -> e.getValue(context)).collect(Collectors.toList()));
+        CallResult<V> result = m.call(context.thread(), this.arguments.stream().map(e -> e.getValue(context)).collect(Collectors.toList()));
         return new InvokeToken(result.getReturnValue(), result.getThrowValue());
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/node/NewNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/node/NewNode.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import cc.quarkus.qcc.graph.Graph;
+import cc.quarkus.qcc.interpret.InterpreterHeap;
 import cc.quarkus.qcc.type.ObjectReference;
 import cc.quarkus.qcc.interpret.Context;
 import cc.quarkus.qcc.type.TypeDescriptor;
@@ -16,7 +17,8 @@ public class NewNode extends AbstractNode<ObjectReference> {
 
     @Override
     public ObjectReference getValue(Context context) {
-        ObjectReference objRef = new ObjectReference(((TypeDescriptor.ObjectTypeDescriptor)typeDescriptor).getTypeDefinition());
+        InterpreterHeap heap = context.thread().heap();
+        ObjectReference objRef = heap.newObject(((TypeDescriptor.ObjectTypeDescriptor)typeDescriptor).getTypeDefinition());
         return objRef;
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/interpret/Context.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/interpret/Context.java
@@ -5,5 +5,5 @@ import cc.quarkus.qcc.graph.node.Node;
 public interface Context {
     <V> void set(Node<V> node, V value);
     <V> V get(Node<V> node);
-    Heap heap();
+    InterpreterThread thread();
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/interpret/Interpreter.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/interpret/Interpreter.java
@@ -4,23 +4,22 @@ import java.util.List;
 
 import cc.quarkus.qcc.graph.Graph;
 import cc.quarkus.qcc.graph.type.EndToken;
-import cc.quarkus.qcc.graph.type.StartToken;
 
 public class Interpreter<V> {
 
-    public Interpreter(Heap heap, Graph<V> graph) {
+    public Interpreter(InterpreterHeap heap, Graph<V> graph) {
         this.heap = heap;
         this.graph = graph;
     }
 
     public EndToken<V> execute(Object...arguments) {
-        return new Thread(this.heap).execute(this.graph, new StartToken(arguments));
+        return new InterpreterThread(this.heap).execute(this.graph, arguments);
     }
 
     public EndToken<V> execute(List<Object> arguments) {
-        return execute(arguments.toArray());
+        return new InterpreterThread(this.heap).execute(this.graph, arguments);
     }
 
-    private final Heap heap;
+    private final InterpreterHeap heap;
     private final Graph<V> graph;
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/interpret/InterpreterHeap.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/interpret/InterpreterHeap.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import cc.quarkus.qcc.type.ObjectReference;
 import cc.quarkus.qcc.type.TypeDefinition;
 
-public interface Heap {
+public interface InterpreterHeap {
     ObjectReference newObject(TypeDefinition type);
     Collection<ObjectReference> allocated();
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/interpret/InterpreterThread.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/interpret/InterpreterThread.java
@@ -16,14 +16,21 @@ import cc.quarkus.qcc.graph.node.RegionNode;
 import cc.quarkus.qcc.graph.type.ControlToken;
 import cc.quarkus.qcc.graph.type.EndToken;
 import cc.quarkus.qcc.graph.type.StartToken;
-import cc.quarkus.qcc.type.Sentinel;
 
-public class Thread implements Context {
+public class InterpreterThread implements Context {
 
-    public Thread(Heap heap) {
+    public InterpreterThread(InterpreterHeap heap) {
         this.heap = heap;
     }
 
+
+    public <V> EndToken<V> execute(Graph<V> graph, Object...arguments) {
+        return execute(graph, new StartToken(arguments));
+    }
+
+    public <V> EndToken<V> execute(Graph<V> graph, List<Object> arguments) {
+        return execute(graph, arguments.toArray());
+    }
 
     @SuppressWarnings("unchecked")
     public <V> EndToken<V> execute(Graph<V> graph, StartToken arguments) {
@@ -52,10 +59,6 @@ public class Thread implements Context {
         }
 
         List<Node<?>> worklist = new ArrayList<>(control.getSuccessors());
-
-        for (Node<?> node : worklist) {
-            //System.err.println( "wl=" + node);
-        }
 
         ControlNode<?> nextControl = null;
 
@@ -132,7 +135,7 @@ public class Thread implements Context {
     }
 
     protected void pushContext() {
-        this.callStack.push(new StackFrame(heap()));
+        this.callStack.push(new StackFrame(thread()));
     }
 
     protected void popContext() {
@@ -164,7 +167,11 @@ public class Thread implements Context {
     }
 
     @Override
-    public Heap heap() {
+    public InterpreterThread thread() {
+        return this;
+    }
+
+    public InterpreterHeap heap() {
         return this.heap;
     }
 
@@ -172,5 +179,5 @@ public class Thread implements Context {
 
     private EndToken<?> endToken;
 
-    private Heap heap;
+    private InterpreterHeap heap;
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/interpret/SimpleInterpreterHeap.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/interpret/SimpleInterpreterHeap.java
@@ -7,7 +7,7 @@ import java.util.List;
 import cc.quarkus.qcc.type.ObjectReference;
 import cc.quarkus.qcc.type.TypeDefinition;
 
-public class SimpleHeap implements Heap {
+public class SimpleInterpreterHeap implements InterpreterHeap {
 
     @Override
     public ObjectReference newObject(TypeDefinition type) {

--- a/compiler/src/main/java/cc/quarkus/qcc/interpret/StackFrame.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/interpret/StackFrame.java
@@ -7,12 +7,17 @@ import cc.quarkus.qcc.graph.node.Node;
 
 public class StackFrame implements Context {
 
-    protected StackFrame(Heap heap) {
-        this.heap = heap;
+    protected StackFrame(InterpreterThread thread) {
+        this.thread = thread;
     }
 
     @Override
     public <T> void set(Node<T> node, T value) {
+        if( value instanceof SimpleInterpreterHeap) {
+            System.err.println( this + " set " + node + " = " + value);
+            new Exception().printStackTrace();
+
+        }
         this.bindings.put(node, value);
     }
 
@@ -23,15 +28,15 @@ public class StackFrame implements Context {
     }
 
     @Override
-    public Heap heap() {
-        return this.heap;
+    public InterpreterThread thread() {
+        return this.thread;
     }
 
     public boolean contains(Node<?> node) {
         return this.bindings.containsKey(node);
     }
 
-    private final Heap heap;
+    private final InterpreterThread thread;
 
     private Map<Node<?>, Object> bindings = new HashMap<>();
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/type/LazyTypeDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/LazyTypeDefinition.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.atomic.AtomicReference;
 
-import cc.quarkus.qcc.interpret.Heap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 
 public class LazyTypeDefinition implements TypeDefinition {
     public LazyTypeDefinition(Universe universe, String name, boolean resolve) {
@@ -101,13 +101,13 @@ public class LazyTypeDefinition implements TypeDefinition {
     }
 
     @Override
-    public ObjectReference newInstance(Heap heap, Object... arguments) {
-        return getDelegate().newInstance(heap, arguments);
+    public ObjectReference newInstance(InterpreterThread thread, Object... arguments) {
+        return getDelegate().newInstance(thread, arguments);
     }
 
     @Override
-    public ObjectReference newInstance(Heap heap, List<Object> arguments) {
-        return getDelegate().newInstance(heap, arguments);
+    public ObjectReference newInstance(InterpreterThread thread, List<Object> arguments) {
+        return getDelegate().newInstance(thread, arguments);
     }
 
     @Override

--- a/compiler/src/main/java/cc/quarkus/qcc/type/MethodDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/MethodDefinition.java
@@ -5,8 +5,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import cc.quarkus.qcc.interpret.Heap;
-import cc.quarkus.qcc.interpret.SimpleHeap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
+import cc.quarkus.qcc.interpret.SimpleInterpreterHeap;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.TryCatchBlockNode;
 
@@ -25,16 +25,16 @@ public interface MethodDefinition<V> extends MethodDescriptor<V> {
     TypeDefinition getTypeDefinition();
 
     default CallResult<V> call(Object... arguments) {
-        return call(new SimpleHeap(), arguments);
+        return call(new InterpreterThread(new SimpleInterpreterHeap()), arguments);
     }
 
     default CallResult<V> call(List<Object> arguments) {
-        return call(new SimpleHeap(), arguments);
+        return call(new InterpreterThread(new SimpleInterpreterHeap()), arguments);
     }
 
-    CallResult<V> call(Heap heap, Object... arguments);
+    CallResult<V> call(InterpreterThread thread, Object... arguments);
 
-    CallResult<V> call(Heap heap, List<Object> arguments);
+    CallResult<V> call(InterpreterThread thread, List<Object> arguments);
 
     default void writeGraph(String path) throws IOException {
         writeGraph(Paths.get(path));

--- a/compiler/src/main/java/cc/quarkus/qcc/type/MethodDefinitionNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/MethodDefinitionNode.java
@@ -8,9 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import cc.quarkus.qcc.graph.DotWriter;
 import cc.quarkus.qcc.graph.Graph;
-import cc.quarkus.qcc.interpret.Context;
-import cc.quarkus.qcc.interpret.Heap;
-import cc.quarkus.qcc.interpret.Interpreter;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 import cc.quarkus.qcc.graph.build.GraphBuilder;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.InsnList;
@@ -95,15 +93,13 @@ public class MethodDefinitionNode<V> extends MethodNode implements MethodDefinit
     }
 
     @Override
-    public CallResult<V> call(Heap heap, Object... arguments) {
-        Interpreter<V> interp = new Interpreter<>(heap, getGraph());
-        return interp.execute(arguments);
+    public CallResult<V> call(InterpreterThread thread, Object... arguments) {
+        return thread.execute(getGraph(), arguments);
     }
 
     @Override
-    public CallResult<V> call(Heap heap, List<Object> arguments) {
-        Interpreter<V> interp = new Interpreter<>(heap, getGraph());
-        return interp.execute(arguments);
+    public CallResult<V> call(InterpreterThread thread, List<Object> arguments) {
+        return thread.execute(getGraph(), arguments);
     }
 
     @Override
@@ -114,7 +110,6 @@ public class MethodDefinitionNode<V> extends MethodNode implements MethodDefinit
         }
 
         Files.createDirectories(path.getParent());
-
 
         try ( DotWriter writer = new DotWriter(path) ) {
             writer.write(getGraph());

--- a/compiler/src/main/java/cc/quarkus/qcc/type/TypeDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/TypeDefinition.java
@@ -3,8 +3,8 @@ package cc.quarkus.qcc.type;
 import java.util.List;
 import java.util.Set;
 
-import cc.quarkus.qcc.interpret.Heap;
-import cc.quarkus.qcc.interpret.SimpleHeap;
+import cc.quarkus.qcc.interpret.SimpleInterpreterHeap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 
 public interface TypeDefinition {
     int getAccess();
@@ -34,14 +34,14 @@ public interface TypeDefinition {
     <V> void putField(FieldDefinition<V> field, ObjectReference objRef, V val);
 
     default ObjectReference newInstance(Object... arguments) {
-        return newInstance(new SimpleHeap(), arguments);
+        return newInstance(new InterpreterThread(new SimpleInterpreterHeap()), arguments);
     }
 
     default ObjectReference newInstance(List<Object> arguments) {
-        return newInstance(new SimpleHeap(), arguments);
+        return newInstance(new InterpreterThread(new SimpleInterpreterHeap()), arguments);
     }
 
-    ObjectReference newInstance(Heap heap, Object... arguments);
+    ObjectReference newInstance(InterpreterThread thread, Object... arguments);
 
-    ObjectReference newInstance(Heap heap, List<Object> arguments);
+    ObjectReference newInstance(InterpreterThread thread, List<Object> arguments);
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/type/TypeDefinitionNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/TypeDefinitionNode.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import cc.quarkus.qcc.interpret.Heap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
@@ -185,9 +185,9 @@ public class TypeDefinitionNode extends ClassNode implements TypeDefinition {
     }
 
     @Override
-    public ObjectReference newInstance(Heap heap, Object... ctorArguments) {
+    public ObjectReference newInstance(InterpreterThread thread, Object... ctorArguments) {
         List<Object> invocationArgs = new ArrayList<>();
-        ObjectReference objRef = heap.newObject(this);
+        ObjectReference objRef = thread.heap().newObject(this);
         invocationArgs.add(objRef);
         invocationArgs.addAll(Arrays.asList(ctorArguments));
         MethodDefinition<?> m = findMethod("<init>", invocationArgs);
@@ -196,7 +196,7 @@ public class TypeDefinitionNode extends ClassNode implements TypeDefinition {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        CallResult<?> result = m.call(heap, invocationArgs);
+        CallResult<?> result = m.call(thread, invocationArgs);
         if ( result.getReturnValue() != null ) {
             return objRef;
         }
@@ -204,7 +204,7 @@ public class TypeDefinitionNode extends ClassNode implements TypeDefinition {
     }
 
     @Override
-    public ObjectReference newInstance(Heap heap, List<Object> arguments) {
+    public ObjectReference newInstance(InterpreterThread thread, List<Object> arguments) {
         return null;
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/type/UnresolvableClassDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/UnresolvableClassDefinition.java
@@ -3,7 +3,7 @@ package cc.quarkus.qcc.type;
 import java.util.List;
 import java.util.Set;
 
-import cc.quarkus.qcc.interpret.Heap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 
 public class UnresolvableClassDefinition implements TypeDefinition {
 
@@ -51,12 +51,12 @@ public class UnresolvableClassDefinition implements TypeDefinition {
     }
 
     @Override
-    public ObjectReference newInstance(Heap heap, Object... arguments) {
+    public ObjectReference newInstance(InterpreterThread thread, Object... arguments) {
         return throwUnresolved();
     }
 
     @Override
-    public ObjectReference newInstance(Heap heap, List<Object> arguments) {
+    public ObjectReference newInstance(InterpreterThread thread, List<Object> arguments) {
         return throwUnresolved();
     }
 

--- a/compiler/src/test/java/cc/quarkus/qcc/graph/AbstractNodeTestCase.java
+++ b/compiler/src/test/java/cc/quarkus/qcc/graph/AbstractNodeTestCase.java
@@ -2,7 +2,8 @@ package cc.quarkus.qcc.graph;
 
 import cc.quarkus.qcc.AbstractTestCase;
 import cc.quarkus.qcc.graph.node.RegionNode;
-import cc.quarkus.qcc.interpret.SimpleHeap;
+import cc.quarkus.qcc.interpret.SimpleInterpreterHeap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 import cc.quarkus.qcc.type.ObjectReference;
 import cc.quarkus.qcc.type.TypeDescriptor;
 import cc.quarkus.qcc.type.Universe;
@@ -14,11 +15,12 @@ public class AbstractNodeTestCase extends AbstractTestCase {
     public void setUpNode() {
         this.method = new MockMethodDefinition<>();
         this.graph = new Graph<>(this.method);
-        this.heap = new SimpleHeap();
-        this.context = new MockContext(this.heap);
+        this.heap = new SimpleInterpreterHeap();
+        this.thread = new InterpreterThread(this.heap);
+        this.context = new MockContext(this.thread);
     }
 
-    protected SimpleHeap heap() {
+    protected SimpleInterpreterHeap heap() {
         return this.heap;
     }
 
@@ -60,11 +62,14 @@ public class AbstractNodeTestCase extends AbstractTestCase {
 
     protected Universe universe;
 
-    private SimpleHeap heap;
+    private InterpreterThread thread;
+
+    private SimpleInterpreterHeap heap;
 
     private MockContext context;
 
     private Graph<?> graph;
 
     private MockMethodDefinition<?> method;
+
 }

--- a/compiler/src/test/java/cc/quarkus/qcc/graph/MockContext.java
+++ b/compiler/src/test/java/cc/quarkus/qcc/graph/MockContext.java
@@ -5,12 +5,12 @@ import java.util.Map;
 
 import cc.quarkus.qcc.graph.node.Node;
 import cc.quarkus.qcc.interpret.Context;
-import cc.quarkus.qcc.interpret.Heap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 
 public class MockContext implements Context  {
 
-    MockContext(Heap heap) {
-        this.heap = heap;
+    MockContext(InterpreterThread thread) {
+        this.thread = thread;
     }
 
     @Override
@@ -25,10 +25,10 @@ public class MockContext implements Context  {
     }
 
     @Override
-    public Heap heap() {
-        return this.heap;
+    public InterpreterThread thread() {
+        return this.thread;
     }
 
-    private final Heap heap;
+    private final InterpreterThread thread;
     private Map<Node<?>, Object> values = new HashMap<>();
 }

--- a/compiler/src/test/java/cc/quarkus/qcc/graph/MockMethodDefinition.java
+++ b/compiler/src/test/java/cc/quarkus/qcc/graph/MockMethodDefinition.java
@@ -5,7 +5,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-import cc.quarkus.qcc.interpret.Heap;
+import cc.quarkus.qcc.interpret.InterpreterThread;
 import cc.quarkus.qcc.type.CallResult;
 import cc.quarkus.qcc.type.MethodDefinition;
 import cc.quarkus.qcc.type.TypeDefinition;
@@ -45,12 +45,12 @@ public class MockMethodDefinition<V> implements MethodDefinition<V> {
     }
 
     @Override
-    public CallResult<V> call(Heap heap, Object... arguments) {
+    public CallResult<V> call(InterpreterThread thread, Object... arguments) {
         return null;
     }
 
     @Override
-    public CallResult<V> call(Heap heap, List<Object> arguments) {
+    public CallResult<V> call(InterpreterThread thread, List<Object> arguments) {
         return null;
     }
 


### PR DESCRIPTION
Ensure new-instances are generated on the interpreter heap.
Rename interpeter classes to avoid JDK clashing.