### PR TITLE
Emit floating-point literals

### DIFF
--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Values.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Values.java
@@ -22,6 +22,14 @@ public final class Values {
         return LLVM.intConstant(val);
     }
 
+    public static LLValue floatConstant(float val) {
+        return LLVM.floatConstant(val);
+    }
+
+    public static LLValue floatConstant(double val) {
+        return LLVM.floatConstant(val);
+    }
+
     public static LLValue global(String name) {
         return LLVM.global(name);
     }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractEmittable.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractEmittable.java
@@ -88,4 +88,14 @@ abstract class AbstractEmittable implements Emittable {
         target.append(Long.toString(val));
         return target;
     }
+
+    static <A extends Appendable> A appendDecimal(A target, double val) throws IOException {
+        target.append(Double.toString(val));
+        return target;
+    }
+
+    static <A extends Appendable> A appendHex(A target, float val) throws IOException {
+        target.append("0x" + Long.toHexString(Double.doubleToRawLongBits((double) val)));
+        return target;
+    }
 }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/DoubleConstant.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/DoubleConstant.java
@@ -1,0 +1,15 @@
+package cc.quarkus.qcc.machine.llvm.impl;
+
+import java.io.IOException;
+
+final class DoubleConstant extends AbstractValue {
+    final double value;
+
+    DoubleConstant(final double value) {
+        this.value = value;
+    }
+
+    public Appendable appendTo(final Appendable target) throws IOException {
+        return appendDecimal(target, value);
+    }
+}

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/FTruncImpl.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/FTruncImpl.java
@@ -8,6 +8,6 @@ final class FTruncImpl extends AbstractCastInstruction {
     }
 
     public Appendable appendTo(final Appendable target) throws IOException {
-        return appendTrailer(super.appendTo(target).append("ftrunc"));
+        return appendTrailer(super.appendTo(target).append("fptrunc"));
     }
 }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/FloatConstant.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/FloatConstant.java
@@ -1,0 +1,21 @@
+package cc.quarkus.qcc.machine.llvm.impl;
+
+import java.io.IOException;
+
+/**
+ * Floating-point constants in LLVM must not be inexact.
+ *
+ * See Section "Constants" in LLVM Language Reference Manual
+ * http://llvm.org/docs/LangRef.html#simple-constants
+ */
+final class FloatConstant extends AbstractValue {
+    final float value;
+
+    FloatConstant(final float value) {
+        this.value = value;
+    }
+
+    public Appendable appendTo(final Appendable target) throws IOException {
+        return appendHex(target, value);
+    }
+}

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/LLVM.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/LLVM.java
@@ -58,6 +58,14 @@ public final class LLVM {
         return new LongConstant(val);
     }
 
+    public static LLValue floatConstant(float val) {
+        return new FloatConstant(val);
+    }
+
+    public static LLValue floatConstant(double val) {
+        return new DoubleConstant(val);
+    }
+
     public static LLValue global(final String name) {
         return new NamedGlobalValueOf(name);
     }

--- a/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
+++ b/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
@@ -131,7 +131,7 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
                 if (toType instanceof FloatType) {
                     if (fromType.getMinBits() < toType.getMinBits()) {
                         // OK
-                        return super.truncate(from, toType);
+                        return super.extend(from, toType);
                     } else if (fromType.getMinBits() == toType.getMinBits()) {
                         // no actual extension needed
                         return from;


### PR DESCRIPTION
This change enables to emit floating-point literals. For single-precision floating-point literals, the change emits the hexadecimal representation just as Clang does. (also described in http://llvm.org/docs/LangRef.html#simple-constants)