### PR TITLE
first cut at parsing InvokeDynamic related classfile structures

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ValueVisitor.java
@@ -12,6 +12,8 @@ import cc.quarkus.qcc.graph.literal.DefinedConstantLiteral;
 import cc.quarkus.qcc.graph.literal.FloatLiteral;
 import cc.quarkus.qcc.graph.literal.IntegerLiteral;
 import cc.quarkus.qcc.graph.literal.InterfaceTypeIdLiteral;
+import cc.quarkus.qcc.graph.literal.MethodDescriptorLiteral;
+import cc.quarkus.qcc.graph.literal.MethodHandleLiteral;
 import cc.quarkus.qcc.graph.literal.NullLiteral;
 import cc.quarkus.qcc.graph.literal.ObjectLiteral;
 import cc.quarkus.qcc.graph.literal.ReferenceArrayTypeIdLiteral;
@@ -133,6 +135,14 @@ public interface ValueVisitor<T, R> {
     }
 
     default R visit(T param, InterfaceTypeIdLiteral node) {
+        return visitUnknown(param, node);
+    }
+
+    default R visit(T param, MethodDescriptorLiteral node) {
+        return visitUnknown(param, node);
+    }
+
+    default R visit(T param, MethodHandleLiteral node) {
         return visitUnknown(param, node);
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/literal/LiteralFactory.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/literal/LiteralFactory.java
@@ -10,6 +10,7 @@ import cc.quarkus.qcc.interpreter.VmObject;
 import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.ValueType;
+import cc.quarkus.qcc.type.descriptor.MethodDescriptor;
 import io.smallrye.common.constraint.Assert;
 
 /**
@@ -36,6 +37,10 @@ public interface LiteralFactory {
     NullLiteral literalOfNull();
 
     ObjectLiteral literalOf(VmObject value);
+
+    MethodHandleLiteral literalOfMethodHandle(int referenceKind, int referenceIndex);
+
+    MethodDescriptorLiteral literalOfMethodDescriptor(String descriptor);
 
     ValueArrayTypeIdLiteral literalOfArrayType(ValueType elementType);
 
@@ -132,6 +137,14 @@ public interface LiteralFactory {
                 Assert.checkNotNullParam("value", value);
                 // todo: cache on object itself?
                 return new ObjectLiteral(typeSystem.getReferenceType(value.getObjectType()).asConst(), value);
+            }
+
+            public MethodHandleLiteral literalOfMethodHandle(int referenceKind, int referenceIndex) {
+                return new MethodHandleLiteral(typeSystem.getMethodHandleType(), referenceKind, referenceIndex);
+            }
+
+            public MethodDescriptorLiteral literalOfMethodDescriptor(String descriptor) {
+                return new MethodDescriptorLiteral(typeSystem.getMethodDescriptorType(), descriptor);
             }
 
             public ValueArrayTypeIdLiteral literalOfArrayType(final ValueType elementType) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/literal/MethodDescriptorLiteral.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/literal/MethodDescriptorLiteral.java
@@ -1,0 +1,39 @@
+package cc.quarkus.qcc.graph.literal;
+
+import cc.quarkus.qcc.graph.ValueVisitor;
+import cc.quarkus.qcc.type.MethodDescriptorType;
+import cc.quarkus.qcc.type.ValueType;
+import cc.quarkus.qcc.type.descriptor.MethodDescriptor;
+
+/**
+ * A literal representing a method handle.
+ */
+public final class MethodDescriptorLiteral extends Literal {
+    private final MethodDescriptorType type;
+    private final String desc;
+
+    MethodDescriptorLiteral(MethodDescriptorType type, String desc) {
+        this.type = type;
+        this.desc = desc;
+    }
+
+    public boolean equals(final Literal other) {
+        return other instanceof MethodDescriptorLiteral && equals((MethodDescriptorLiteral) other);
+    }
+
+    public boolean equals(final MethodDescriptorLiteral other) {
+        return this == other || other != null && desc.equals(other.desc);
+    }
+
+    public int hashCode() {
+        return type.hashCode() * 19 + desc.hashCode();
+    }
+
+    public ValueType getType() {
+      return this.type;
+    }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/literal/MethodHandleLiteral.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/literal/MethodHandleLiteral.java
@@ -1,0 +1,40 @@
+package cc.quarkus.qcc.graph.literal;
+
+import cc.quarkus.qcc.graph.ValueVisitor;
+import cc.quarkus.qcc.type.MethodHandleType;
+import cc.quarkus.qcc.type.ValueType;
+
+/**
+ * A literal representing a method handle.
+ */
+public final class MethodHandleLiteral extends Literal {
+    private final MethodHandleType type;
+    private final int referenceKind;
+    private final int referenceIndex; // TODO: this should be the actual information, not the cpIndex.
+
+    MethodHandleLiteral(MethodHandleType type, int kind, final int reference) {
+        this.type = type;
+        this.referenceKind = kind;
+        this.referenceIndex = reference;
+    }
+
+    public boolean equals(final Literal other) {
+        return other instanceof MethodHandleLiteral && equals((MethodHandleLiteral) other);
+    }
+
+    public boolean equals(final MethodHandleLiteral other) {
+        return this == other || other != null && referenceKind == other.referenceKind && referenceIndex == other.referenceIndex;
+    }
+
+    public int hashCode() {
+        return Integer.hashCode(referenceKind) * 19 + Integer.hashCode(referenceIndex);
+    }
+
+    public ValueType getType() {
+      return this.type;
+    }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/type/MethodDescriptorType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/MethodDescriptorType.java
@@ -1,0 +1,44 @@
+package cc.quarkus.qcc.type;
+
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * The type representing method descriptor literals, which are always {@code const}, have no size and are incomplete.
+ */
+public final class MethodDescriptorType extends ValueType {
+  MethodDescriptorType(final TypeSystem typeSystem) {
+        super(typeSystem, MethodDescriptorType.class.hashCode(), true);
+    }
+
+    public boolean isComplete() {
+        return false;
+    }
+
+    public long getSize() {
+        return 0;
+    }
+
+    ValueType constructConst() {
+        throw Assert.unreachableCode();
+    }
+
+    public MethodDescriptorType asConst() {
+        return this;
+    }
+
+    public int getAlign() {
+        return 0;
+    }
+
+    public boolean equals(final ValueType other) {
+        return other instanceof MethodDescriptorType && super.equals(other);
+    }
+
+    public StringBuilder toString(final StringBuilder b) {
+        return b.append("methoddescriptor");
+    }
+
+    public StringBuilder toFriendlyString(final StringBuilder b) {
+        return b.append("mdesc");
+    }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/type/MethodHandleType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/MethodHandleType.java
@@ -1,0 +1,44 @@
+package cc.quarkus.qcc.type;
+
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * The type representing method handle literals, which are always {@code const}, have no size and are incomplete.
+ */
+public final class MethodHandleType extends ValueType {
+  MethodHandleType(final TypeSystem typeSystem) {
+        super(typeSystem, MethodHandleType.class.hashCode(), true);
+    }
+
+    public boolean isComplete() {
+        return false;
+    }
+
+    public long getSize() {
+        return 0;
+    }
+
+    ValueType constructConst() {
+        throw Assert.unreachableCode();
+    }
+
+    public MethodHandleType asConst() {
+        return this;
+    }
+
+    public int getAlign() {
+        return 0;
+    }
+
+    public boolean equals(final ValueType other) {
+        return other instanceof MethodHandleType && super.equals(other);
+    }
+
+    public StringBuilder toString(final StringBuilder b) {
+        return b.append("methodhandle");
+    }
+
+    public StringBuilder toFriendlyString(final StringBuilder b) {
+        return b.append("mh");
+    }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/type/TypeSystem.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/TypeSystem.java
@@ -25,6 +25,8 @@ public final class TypeSystem {
     private final BlockType blockType = new BlockType(this);
     private final StringType stringType = new StringType(this);
     private final TypeType typeType = new TypeType(this);
+    private final MethodHandleType methodHandleType = new MethodHandleType(this);
+    private final MethodDescriptorType methodDescriptorType = new MethodDescriptorType(this);
     private final BooleanType booleanType;
     private final TypeIdType typeIdType;
     private final FloatType float32Type;
@@ -113,6 +115,14 @@ public final class TypeSystem {
 
     public TypeType getTypeType() {
         return typeType;
+    }
+
+    public MethodHandleType getMethodHandleType() {
+        return methodHandleType;
+    }
+
+    public MethodDescriptorType getMethodDescriptorType() {
+        return methodDescriptorType;
     }
 
     public ReferenceType getReferenceType(TypeIdLiteral typeId) {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinition.java
@@ -5,6 +5,7 @@ import java.util.function.ObjIntConsumer;
 
 import cc.quarkus.qcc.type.annotation.Annotation;
 import cc.quarkus.qcc.type.annotation.type.TypeAnnotationList;
+import cc.quarkus.qcc.type.definition.classfile.BootstrapMethod;
 import cc.quarkus.qcc.type.definition.classfile.ClassFile;
 import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.FieldElement;
@@ -205,6 +206,8 @@ public interface DefinedTypeDefinition extends FieldResolver,
 
         void setInvisibleTypeAnnotations(TypeAnnotationList annotationList);
 
+        void setBootstrapMethods(List<BootstrapMethod> bootstrapMethods);
+
         DefinedTypeDefinition build();
 
         static Builder basic() {
@@ -284,6 +287,10 @@ public interface DefinedTypeDefinition extends FieldResolver,
 
             default void setInvisibleTypeAnnotations(TypeAnnotationList annotationList) {
                 getDelegate().setInvisibleTypeAnnotations(annotationList);
+            }
+
+            default void setBootstrapMethods(List<BootstrapMethod> bootstrapMethods) {
+                getDelegate().setBootstrapMethods(bootstrapMethods);
             }
 
             default DefinedTypeDefinition build() {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinitionImpl.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import cc.quarkus.qcc.type.annotation.Annotation;
 import cc.quarkus.qcc.type.annotation.type.TypeAnnotationList;
+import cc.quarkus.qcc.type.definition.classfile.BootstrapMethod;
 import cc.quarkus.qcc.type.definition.classfile.ClassFile;
 import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.FieldElement;
@@ -38,6 +39,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
     private final List<Annotation> invisibleAnnotations;
     private final TypeAnnotationList visibleTypeAnnotations;
     private final TypeAnnotationList invisibleTypeAnnotations;
+    private final List<BootstrapMethod> bootstrapMethods;
 
     private volatile DefinedTypeDefinition validated;
 
@@ -49,6 +51,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
     private static final ConstructorResolver[] NO_CONSTRUCTORS = new ConstructorResolver[0];
     private static final Annotation[][] NO_ANNOTATION_ARRAYS = new Annotation[0][];
     private static final Annotation[][][] NO_ANNOTATION_ARRAY_ARRAYS = new Annotation[0][][];
+    private static final BootstrapMethod[] NO_BOOTSTAP_METHODS = new BootstrapMethod[0];
 
     DefinedTypeDefinitionImpl(final BuilderImpl builder) {
         this.context = builder.context;
@@ -71,6 +74,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
         this.invisibleAnnotations = builder.invisibleAnnotations;
         this.visibleTypeAnnotations = builder.visibleTypeAnnotations;
         this.invisibleTypeAnnotations = builder.invisibleTypeAnnotations;
+        this.bootstrapMethods = builder.bootstrapMethods;
         this.initializerResolver = Assert.checkNotNullParam("builder.initializerResolver", builder.initializerResolver);
         this.initializerIndex = builder.initializerIndex;
     }
@@ -206,6 +210,14 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
         return invisibleTypeAnnotations;
     }
 
+    public List<BootstrapMethod> getBootstrapMethods() {
+        return bootstrapMethods;
+    }
+
+    public BootstrapMethod getBootstrapMethod(final int index) {
+        return bootstrapMethods.get(index);
+    }
+
     public boolean hasSuperClass() {
         return superClassName != null;
     }
@@ -235,6 +247,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
         List<Annotation> invisibleAnnotations = List.of();
         TypeAnnotationList visibleTypeAnnotations = TypeAnnotationList.empty();
         TypeAnnotationList invisibleTypeAnnotations = TypeAnnotationList.empty();
+        List<BootstrapMethod> bootstrapMethods = List.of();
 
         public void setContext(final ClassContext context) {
             this.context = context;
@@ -387,6 +400,10 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
 
         public void setInvisibleTypeAnnotations(final TypeAnnotationList annotationList) {
             this.invisibleTypeAnnotations = Assert.checkNotNullParam("annotationList", annotationList);
+        }
+
+        public void setBootstrapMethods(final List<BootstrapMethod> bootstrapMethods) {
+            this.bootstrapMethods = Assert.checkNotNullParam("bootstrapMethods", bootstrapMethods);
         }
 
         public void setName(final String internalName) {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/BootstrapMethod.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/BootstrapMethod.java
@@ -1,0 +1,41 @@
+package cc.quarkus.qcc.type.definition.classfile;
+
+import java.nio.ByteBuffer;
+
+import cc.quarkus.qcc.type.definition.ClassContext;
+
+/**
+ * A BootstrapMethod contains the cpIndex data from a single
+ * entry in the bootstrap_methods[] of a BootstrapMethod attribute.
+ */
+public class BootstrapMethod {
+  private final int bootstrapMethod;
+  private final int[] bootstrapArgs;
+
+  BootstrapMethod(int bootstrapMethod, int[] bootstrapArgs) {
+    this.bootstrapMethod = bootstrapMethod;
+    this.bootstrapArgs = bootstrapArgs;
+  }
+
+  public int getBootstrapMethod() {
+    return bootstrapMethod;
+  }
+
+  public int getBootstrapArgCount() {
+    return bootstrapArgs.length;
+  }
+
+  public int getBootstrapArg(int index) {
+    return bootstrapArgs[index];
+  }
+
+  public static BootstrapMethod parse(final ClassFile classFile, final ClassContext classContext, final ByteBuffer buf) {
+    int method = buf.getShort() & 0xffff;
+    int argCount = buf.getShort() & 0xffff;
+    int[] args = new int[argCount];
+    for (int i = 0; i < argCount; i++) {
+      args[i] = buf.getShort() & 0xffff;
+    }
+    return new BootstrapMethod(method, args);
+  }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassFile.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassFile.java
@@ -445,10 +445,32 @@ public interface ClassFile extends FieldResolver,
         return getRawConstantShort(idx, 3);
     }
 
-    // todo: MethodHandle
-    // todo: MethodType
+    default int getInvokeDynamicBootstrapMethodIndex(int idx) throws IndexOutOfBoundsException, ConstantTypeMismatchException {
+        checkConstantType(idx, CONSTANT_InvokeDynamic);
+        return getRawConstantShort(idx, 1);
+    }
+
+    default int getInvokeDynamicNameAndTypeIndex(int idx) throws IndexOutOfBoundsException, ConstantTypeMismatchException {
+        checkConstantType(idx, CONSTANT_InvokeDynamic);
+        return getRawConstantShort(idx, 3);
+    }
+
+    default int getMethodHandleReferenceKind(int idx) throws IndexOutOfBoundsException, ConstantTypeMismatchException {
+        checkConstantType(idx, CONSTANT_MethodHandle);
+        return getRawConstantByte(idx, 1);
+    }
+
+    default int getMethodHandleReferenceIndex(int idx) throws IndexOutOfBoundsException, ConstantTypeMismatchException {
+        checkConstantType(idx, CONSTANT_MethodHandle);
+        return getRawConstantShort(idx, 3);
+    }
+
+    default int getMethodTypeDescriptorIndex(int idx) throws IndexOutOfBoundsException, ConstantTypeMismatchException {
+        checkConstantType(idx, CONSTANT_MethodType);
+        return getRawConstantShort(idx, 1);
+    }
+
     // todo: Dynamic
-    // todo: InvokeDynamic
     // todo: Module
     // todo: Package
 


### PR DESCRIPTION
I think we are going to want/need to represent MethodHandles and MethodDescriptors as literals so we can generate code that passes them to the bootstrap method for invoke dynamic.

This is some progress in that direction, but not ready to merge yet.  Want to validate that this is a reasonable direction before I go too far down a bad path.