### PR TITLE
Register class and interface literals to avoid NPE

### DIFF
--- a/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/ValidatedTypeDefinitionImpl.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/ValidatedTypeDefinitionImpl.java
@@ -43,9 +43,13 @@ final class ValidatedTypeDefinitionImpl implements ValidatedTypeDefinition {
             interfaceTypes[i] = (InterfaceTypeIdLiteral) classType;
         }
         if (isInterface()) {
-            typeId = getContext().getLiteralFactory().literalOfInterface(getInternalName(), interfaceTypes);
+            InterfaceTypeIdLiteral interfaceTypeId = getContext().getLiteralFactory().literalOfInterface(getInternalName(), interfaceTypes);
+            getContext().registerInterfaceLiteral(interfaceTypeId, this);
+            typeId = interfaceTypeId;
         } else {
-            typeId = getContext().getLiteralFactory().literalOfClass(getInternalName(), superType == null ? null : (ClassTypeIdLiteral) superType.getTypeId(), interfaceTypes);
+            ClassTypeIdLiteral classTypeId = getContext().getLiteralFactory().literalOfClass(getInternalName(), superType == null ? null : (ClassTypeIdLiteral) superType.getTypeId(), interfaceTypes);
+            getContext().registerClassLiteral(classTypeId, this);
+            typeId = classTypeId;
         }
         instanceFieldSet = new FieldSet(this, false);
         staticFieldSet = new FieldSet(this, true);


### PR DESCRIPTION
Fixes the following NPE:

```
jbang ./qcc.java
QCC...
Hello.java: error: Exception while constructing method body: java.lang.NullPointerException
    member: method main:Hello
  location: type Hello
MethodParser.java:1247: note: This is the location of the exception
    member: method resolveTargetOfFieldRef
  location: type MethodParser
Compilation failed with 1 error(s)
make: *** [qcc] Error 1
```

Hello class, along with JBang script to exercise it, can be found in my (private) [qoccido](https://github.com/galderz/qoccido) repo.