### PR TITLE
Rename VM types

### DIFF
--- a/compiler/graph/src/main/java/cc/quarkus/qcc/context/CompilationContext.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/context/CompilationContext.java
@@ -3,7 +3,7 @@ package cc.quarkus.qcc.context;
 import java.nio.file.Path;
 
 import cc.quarkus.qcc.graph.literal.LiteralFactory;
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.definition.ClassContext;
 import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
@@ -22,7 +22,7 @@ public interface CompilationContext extends DiagnosticContext {
 
     ClassContext getBootstrapClassContext();
 
-    ClassContext constructClassContext(JavaObject classLoaderObject);
+    ClassContext constructClassContext(VmObject classLoaderObject);
 
     void enqueue(ExecutableElement element);
 

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/graph/literal/LiteralFactory.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/graph/literal/LiteralFactory.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 import cc.quarkus.qcc.graph.BlockLabel;
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.ValueType;
@@ -34,7 +34,7 @@ public interface LiteralFactory {
 
     NullLiteral literalOfNull();
 
-    ObjectLiteral literalOf(JavaObject value);
+    ObjectLiteral literalOf(VmObject value);
 
     ValueArrayTypeIdLiteral literalOfArrayType(ValueType elementType);
 
@@ -110,7 +110,7 @@ public interface LiteralFactory {
                 return NULL;
             }
 
-            public ObjectLiteral literalOf(final JavaObject value) {
+            public ObjectLiteral literalOf(final VmObject value) {
                 Assert.checkNotNullParam("value", value);
                 // todo: cache on object itself?
                 return new ObjectLiteral(typeSystem.getReferenceType(value.getObjectType()).asConst(), value);

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/graph/literal/ObjectLiteral.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/graph/literal/ObjectLiteral.java
@@ -2,7 +2,7 @@ package cc.quarkus.qcc.graph.literal;
 
 import cc.quarkus.qcc.constraint.Constraint;
 import cc.quarkus.qcc.graph.ValueVisitor;
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.ValueType;
 
@@ -11,9 +11,9 @@ import cc.quarkus.qcc.type.ValueType;
  */
 public final class ObjectLiteral extends Literal {
     private final ReferenceType type;
-    private final JavaObject value;
+    private final VmObject value;
 
-    ObjectLiteral(final ReferenceType type, final JavaObject value) {
+    ObjectLiteral(final ReferenceType type, final VmObject value) {
         this.type = type;
         this.value = value;
     }
@@ -26,7 +26,7 @@ public final class ObjectLiteral extends Literal {
         return value.getObjectType();
     }
 
-    public JavaObject getValue() {
+    public VmObject getValue() {
         return value;
     }
 

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/Dictionary.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/Dictionary.java
@@ -22,15 +22,15 @@ public class Dictionary implements ClassContext {
 
     private final ConcurrentHashMap<String, DefinedTypeDefinition> typesByName = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<TypeIdLiteral, DefinedTypeDefinition> typesByLiteral = new ConcurrentHashMap<>();
-    private final JavaObject classLoader;
-    private final JavaVMImpl vm;
+    private final VmObject classLoader;
+    private final VmImpl vm;
 
-    Dictionary(final JavaVMImpl vm) {
+    Dictionary(final VmImpl vm) {
         this.vm = vm;
         classLoader = null;
     }
 
-    Dictionary(JavaObject classLoader, final JavaVMImpl vm) {
+    Dictionary(VmObject classLoader, final VmImpl vm) {
         this.classLoader = Assert.checkNotNullParam("classLoader", classLoader);
         this.vm = vm;
     }
@@ -54,7 +54,7 @@ public class Dictionary implements ClassContext {
         if (typesByName.containsKey(name)) {
             return null;
         }
-        JavaVM vm = JavaVM.requireCurrent();
+        Vm vm = Vm.requireCurrent();
 
         ClassFile classFile = ClassFile.of(this, buffer);
         DefinedTypeDefinition.Builder builder = vm.newTypeDefinitionBuilder(classLoader);
@@ -70,7 +70,7 @@ public class Dictionary implements ClassContext {
         if (typesByName.containsKey(name)) {
             throw new DefineFailedException("Duplicated class named " + name);
         }
-        JavaVM vm = JavaVM.requireCurrent();
+        Vm vm = Vm.requireCurrent();
 
         ClassFile classFile = ClassFile.of(this, buffer);
         DefinedTypeDefinition.Builder builder = vm.newTypeDefinitionBuilder(classLoader);
@@ -129,7 +129,7 @@ public class Dictionary implements ClassContext {
         return null;
     }
 
-    public JavaObject getClassLoader() {
+    public VmObject getClassLoader() {
         return classLoader;
     }
 }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/Thrown.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/Thrown.java
@@ -2,13 +2,13 @@ package cc.quarkus.qcc.interpreter;
 
 @SuppressWarnings("serial")
 public final class Thrown extends RuntimeException {
-    private final JavaObject throwable;
+    private final VmObject throwable;
 
-    public Thrown(final JavaObject throwable) {
+    public Thrown(final VmObject throwable) {
         this.throwable = throwable;
     }
 
-    public JavaObject getThrowable() {
+    public VmObject getThrowable() {
         return throwable;
     }
 }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/Vm.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/Vm.java
@@ -23,7 +23,7 @@ import io.smallrye.common.constraint.Assert;
 /**
  * A virtual machine.
  */
-public interface JavaVM extends AutoCloseable {
+public interface Vm extends AutoCloseable {
     /**
      * Create a new thread.
      *
@@ -32,26 +32,26 @@ public interface JavaVM extends AutoCloseable {
      * @param daemon {@code true} to make a daemon thread
      * @return the new thread
      */
-    JavaThread newThread(String threadName, JavaObject threadGroup, boolean daemon);
+    VmThread newThread(String threadName, VmObject threadGroup, boolean daemon);
 
-    static JavaThread currentThread() {
-        return JavaVMImpl.currentThread();
+    static VmThread currentThread() {
+        return VmImpl.currentThread();
     }
 
-    static JavaThread requireCurrentThread() {
-        JavaThread javaThread = currentThread();
-        if (javaThread == null) {
+    static VmThread requireCurrentThread() {
+        VmThread vmThread = currentThread();
+        if (vmThread == null) {
             throw new IllegalStateException("Thread is not attached");
         }
-        return javaThread;
+        return vmThread;
     }
 
-    static JavaVM current() {
-        return JavaVMImpl.currentVm();
+    static Vm current() {
+        return VmImpl.currentVm();
     }
 
-    static JavaVM requireCurrent() {
-        JavaVM current = current();
+    static Vm requireCurrent() {
+        Vm current = current();
         if (current == null) {
             throw new IllegalStateException("JavaVM is not attached");
         }
@@ -72,7 +72,7 @@ public interface JavaVM extends AutoCloseable {
      * @param bytes the class bytes (must not be {@code null})
      * @return the defined class (not {@code null})
      */
-    DefinedTypeDefinition defineClass(String name, JavaObject classLoader, ByteBuffer bytes);
+    DefinedTypeDefinition defineClass(String name, VmObject classLoader, ByteBuffer bytes);
 
     /**
      * Define an unresolved anonymous class into this VM.
@@ -92,7 +92,7 @@ public interface JavaVM extends AutoCloseable {
      * @return the class (not {@code null})
      * @throws Thrown if the internal JVM has thrown an exception while loading the class
      */
-    DefinedTypeDefinition loadClass(JavaObject classLoader, String name) throws Thrown;
+    DefinedTypeDefinition loadClass(VmObject classLoader, String name) throws Thrown;
 
     /**
      * Find a loaded class, returning {@code null} if the class loader did not previously load the class.  The VM
@@ -102,7 +102,7 @@ public interface JavaVM extends AutoCloseable {
      * @param name the internal name of the class to load (must not be {@code null})
      * @return the class, or {@code null} if the class was not already loaded
      */
-    DefinedTypeDefinition findLoadedClass(JavaObject classLoader, String name);
+    DefinedTypeDefinition findLoadedClass(VmObject classLoader, String name);
 
     /**
      * Allocate an object without initializing it (all fields/elements will be {@code null}, {@code false}, or zero).
@@ -111,9 +111,9 @@ public interface JavaVM extends AutoCloseable {
      * @param type the type to allocate (must not be {@code null})
      * @return the allocated object (not {@code null})
      */
-    JavaObject allocateObject(ClassTypeIdLiteral type);
+    VmObject allocateObject(ClassTypeIdLiteral type);
 
-    JavaArray allocateArray(ArrayTypeIdLiteral type, int length);
+    VmArray allocateArray(ArrayTypeIdLiteral type, int length);
 
     /**
      * Invoke a constructor reflectively.  Primitive arguments should be boxed.
@@ -122,7 +122,7 @@ public interface JavaVM extends AutoCloseable {
      * @param instance the instance to invoke upon
      * @param args the arguments, whose times must match the constructor's expectations
      */
-    void invokeExact(ConstructorElement method, JavaObject instance, Object... args);
+    void invokeExact(ConstructorElement method, VmObject instance, Object... args);
 
     /**
      * Invoke a method reflectively.  Primitive arguments should be boxed.
@@ -132,7 +132,7 @@ public interface JavaVM extends AutoCloseable {
      * @param args the arguments, whose times must match the method's expectations
      * @return the result
      */
-    Object invokeExact(MethodElement method, JavaObject instance, Object... args);
+    Object invokeExact(MethodElement method, VmObject instance, Object... args);
 
     void initialize(TypeIdLiteral typeId);
 
@@ -144,7 +144,7 @@ public interface JavaVM extends AutoCloseable {
      * @param args the arguments, whose times must match the method's expectations
      * @return the result
      */
-    Object invokeVirtual(MethodElement method, final JavaObject instance, Object... args);
+    Object invokeVirtual(MethodElement method, final VmObject instance, Object... args);
 
     /**
      * Deliver a "signal" to the target environment.
@@ -168,9 +168,9 @@ public interface JavaVM extends AutoCloseable {
      * @param string the string to deduplicate
      * @return the deduplicated string
      */
-    String deduplicate(JavaObject classLoader, String string);
+    String deduplicate(VmObject classLoader, String string);
 
-    String deduplicate(JavaObject classLoader, ByteBuffer buffer, int offset, int length, boolean expectTerminator);
+    String deduplicate(VmObject classLoader, ByteBuffer buffer, int offset, int length, boolean expectTerminator);
 
     MethodDescriptor getMethodDescriptor(ValueType returnType, ValueType... paramTypes);
 
@@ -188,7 +188,7 @@ public interface JavaVM extends AutoCloseable {
      * @param string the input string (must not be {@code null})
      * @return the instance
      */
-    JavaObject getSharedString(String string);
+    VmObject getSharedString(String string);
 
     /**
      * Allocate a direct byte buffer object with the given backing buffer.  The backing content will be determined
@@ -198,7 +198,7 @@ public interface JavaVM extends AutoCloseable {
      * @param backingBuffer the backing buffer (must not be {@code null})
      * @return the allocated direct buffer object (not {@code null})
      */
-    JavaObject allocateDirectBuffer(ByteBuffer backingBuffer);
+    VmObject allocateDirectBuffer(ByteBuffer backingBuffer);
 
     /**
      * Kill the VM, terminating all in-progress threads and releasing all heap objects.
@@ -213,7 +213,7 @@ public interface JavaVM extends AutoCloseable {
      * @param classLoader the class loader for the new class, or {@code null} for the bootstrap class loader
      * @return the builder
      */
-    DefinedTypeDefinition.Builder newTypeDefinitionBuilder(JavaObject classLoader);
+    DefinedTypeDefinition.Builder newTypeDefinitionBuilder(VmObject classLoader);
 
     /**
      * Get a builder for a new VM.
@@ -229,7 +229,7 @@ public interface JavaVM extends AutoCloseable {
      *
      * @return the thread group (not {@code null})
      */
-    JavaObject getMainThreadGroup();
+    VmObject getMainThreadGroup();
 
     /**
      * A builder for the VM.
@@ -298,8 +298,8 @@ public interface JavaVM extends AutoCloseable {
          *
          * @return the new VM (not {@code null})
          */
-        public JavaVM build() {
-            return new JavaVMImpl(this);
+        public Vm build() {
+            return new VmImpl(this);
         }
     }
 }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmArray.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmArray.java
@@ -3,10 +3,10 @@ package cc.quarkus.qcc.interpreter;
 /**
  *
  */
-public interface JavaArray extends JavaObject {
+public interface VmArray extends VmObject {
     int getLength();
 
-    JavaClass getNestedType();
+    VmClass getNestedType();
 
     boolean getArrayBoolean(int index);
 
@@ -14,7 +14,7 @@ public interface JavaArray extends JavaObject {
 
     long getArrayLong(int index);
 
-    JavaObject getArrayObject(int index);
+    VmObject getArrayObject(int index);
 
     void putArray(int index, boolean value);
 
@@ -22,5 +22,5 @@ public interface JavaArray extends JavaObject {
 
     void putArray(int index, long value);
 
-    void putArray(int index, JavaObject value);
+    void putArray(int index, VmObject value);
 }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmClass.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmClass.java
@@ -5,7 +5,7 @@ import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
 /**
  *
  */
-public interface JavaClass extends JavaObject {
+public interface VmClass extends VmObject {
 
     ValidatedTypeDefinition getTypeDefinition();
 }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmClassImpl.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmClassImpl.java
@@ -3,17 +3,17 @@ package cc.quarkus.qcc.interpreter;
 import cc.quarkus.qcc.type.definition.FieldSet;
 import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
 
-final class JavaClassImpl extends JavaObjectImpl implements JavaClass {
+final class VmClassImpl extends VmObjectImpl implements VmClass {
     final ValidatedTypeDefinition definition;
     final FieldSet instanceFields;
 
-    JavaClassImpl(final JavaVMImpl vm, final ValidatedTypeDefinition definition) {
+    VmClassImpl(final VmImpl vm, final ValidatedTypeDefinition definition) {
         super(vm.classClass.validate());
         this.definition = definition;
         instanceFields = new FieldSet(definition, false);
     }
 
-    JavaClassImpl(final JavaVMImpl vm, final ValidatedTypeDefinition definition, boolean ignoredClassClass) {
+    VmClassImpl(final VmImpl vm, final ValidatedTypeDefinition definition, boolean ignoredClassClass) {
         // Class.class
         super(definition);
         this.definition = definition;

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmObject.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmObject.java
@@ -5,7 +5,7 @@ import cc.quarkus.qcc.graph.literal.RealTypeIdLiteral;
 /**
  * A Java object handle.
  */
-public interface JavaObject {
+public interface VmObject {
 
     RealTypeIdLiteral getObjectType();
 }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmObjectImpl.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmObjectImpl.java
@@ -4,11 +4,11 @@ import cc.quarkus.qcc.graph.literal.RealTypeIdLiteral;
 import cc.quarkus.qcc.type.definition.FieldContainer;
 import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
 
-class JavaObjectImpl implements JavaObject {
+class VmObjectImpl implements VmObject {
     final ValidatedTypeDefinition definition;
     final FieldContainer fields;
 
-    JavaObjectImpl(final ValidatedTypeDefinition definition) {
+    VmObjectImpl(final ValidatedTypeDefinition definition) {
         this.definition = definition;
         fields = FieldContainer.forInstanceFieldsOf(definition);
     }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmPrimitiveClass.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmPrimitiveClass.java
@@ -3,6 +3,6 @@ package cc.quarkus.qcc.interpreter;
 /**
  * A primitive class (or {@code void}).
  */
-public interface JavaPrimitiveClass extends JavaClass {
+public interface VmPrimitiveClass extends VmClass {
 
 }

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmThread.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmThread.java
@@ -6,7 +6,7 @@ package cc.quarkus.qcc.interpreter;
  * Any unclosed thread can be invoked upon as frequently as desired, as long as it is
  * attached to the current calling thread.  Unattached threads cannot be invoked upon.
  */
-public interface JavaThread {
+public interface VmThread {
     /**
      * Perform the given action with this thread attached to the host thread.  Any previously attached thread
      * is suspended.
@@ -15,7 +15,7 @@ public interface JavaThread {
      */
     void doAttached(Runnable r);
 
-    JavaVM getVM();
+    Vm getVM();
 
     boolean isRunning();
 

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmThreadImpl.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/interpreter/VmThreadImpl.java
@@ -5,23 +5,23 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import cc.quarkus.qcc.graph.Invocation;
 
-final class JavaThreadImpl implements JavaThread {
-    final JavaVMImpl vm;
-    final JavaObjectImpl instance;
+final class VmThreadImpl implements VmThread {
+    final VmImpl vm;
+    final VmObjectImpl instance;
     State state = State.RUNNING;
     Thread attachedThread;
-    JavaVMImpl.StackFrame tos;
+    VmImpl.StackFrame tos;
     Lock threadLock = new ReentrantLock();
 
-    JavaThreadImpl(final String threadName, final JavaObject threadGroup, final boolean daemon, final JavaVMImpl vm) {
+    VmThreadImpl(final String threadName, final VmObject threadGroup, final boolean daemon, final VmImpl vm) {
         this.vm = vm;
-        instance = new JavaObjectImpl(vm.threadClass.validate());
+        instance = new VmObjectImpl(vm.threadClass.validate());
         // todo: initialize thread fields...
     }
 
     public void doAttached(final Runnable r) {
         vm.doAttached(() -> {
-            JavaThreadImpl currentlyAttached = vm.attachedThread.get();
+            VmThreadImpl currentlyAttached = vm.attachedThread.get();
             if (currentlyAttached == this) {
                 r.run();
                 return;
@@ -53,11 +53,11 @@ final class JavaThreadImpl implements JavaThread {
         });
     }
 
-    JavaVMImpl.StackFrame pushNewFrame(Invocation caller) {
-        return tos = new JavaVMImpl.StackFrame(tos, caller);
+    VmImpl.StackFrame pushNewFrame(Invocation caller) {
+        return tos = new VmImpl.StackFrame(tos, caller);
     }
 
-    JavaVMImpl.StackFrame popFrame() {
+    VmImpl.StackFrame popFrame() {
         try {
             return tos;
         } finally {
@@ -76,7 +76,7 @@ final class JavaThreadImpl implements JavaThread {
         }
     }
 
-    public JavaVM getVM() {
+    public Vm getVM() {
         return vm;
     }
 

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/ClassContext.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/ClassContext.java
@@ -18,7 +18,7 @@ import cc.quarkus.qcc.graph.literal.ClassTypeIdLiteral;
 import cc.quarkus.qcc.graph.literal.InterfaceTypeIdLiteral;
 import cc.quarkus.qcc.graph.literal.LiteralFactory;
 import cc.quarkus.qcc.graph.literal.TypeIdLiteral;
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.definition.classfile.ClassFile;
 import cc.quarkus.qcc.type.definition.element.ExecutableElement;
@@ -36,7 +36,7 @@ public interface ClassContext {
      *
      * @return the class loader object for this context
      */
-    JavaObject getClassLoader();
+    VmObject getClassLoader();
 
     DefinedTypeDefinition findDefinedType(String typeName);
 
@@ -105,7 +105,7 @@ public interface ClassContext {
                 return null;
             }
 
-            public JavaObject getClassLoader() {
+            public VmObject getClassLoader() {
                 return null;
             }
 

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/FieldContainer.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/FieldContainer.java
@@ -1,6 +1,6 @@
 package cc.quarkus.qcc.type.definition;
 
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 import io.smallrye.common.constraint.Assert;
 
 public interface FieldContainer {
@@ -14,11 +14,11 @@ public interface FieldContainer {
 
     FieldSet getFieldSet();
 
-    JavaObject getObjectFieldPlain(String name);
+    VmObject getObjectFieldPlain(String name);
 
-    JavaObject getObjectFieldVolatile(String name);
+    VmObject getObjectFieldVolatile(String name);
 
-    JavaObject getObjectFieldAcquire(String name);
+    VmObject getObjectFieldAcquire(String name);
 
     long getLongFieldPlain(String name);
 
@@ -32,11 +32,11 @@ public interface FieldContainer {
 
     int getIntFieldAcquire(String name);
 
-    void setFieldPlain(String name, JavaObject value);
+    void setFieldPlain(String name, VmObject value);
 
-    void setFieldVolatile(String name, JavaObject value);
+    void setFieldVolatile(String name, VmObject value);
 
-    void setFieldRelease(String name, JavaObject value);
+    void setFieldRelease(String name, VmObject value);
 
     void setFieldPlain(String name, long value);
 

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/FieldContainerImpl.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/FieldContainerImpl.java
@@ -1,6 +1,6 @@
 package cc.quarkus.qcc.type.definition;
 
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -24,16 +24,16 @@ final class FieldContainerImpl implements FieldContainer {
         return fieldSet;
     }
 
-    public JavaObject getObjectFieldPlain(String name) {
-        return (JavaObject) objects.getPlain(fieldSet.getIndex(name));
+    public VmObject getObjectFieldPlain(String name) {
+        return (VmObject) objects.getPlain(fieldSet.getIndex(name));
     }
 
-    public JavaObject getObjectFieldVolatile(String name) {
-        return (JavaObject) objects.get(fieldSet.getIndex(name));
+    public VmObject getObjectFieldVolatile(String name) {
+        return (VmObject) objects.get(fieldSet.getIndex(name));
     }
 
-    public JavaObject getObjectFieldAcquire(String name) {
-        return (JavaObject) objects.getAcquire(fieldSet.getIndex(name));
+    public VmObject getObjectFieldAcquire(String name) {
+        return (VmObject) objects.getAcquire(fieldSet.getIndex(name));
     }
 
     public long getLongFieldPlain(String name) {
@@ -60,15 +60,15 @@ final class FieldContainerImpl implements FieldContainer {
         return ((Number) objects.getAcquire(fieldSet.getIndex(name))).intValue();
     }
 
-    public void setFieldPlain(String name, JavaObject value) {
+    public void setFieldPlain(String name, VmObject value) {
         objects.setPlain(fieldSet.getIndex(name), value);
     }
 
-    public void setFieldVolatile(String name, JavaObject value) {
+    public void setFieldVolatile(String name, VmObject value) {
         objects.set(fieldSet.getIndex(name), value);
     }
 
-    public void setFieldRelease(String name, JavaObject value) {
+    public void setFieldRelease(String name, VmObject value) {
         objects.setRelease(fieldSet.getIndex(name), value);
     }
 

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/PreparedTypeDefinitionImpl.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/PreparedTypeDefinitionImpl.java
@@ -1,7 +1,7 @@
 package cc.quarkus.qcc.type.definition;
 
 import cc.quarkus.qcc.graph.literal.TypeIdLiteral;
-import cc.quarkus.qcc.interpreter.JavaVM;
+import cc.quarkus.qcc.interpreter.Vm;
 import cc.quarkus.qcc.interpreter.Thrown;
 import cc.quarkus.qcc.type.annotation.Annotation;
 import cc.quarkus.qcc.type.definition.element.ConstructorElement;
@@ -160,7 +160,7 @@ final class PreparedTypeDefinitionImpl implements PreparedTypeDefinition {
                     return initializing.initialize();
                 }
                 this.initializing = initialized = new InitializedTypeDefinitionImpl(this);
-                JavaVM vm = JavaVM.requireCurrent();
+                Vm vm = Vm.requireCurrent();
                 try {
                     vm.initialize(getTypeId());
                 } catch (Thrown t) {

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/ResolvedTypeDefinition.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/ResolvedTypeDefinition.java
@@ -1,7 +1,7 @@
 package cc.quarkus.qcc.type.definition;
 
 import cc.quarkus.qcc.type.Type;
-import cc.quarkus.qcc.interpreter.JavaVM;
+import cc.quarkus.qcc.interpreter.Vm;
 import cc.quarkus.qcc.type.definition.classfile.ClassFile;
 import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.FieldElement;
@@ -215,7 +215,7 @@ public interface ResolvedTypeDefinition extends ValidatedTypeDefinition {
         // specified by the interface method reference, which has its ACC_PUBLIC flag set
         // and does not have its ACC_STATIC flag set, method lookup succeeds.
         if (! virtualOnly) {
-            ResolvedTypeDefinition object = JavaVM.currentThread().getVM().getObjectTypeDefinition().validate().resolve();
+            ResolvedTypeDefinition object = Vm.currentThread().getVM().getObjectTypeDefinition().validate().resolve();
             result = object.findMethodIndex(name, descriptor);
             if (result != -1) {
                 MethodElement method = object.getMethod(result);

--- a/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/element/AbstractParameterizedExecutableElement.java
+++ b/compiler/graph/src/main/java/cc/quarkus/qcc/type/definition/element/AbstractParameterizedExecutableElement.java
@@ -2,7 +2,7 @@ package cc.quarkus.qcc.type.definition.element;
 
 import java.util.Arrays;
 
-import cc.quarkus.qcc.interpreter.JavaVM;
+import cc.quarkus.qcc.interpreter.Vm;
 import cc.quarkus.qcc.type.ValueType;
 import cc.quarkus.qcc.type.descriptor.ParameterizedExecutableDescriptor;
 
@@ -57,7 +57,7 @@ abstract class AbstractParameterizedExecutableElement extends AbstractExactExecu
             for (int i = 0; i < cnt; i ++) {
                 types[i] = parameters[i].getType();
             }
-            return JavaVM.requireCurrent().getParameterizedExecutableDescriptor(types);
+            return Vm.requireCurrent().getParameterizedExecutableDescriptor(types);
         }
 
         public abstract AbstractParameterizedExecutableElement build();

--- a/driver/src/main/java/cc/quarkus/qcc/driver/ClassContextImpl.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/ClassContextImpl.java
@@ -12,7 +12,7 @@ import cc.quarkus.qcc.graph.literal.ClassTypeIdLiteral;
 import cc.quarkus.qcc.graph.literal.InterfaceTypeIdLiteral;
 import cc.quarkus.qcc.graph.literal.LiteralFactory;
 import cc.quarkus.qcc.graph.literal.TypeIdLiteral;
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.definition.ClassContext;
 import cc.quarkus.qcc.type.definition.DefineFailedException;
@@ -24,14 +24,14 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
  */
 final class ClassContextImpl implements ClassContext {
     private final CompilationContextImpl compilationContext;
-    private final JavaObject classLoader;
+    private final VmObject classLoader;
     private final ConcurrentMap<String, AtomicReference<Object>> definedClasses = new ConcurrentHashMap<>();
     private final ConcurrentMap<TypeIdLiteral, DefinedTypeDefinition> classForLiteral = new ConcurrentHashMap<>();
 
     private static final Object LOADING = new Object();
     private static final Object NOT_FOUND = new Object();
 
-    ClassContextImpl(final CompilationContextImpl compilationContext, final JavaObject classLoader) {
+    ClassContextImpl(final CompilationContextImpl compilationContext, final VmObject classLoader) {
         this.compilationContext = compilationContext;
         this.classLoader = classLoader;
     }
@@ -40,12 +40,12 @@ final class ClassContextImpl implements ClassContext {
         return compilationContext;
     }
 
-    public JavaObject getClassLoader() {
+    public VmObject getClassLoader() {
         return classLoader;
     }
 
     public DefinedTypeDefinition findDefinedType(final String typeName) {
-        BiFunction<JavaObject, String, DefinedTypeDefinition> finder = compilationContext.getFinder();
+        BiFunction<VmObject, String, DefinedTypeDefinition> finder = compilationContext.getFinder();
         AtomicReference<Object> ref = definedClasses.get(typeName);
         Object val;
         DefinedTypeDefinition definition;

--- a/driver/src/main/java/cc/quarkus/qcc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/CompilationContextImpl.java
@@ -18,7 +18,7 @@ import cc.quarkus.qcc.context.Location;
 import cc.quarkus.qcc.graph.BasicBlockBuilder;
 import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.literal.LiteralFactory;
-import cc.quarkus.qcc.interpreter.JavaObject;
+import cc.quarkus.qcc.interpreter.VmObject;
 import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.definition.ClassContext;
 import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
@@ -34,16 +34,16 @@ final class CompilationContextImpl implements CompilationContext {
     private final TypeSystem typeSystem;
     private final LiteralFactory literalFactory;
     private final BaseDiagnosticContext baseDiagnosticContext;
-    private final ConcurrentMap<JavaObject, ClassContext> classLoaderContexts = new ConcurrentHashMap<>();
+    private final ConcurrentMap<VmObject, ClassContext> classLoaderContexts = new ConcurrentHashMap<>();
     final Set<ExecutableElement> queued = ConcurrentHashMap.newKeySet();
     final Queue<ExecutableElement> queue = new ConcurrentLinkedDeque<>();
     final Set<MethodElement> entryPoints = ConcurrentHashMap.newKeySet();
     final ClassContext bootstrapClassContext = new ClassContextImpl(this, null);
     private final BiFunction<CompilationContext, ExecutableElement, BasicBlockBuilder> blockFactory;
-    private final BiFunction<JavaObject, String, DefinedTypeDefinition> finder;
+    private final BiFunction<VmObject, String, DefinedTypeDefinition> finder;
     private final Path outputDir;
 
-    CompilationContextImpl(final BaseDiagnosticContext baseDiagnosticContext, final TypeSystem typeSystem, final LiteralFactory literalFactory, final BiFunction<CompilationContext, ExecutableElement, BasicBlockBuilder> blockFactory, final BiFunction<JavaObject, String, DefinedTypeDefinition> finder, final Path outputDir) {
+    CompilationContextImpl(final BaseDiagnosticContext baseDiagnosticContext, final TypeSystem typeSystem, final LiteralFactory literalFactory, final BiFunction<CompilationContext, ExecutableElement, BasicBlockBuilder> blockFactory, final BiFunction<VmObject, String, DefinedTypeDefinition> finder, final Path outputDir) {
         this.baseDiagnosticContext = baseDiagnosticContext;
         this.typeSystem = typeSystem;
         this.literalFactory = literalFactory;
@@ -140,7 +140,7 @@ final class CompilationContextImpl implements CompilationContext {
         return baseDiagnosticContext.deduplicate(original);
     }
 
-    public ClassContext constructClassContext(final JavaObject classLoaderObject) {
+    public ClassContext constructClassContext(final VmObject classLoaderObject) {
         return classLoaderContexts.computeIfAbsent(classLoaderObject, classLoader -> new ClassContextImpl(this, classLoader));
     }
 
@@ -215,7 +215,7 @@ final class CompilationContextImpl implements CompilationContext {
         return entryPoints;
     }
 
-    BiFunction<JavaObject, String, DefinedTypeDefinition> getFinder() {
+    BiFunction<VmObject, String, DefinedTypeDefinition> getFinder() {
         return finder;
     }
 

--- a/driver/src/main/java/cc/quarkus/qcc/driver/Driver.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/Driver.java
@@ -29,8 +29,8 @@ import cc.quarkus.qcc.graph.Value;
 import cc.quarkus.qcc.graph.literal.LiteralFactory;
 import cc.quarkus.qcc.graph.literal.TypeIdLiteral;
 import cc.quarkus.qcc.graph.schedule.Schedule;
-import cc.quarkus.qcc.interpreter.JavaObject;
-import cc.quarkus.qcc.interpreter.JavaVM;
+import cc.quarkus.qcc.interpreter.VmObject;
+import cc.quarkus.qcc.interpreter.Vm;
 import cc.quarkus.qcc.machine.arch.Platform;
 import cc.quarkus.qcc.machine.tool.CToolChain;
 import cc.quarkus.qcc.tool.llvm.LlvmTool;
@@ -177,8 +177,8 @@ public class Driver implements Closeable {
             return result;
         };
 
-        final BiFunction<JavaObject, String, DefinedTypeDefinition> finder;
-        JavaVM vm = builder.vm;
+        final BiFunction<VmObject, String, DefinedTypeDefinition> finder;
+        Vm vm = builder.vm;
         if (vm != null) {
             finder = vm::loadClass;
         } else {
@@ -199,7 +199,7 @@ public class Driver implements Closeable {
         postGenerateHooks = List.copyOf(builder.postGenerateHooks);
     }
 
-    private DefinedTypeDefinition defaultFinder(JavaObject classLoader, String name) {
+    private DefinedTypeDefinition defaultFinder(VmObject classLoader, String name) {
         if (classLoader != null) {
             return null;
         }
@@ -476,7 +476,7 @@ public class Driver implements Closeable {
         BaseDiagnosticContext initialContext;
         Platform targetPlatform;
         TypeSystem typeSystem;
-        JavaVM vm;
+        Vm vm;
         CToolChain toolChain;
         LlvmTool llvmTool;
 
@@ -585,11 +585,11 @@ public class Driver implements Closeable {
             return this;
         }
 
-        public JavaVM getVm() {
+        public Vm getVm() {
             return vm;
         }
 
-        public Builder setVm(final JavaVM vm) {
+        public Builder setVm(final Vm vm) {
             this.vm = vm;
             return this;
         }


### PR DESCRIPTION
I went for `VmObject`, `VmThread`, etc., instead of `VMObject`, `VMThread`, etc.
I think it looks nicer, but I can change it to `VM*` if preferred.

Closes #72 