### PR TITLE
Fix native type resolution, including lowering pointer types and resolving inner class attributes

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/BasicBlockBuilder.java
@@ -158,6 +158,8 @@ public interface BasicBlockBuilder {
 
     Value valueConvert(Value value, WordType toType);
 
+    Value instanceOf(Value input, ValueType expectedType);
+
     /**
      * Narrow a value with reference type to another (typically more specific) type.
      *
@@ -165,7 +167,7 @@ public interface BasicBlockBuilder {
      * @param toType the type to narrow to
      * @return the narrowed type
      */
-    Value narrow(Value value, TypeIdLiteral toType);
+    Value narrow(Value value, ValueType toType);
 
     // memory
 
@@ -479,8 +481,12 @@ public interface BasicBlockBuilder {
                 return new Convert(line, bci, value, toType);
             }
 
-            public Value narrow(final Value value, final TypeIdLiteral toType) {
-                return new Narrow(line, bci, value, typeSystem.getReferenceType(toType));
+            public Value instanceOf(final Value input, final ValueType expectedType) {
+                return new InstanceOf(line, bci, input, expectedType, typeSystem.getBooleanType());
+            }
+
+            public Value narrow(final Value value, final ValueType toType) {
+                return new Narrow(line, bci, value, toType);
             }
 
             public Value receiver(final TypeIdLiteral upperBound) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/DelegatingBasicBlockBuilder.java
@@ -54,7 +54,7 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return delegate;
     }
 
-    public Value narrow(final Value value, final TypeIdLiteral toType) {
+    public Value narrow(final Value value, final ValueType toType) {
         return getDelegate().narrow(value, toType);
     }
 
@@ -300,6 +300,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
 
     public Value valueConvert(final Value value, final WordType toType) {
         return getDelegate().valueConvert(value, toType);
+    }
+
+    public Value instanceOf(final Value input, final ValueType expectedType) {
+        return getDelegate().instanceOf(input, expectedType);
     }
 
     public Value populationCount(final Value v) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceOf.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceOf.java
@@ -1,0 +1,58 @@
+package cc.quarkus.qcc.graph;
+
+import java.util.Objects;
+
+import cc.quarkus.qcc.type.BooleanType;
+import cc.quarkus.qcc.type.ValueType;
+
+/**
+ * A node that represents a check of the upper bound of the value against the given type.
+ */
+public final class InstanceOf extends AbstractValue implements InstanceOperation {
+    private final Value input;
+    private final ValueType checkType;
+    private final BooleanType booleanType;
+
+    InstanceOf(final int line, final int bci, final Value input, final ValueType checkType, final BooleanType booleanType) {
+        super(line, bci);
+        this.input = input;
+        this.checkType = checkType;
+        this.booleanType = booleanType;
+    }
+
+    public ValueType getCheckType() {
+        return checkType;
+    }
+
+    int calcHashCode() {
+        return Objects.hash(input, checkType);
+    }
+
+    public boolean equals(final Object other) {
+        return other instanceof InstanceOf && equals((InstanceOf) other);
+    }
+
+    public boolean equals(final InstanceOf other) {
+        return this == other || other != null && input.equals(other.input) && checkType.equals(other.checkType);
+    }
+
+    public int getValueDependencyCount() {
+        return 1;
+    }
+
+    public Value getValueDependency(final int index) throws IndexOutOfBoundsException {
+        return index == 0 ? input : Util.throwIndexOutOfBounds(index);
+    }
+
+    public Value getInstance() {
+        return input;
+    }
+
+    public BooleanType getType() {
+        return booleanType;
+    }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Narrow.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Narrow.java
@@ -2,16 +2,16 @@ package cc.quarkus.qcc.graph;
 
 import java.util.Objects;
 
-import cc.quarkus.qcc.type.ReferenceType;
+import cc.quarkus.qcc.type.ValueType;
 
 /**
  * A narrowed value.  The input value is assumed to be wider; violating this assumption can cause problems.
  */
 public final class Narrow extends AbstractValue implements CastValue {
     private final Value input;
-    private final ReferenceType type;
+    private final ValueType type;
 
-    Narrow(final int line, final int bci, final Value input, final ReferenceType type) {
+    Narrow(final int line, final int bci, final Value input, final ValueType type) {
         super(line, bci);
         this.input = input;
         this.type = type;
@@ -21,7 +21,7 @@ public final class Narrow extends AbstractValue implements CastValue {
         return input;
     }
 
-    public ReferenceType getType() {
+    public ValueType getType() {
         return type;
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Node.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Node.java
@@ -476,7 +476,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final Narrow node) {
-                return param.getBlockBuilder().narrow(param.copyValue(node.getInput()), node.getType().getUpperBound());
+                return param.getBlockBuilder().narrow(param.copyValue(node.getInput()), node.getType());
             }
 
             public Value visit(final Copier param, final Neg node) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ValueVisitor.java
@@ -130,6 +130,10 @@ public interface ValueVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, InstanceOf node) {
+        return visitUnknown(param, node);
+    }
+
     default R visit(T param, IntegerLiteral node) {
         return visitUnknown(param, node);
     }
@@ -362,6 +366,10 @@ public interface ValueVisitor<T, R> {
         }
 
         default R visit(T param, InstanceInvocationValue node) {
+            return getDelegateValueVisitor().visit(param, node);
+        }
+
+        default R visit(T param, InstanceOf node) {
             return getDelegateValueVisitor().visit(param, node);
         }
 
@@ -687,7 +695,7 @@ public interface ValueVisitor<T, R> {
         }
 
         default Value visit(final T param, final Narrow node) {
-            return getBuilder(param).narrow(copy(param, node.getInput()), node.getType().getUpperBound());
+            return getBuilder(param).narrow(copy(param, node.getInput()), node.getType());
         }
 
         default Value visit(final T param, final Neg node) {

--- a/compiler/src/main/java/cc/quarkus/qcc/interpreter/Dictionary.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/interpreter/Dictionary.java
@@ -142,7 +142,11 @@ public class Dictionary implements ClassContext {
         throw Assert.unsupported();
     }
 
-    public FunctionType resolveTypeFromMethodDescriptor(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
+    public FunctionType resolveMethodFunctionType(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
+        return null;
+    }
+
+    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
         return null;
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/type/TypeSystem.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/TypeSystem.java
@@ -125,9 +125,9 @@ public final class TypeSystem {
         return methodDescriptorType;
     }
 
-    public ReferenceType getReferenceType(TypeIdLiteral typeId) {
-        Assert.checkNotNullParam("typeId", typeId);
-        return referenceTypeCache.computeIfAbsent(typeId, id -> new ReferenceType(this, id, false, referenceSize, referenceAlign, false));
+    public ReferenceType getReferenceType(TypeIdLiteral upperBound) {
+        Assert.checkNotNullParam("upperBound", upperBound);
+        return referenceTypeCache.computeIfAbsent(upperBound, id -> new ReferenceType(this, id, false, referenceSize, referenceAlign, false));
     }
 
     /**

--- a/compiler/src/main/java/cc/quarkus/qcc/type/annotation/AnnotationValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/annotation/AnnotationValue.java
@@ -125,6 +125,9 @@ public abstract class AnnotationValue {
             case 'e': {
                 return EnumConstantAnnotationValue.of(classFile.getUtf8Constant(nextShort(buf)), classFile.getUtf8Constant(nextShort(buf)));
             }
+            case 'c': {
+                return ClassAnnotationValue.of(classFile.getUtf8Constant(nextShort(buf)));
+            }
             case '@': {
                 return Annotation.parse(classFile, classContext, buf);
             }

--- a/compiler/src/main/java/cc/quarkus/qcc/type/annotation/ClassAnnotationValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/annotation/ClassAnnotationValue.java
@@ -1,5 +1,7 @@
 package cc.quarkus.qcc.type.annotation;
 
+import io.smallrye.common.constraint.Assert;
+
 /**
  * A {@link Class} annotation value.
  */
@@ -16,5 +18,9 @@ public final class ClassAnnotationValue extends AnnotationValue {
 
     public Kind getKind() {
         return Kind.CLASS;
+    }
+
+    public static ClassAnnotationValue of(final String typeName) {
+        return new ClassAnnotationValue(Assert.checkNotNullParam("typeName", typeName));
     }
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/ClassContext.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/ClassContext.java
@@ -68,7 +68,7 @@ public interface ClassContext extends DescriptorTypeResolver {
 
     ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations);
 
-    FunctionType resolveTypeFromMethodDescriptor(MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations);
+    FunctionType resolveMethodFunctionType(MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations);
 
     /**
      * Create a basic class context which can be used to produce type definitions.
@@ -197,7 +197,11 @@ public interface ClassContext extends DescriptorTypeResolver {
                 throw Assert.unsupported();
             }
 
-            public FunctionType resolveTypeFromMethodDescriptor(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
+            public FunctionType resolveMethodFunctionType(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
+                throw Assert.unsupported();
+            }
+
+            public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
                 throw Assert.unsupported();
             }
         };

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinition.java
@@ -186,7 +186,13 @@ public interface DefinedTypeDefinition extends FieldResolver,
 
         void addConstructor(ConstructorResolver resolver, int index);
 
+        void setEnclosingClass(EnclosingClassResolver resolver, int index);
+
+        void addEnclosedClass(EnclosedClassResolver resolver, int index);
+
         void setName(String internalName);
+
+        void setSimpleName(String simpleName);
 
         void setModifiers(int modifiers);
 
@@ -249,8 +255,20 @@ public interface DefinedTypeDefinition extends FieldResolver,
                 getDelegate().addConstructor(resolver, index);
             }
 
+            default void setEnclosingClass(EnclosingClassResolver resolver, int index) {
+                getDelegate().setEnclosingClass(resolver, index);
+            }
+
+            default void addEnclosedClass(EnclosedClassResolver resolver, int index) {
+                getDelegate().addEnclosedClass(resolver, index);
+            }
+
             default void setName(String internalName) {
                 getDelegate().setName(internalName);
+            }
+
+            default void setSimpleName(String simpleName) {
+                getDelegate().setSimpleName(simpleName);
             }
 
             default void setModifiers(int modifiers) {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/DelegatingValidatedTypeDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/DelegatingValidatedTypeDefinition.java
@@ -5,6 +5,7 @@ import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.FieldElement;
 import cc.quarkus.qcc.type.definition.element.InitializerElement;
 import cc.quarkus.qcc.type.definition.element.MethodElement;
+import cc.quarkus.qcc.type.definition.element.NestedClassElement;
 
 /**
  *
@@ -36,6 +37,18 @@ public abstract class DelegatingValidatedTypeDefinition extends DelegatingDefine
 
     public FieldSet getStaticFieldSet() {
         return getDelegate().getStaticFieldSet();
+    }
+
+    public NestedClassElement getEnclosingNestedClass() {
+        return getDelegate().getEnclosingNestedClass();
+    }
+
+    public int getEnclosedNestedClassCount() {
+        return getDelegate().getEnclosedNestedClassCount();
+    }
+
+    public NestedClassElement getEnclosedNestedClass(final int index) throws IndexOutOfBoundsException {
+        return getDelegate().getEnclosedNestedClass(index);
     }
 
     public ValidatedTypeDefinition validate() {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/DescriptorTypeResolver.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/DescriptorTypeResolver.java
@@ -53,7 +53,9 @@ public interface DescriptorTypeResolver {
      * @param invisibleAnnotations the list of visible type annotations list on the parameters of this use site (must not be {@code null})
      * @return the resolved function type
      */
-    FunctionType resolveTypeFromMethodDescriptor(MethodDescriptor descriptor, List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, List<TypeAnnotationList> invisibleAnnotations);
+    FunctionType resolveMethodFunctionType(MethodDescriptor descriptor, List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, List<TypeAnnotationList> invisibleAnnotations);
+
+    ValueType resolveTypeFromMethodDescriptor(TypeDescriptor descriptor, List<ParameterizedSignature> typeParamCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations);
 
     interface Delegating extends DescriptorTypeResolver {
         DescriptorTypeResolver getDelegate();
@@ -66,8 +68,12 @@ public interface DescriptorTypeResolver {
             return getDelegate().resolveTypeFromDescriptor(descriptor, typeParamCtxt, signature, visibleAnnotations, invisibleAnnotations);
         }
 
-        default FunctionType resolveTypeFromMethodDescriptor(MethodDescriptor descriptor, List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, List<TypeAnnotationList> invisibleAnnotations) {
-            return getDelegate().resolveTypeFromMethodDescriptor(descriptor, typeParamCtxt, signature, returnTypeVisible, visibleAnnotations, returnTypeInvisible, invisibleAnnotations);
+        default FunctionType resolveMethodFunctionType(MethodDescriptor descriptor, List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, List<TypeAnnotationList> invisibleAnnotations) {
+            return getDelegate().resolveMethodFunctionType(descriptor, typeParamCtxt, signature, returnTypeVisible, visibleAnnotations, returnTypeInvisible, invisibleAnnotations);
+        }
+
+        default ValueType resolveTypeFromMethodDescriptor(TypeDescriptor descriptor, List<ParameterizedSignature> typeParamCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations) {
+            return getDelegate().resolveTypeFromMethodDescriptor(descriptor, typeParamCtxt, signature, visibleAnnotations, invisibleAnnotations);
         }
     }
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/EnclosedClassResolver.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/EnclosedClassResolver.java
@@ -1,0 +1,10 @@
+package cc.quarkus.qcc.type.definition;
+
+import cc.quarkus.qcc.type.definition.element.NestedClassElement;
+
+/**
+ *
+ */
+public interface EnclosedClassResolver {
+    NestedClassElement resolveEnclosedNestedClass(int index, final DefinedTypeDefinition enclosing);
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/EnclosingClassResolver.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/EnclosingClassResolver.java
@@ -1,0 +1,10 @@
+package cc.quarkus.qcc.type.definition;
+
+import cc.quarkus.qcc.type.definition.element.NestedClassElement;
+
+/**
+ *
+ */
+public interface EnclosingClassResolver {
+    NestedClassElement resolveEnclosingNestedClass(int index, DefinedTypeDefinition enclosed);
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/ValidatedTypeDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/ValidatedTypeDefinition.java
@@ -9,6 +9,7 @@ import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.FieldElement;
 import cc.quarkus.qcc.type.definition.element.InitializerElement;
 import cc.quarkus.qcc.type.definition.element.MethodElement;
+import cc.quarkus.qcc.type.definition.element.NestedClassElement;
 import cc.quarkus.qcc.type.descriptor.MethodDescriptor;
 import cc.quarkus.qcc.type.descriptor.TypeDescriptor;
 import io.smallrye.common.constraint.Assert;
@@ -46,6 +47,12 @@ public interface ValidatedTypeDefinition extends DefinedTypeDefinition {
     FieldSet getInstanceFieldSet();
 
     FieldSet getStaticFieldSet();
+
+    NestedClassElement getEnclosingNestedClass();
+
+    int getEnclosedNestedClassCount();
+
+    NestedClassElement getEnclosedNestedClass(int index) throws IndexOutOfBoundsException;
 
     FieldElement getField(int index);
 

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/ValidatedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/ValidatedTypeDefinitionImpl.java
@@ -9,6 +9,7 @@ import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.FieldElement;
 import cc.quarkus.qcc.type.definition.element.InitializerElement;
 import cc.quarkus.qcc.type.definition.element.MethodElement;
+import cc.quarkus.qcc.type.definition.element.NestedClassElement;
 
 /**
  *
@@ -24,9 +25,11 @@ final class ValidatedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition 
     private final InitializerElement init;
     private final FieldSet staticFieldSet;
     private final FieldSet instanceFieldSet;
+    private final NestedClassElement enclosingClass;
+    private final NestedClassElement[] enclosedClasses;
     private volatile ResolvedTypeDefinition resolved;
 
-    ValidatedTypeDefinitionImpl(final DefinedTypeDefinitionImpl delegate, final ValidatedTypeDefinition superType, final ValidatedTypeDefinition[] interfaces, final FieldElement[] fields, final MethodElement[] methods, final ConstructorElement[] ctors, final InitializerElement init) {
+    ValidatedTypeDefinitionImpl(final DefinedTypeDefinitionImpl delegate, final ValidatedTypeDefinition superType, final ValidatedTypeDefinition[] interfaces, final FieldElement[] fields, final MethodElement[] methods, final ConstructorElement[] ctors, final InitializerElement init, final NestedClassElement enclosingClass, final NestedClassElement[] enclosedClasses) {
         this.delegate = delegate;
         this.superType = superType;
         this.interfaces = interfaces;
@@ -34,6 +37,8 @@ final class ValidatedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition 
         this.methods = methods;
         this.ctors = ctors;
         this.init = init;
+        this.enclosingClass = enclosingClass;
+        this.enclosedClasses = enclosedClasses;
         int interfaceCnt = interfaces.length;
         InterfaceTypeIdLiteral[] interfaceTypes = new InterfaceTypeIdLiteral[interfaceCnt];
         for (int i = 0; i < interfaceCnt; i ++) {
@@ -82,6 +87,18 @@ final class ValidatedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition 
 
     public FieldSet getStaticFieldSet() {
         return staticFieldSet;
+    }
+
+    public NestedClassElement getEnclosingNestedClass() {
+        return enclosingClass;
+    }
+
+    public int getEnclosedNestedClassCount() {
+        return enclosedClasses.length;
+    }
+
+    public NestedClassElement getEnclosedNestedClass(final int index) throws IndexOutOfBoundsException {
+        return enclosedClasses[index];
     }
 
     public FieldSet getInstanceFieldSet() {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassFile.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassFile.java
@@ -334,6 +334,10 @@ public interface ClassFile extends FieldResolver,
         return getUtf8Constant(getClassConstantNameIdx(idx));
     }
 
+    default boolean classConstantNameEquals(int idx, String expect) {
+        return utf8ConstantEquals(getClassConstantNameIdx(idx), expect);
+    }
+
     default int getClassConstantNameIdx(int idx) throws IndexOutOfBoundsException, ConstantTypeMismatchException {
         if (idx == 0) {
             return 0;

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/ElementVisitor.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/ElementVisitor.java
@@ -28,6 +28,10 @@ public interface ElementVisitor<T, R> {
         return visitUnknown(param, element);
     }
 
+    default R visit(T param, NestedClassElement element) {
+        return visitUnknown(param, element);
+    }
+
     default R visit(T param, ParameterElement element) {
         return visitUnknown(param, element);
     }
@@ -49,6 +53,10 @@ public interface ElementVisitor<T, R> {
         }
 
         default R visit(final T param, final MethodElement element) {
+            return getDelegateElementVisitor().visit(param, element);
+        }
+
+        default R visit(final T param, final NestedClassElement element) {
             return getDelegateElementVisitor().visit(param, element);
         }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/FieldElement.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/FieldElement.java
@@ -34,10 +34,6 @@ public final class FieldElement extends VariableElement implements MemberElement
         return enclosingType;
     }
 
-    public ValueType getType(final ClassContext classContext, final List<ParameterizedSignature> signatureContext) {
-        return null;
-    }
-
     public <T, R> R accept(final ElementVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
     }

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/InvokableElement.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/InvokableElement.java
@@ -73,7 +73,7 @@ public abstract class InvokableElement extends AnnotatedElement implements Execu
     public FunctionType getType(final ClassContext classContext, final List<ParameterizedSignature> signatureContext) {
         FunctionType type = this.type;
         if (type == null) {
-            this.type = type = classContext.resolveTypeFromMethodDescriptor(
+            this.type = type = classContext.resolveMethodFunctionType(
                 descriptor,
                 signatureContext,
                 signature,

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/NestedClassElement.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/NestedClassElement.java
@@ -1,0 +1,66 @@
+package cc.quarkus.qcc.type.definition.element;
+
+import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * A class element, representing a class that is enclosed within another class.
+ */
+public final class NestedClassElement extends BasicElement implements MemberElement, NamedElement {
+    public static final NestedClassElement[] NO_NESTED_CLASSES = new NestedClassElement[0];
+
+    private final String name;
+    private final DefinedTypeDefinition enclosingType;
+    private final DefinedTypeDefinition correspondingType;
+
+    NestedClassElement(final Builder builder) {
+        super(builder);
+        this.name = Assert.checkNotNullParam("builder.name", builder.name);
+        this.enclosingType = Assert.checkNotNullParam("builder.enclosingType", builder.enclosingType);
+        this.correspondingType = Assert.checkNotNullParam("builder.correspondingType", builder.correspondingType);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public DefinedTypeDefinition getEnclosingType() {
+        return enclosingType;
+    }
+
+    public DefinedTypeDefinition getCorrespondingType() {
+        return correspondingType;
+    }
+
+    public <T, R> R accept(final ElementVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends BasicElement.Builder implements MemberElement.Builder, NamedElement.Builder {
+        private String name;
+        private DefinedTypeDefinition enclosingType;
+        private DefinedTypeDefinition correspondingType;
+
+        Builder() {}
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public void setEnclosingType(final DefinedTypeDefinition enclosingType) {
+            this.enclosingType = enclosingType;
+        }
+
+        public void setCorrespondingType(final DefinedTypeDefinition correspondingType) {
+            this.correspondingType = correspondingType;
+        }
+
+        public NestedClassElement build() {
+            return new NestedClassElement(this);
+        }
+    }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/ParameterElement.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/ParameterElement.java
@@ -1,5 +1,11 @@
 package cc.quarkus.qcc.type.definition.element;
 
+import java.util.List;
+
+import cc.quarkus.qcc.type.ValueType;
+import cc.quarkus.qcc.type.definition.ClassContext;
+import cc.quarkus.qcc.type.generic.ParameterizedSignature;
+
 /**
  * A method parameter variable.
  */
@@ -16,6 +22,15 @@ public final class ParameterElement extends VariableElement {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    ValueType resolveTypeDescriptor(final ClassContext classContext, final List<ParameterizedSignature> signatureContext) {
+        return classContext.resolveTypeFromMethodDescriptor(
+                        getTypeDescriptor(),
+                        signatureContext,
+                        getTypeSignature(),
+                        getVisibleTypeAnnotations(),
+                        getInvisibleTypeAnnotations());
     }
 
     public static final class Builder extends VariableElement.Builder {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/VariableElement.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/VariableElement.java
@@ -62,15 +62,18 @@ public abstract class VariableElement extends AnnotatedElement implements NamedE
     public ValueType getType(ClassContext classContext, List<ParameterizedSignature> signatureContext) {
         ValueType type = this.type;
         if (type == null) {
-            this.type = type = classContext.resolveTypeFromDescriptor(
-                getTypeDescriptor(),
-                signatureContext,
-                getTypeSignature(),
-                getVisibleTypeAnnotations(),
-                getInvisibleTypeAnnotations()
-            );
+            this.type = type = resolveTypeDescriptor(classContext, signatureContext);
         }
         return type;
+    }
+
+    ValueType resolveTypeDescriptor(ClassContext classContext, List<ParameterizedSignature> signatureContext) {
+        return classContext.resolveTypeFromDescriptor(
+                        getTypeDescriptor(),
+                        signatureContext,
+                        getTypeSignature(),
+                        getVisibleTypeAnnotations(),
+                        getInvisibleTypeAnnotations());
     }
 
     public boolean isFinal() {

--- a/compiler/src/test/java/cc/quarkus/qcc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/cc/quarkus/qcc/type/generic/TestClassContext.java
@@ -228,7 +228,11 @@ public class TestClassContext implements ClassContext {
         return null;
     }
 
-    public FunctionType resolveTypeFromMethodDescriptor(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
+    public FunctionType resolveMethodFunctionType(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
+        return null;
+    }
+
+    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
         return null;
     }
 }

--- a/driver/src/main/java/cc/quarkus/qcc/driver/BasicDescriptorTypeResolver.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/BasicDescriptorTypeResolver.java
@@ -73,7 +73,7 @@ final class BasicDescriptorTypeResolver implements DescriptorTypeResolver {
         }
     }
 
-    public FunctionType resolveTypeFromMethodDescriptor(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visible, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisible) {
+    public FunctionType resolveMethodFunctionType(final MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final MethodSignature signature, final TypeAnnotationList returnTypeVisible, final List<TypeAnnotationList> visible, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisible) {
         TypeDescriptor returnType = descriptor.getReturnType();
         List<TypeDescriptor> parameterTypes = descriptor.getParameterTypes();
         TypeSignature returnTypeSignature = signature.getReturnTypeSignature();
@@ -93,12 +93,16 @@ final class BasicDescriptorTypeResolver implements DescriptorTypeResolver {
                 nestedCtxt = Arrays.asList(array);
             }
         }
-        ValueType resolvedReturnType = classContext.resolveTypeFromDescriptor(returnType, nestedCtxt, returnTypeSignature, returnTypeVisible, returnTypeInvisible);
+        ValueType resolvedReturnType = classContext.resolveTypeFromMethodDescriptor(returnType, nestedCtxt, returnTypeSignature, returnTypeVisible, returnTypeInvisible);
         int cnt = parameterTypes.size();
         ValueType[] resolvedParamTypes = new ValueType[cnt];
         for (int i = 0; i < cnt; i ++) {
-            resolvedParamTypes[i] = classContext.resolveTypeFromDescriptor(parameterTypes.get(i), nestedCtxt, paramSignatures.get(i), visible.get(i), invisible.get(i));
+            resolvedParamTypes[i] = classContext.resolveTypeFromMethodDescriptor(parameterTypes.get(i), nestedCtxt, paramSignatures.get(i), visible.get(i), invisible.get(i));
         }
         return classContext.getTypeSystem().getFunctionType(resolvedReturnType, resolvedParamTypes);
+    }
+
+    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
+        return classContext.resolveTypeFromDescriptor(descriptor, typeParamCtxt, signature, visibleAnnotations, invisibleAnnotations);
     }
 }

--- a/driver/src/main/java/cc/quarkus/qcc/driver/ClassContextImpl.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/ClassContextImpl.java
@@ -148,8 +148,11 @@ final class ClassContextImpl implements ClassContext {
         return descriptorTypeResolver.resolveTypeFromDescriptor(descriptor, typeParamCtxt, signature, visibleAnnotations, invisibleAnnotations);
     }
 
-    public FunctionType resolveTypeFromMethodDescriptor(MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
-        return descriptorTypeResolver.resolveTypeFromMethodDescriptor(descriptor, typeParamCtxt, signature, returnTypeVisible, visibleAnnotations, returnTypeInvisible, invisibleAnnotations);
+    public FunctionType resolveMethodFunctionType(MethodDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, MethodSignature signature, final TypeAnnotationList returnTypeVisible, List<TypeAnnotationList> visibleAnnotations, final TypeAnnotationList returnTypeInvisible, final List<TypeAnnotationList> invisibleAnnotations) {
+        return descriptorTypeResolver.resolveMethodFunctionType(descriptor, typeParamCtxt, signature, returnTypeVisible, visibleAnnotations, returnTypeInvisible, invisibleAnnotations);
     }
 
+    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
+        return descriptorTypeResolver.resolveTypeFromMethodDescriptor(descriptor, typeParamCtxt, signature, visibleAnnotations, invisibleAnnotations);
+    }
 }

--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -27,6 +27,7 @@ import cc.quarkus.qcc.plugin.lowering.InvocationLoweringBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.native_.ConstTypeResolver;
 import cc.quarkus.qcc.plugin.native_.ConstantDefiningBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.native_.ExternExportTypeBuilder;
+import cc.quarkus.qcc.plugin.native_.FunctionTypeResolver;
 import cc.quarkus.qcc.plugin.native_.NativeBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.native_.NativeTypeBuilder;
 import cc.quarkus.qcc.plugin.native_.NativeTypeResolver;
@@ -196,6 +197,7 @@ public class Main {
                                 builder.addTypeBuilderFactory(ExternExportTypeBuilder::new);
                                 builder.addTypeBuilderFactory(NativeTypeBuilder::new);
                                 builder.addResolverFactory(ConstTypeResolver::new);
+                                builder.addResolverFactory(FunctionTypeResolver::new);
                                 builder.addResolverFactory(NativeTypeResolver::new);
                                 builder.addResolverFactory(PointerTypeResolver::new);
                                 builder.addAdditivePhaseBlockBuilderFactory(BuilderStage.TRANSFORM, ConstantDefiningBasicBlockBuilder::new);

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMGenerator.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMGenerator.java
@@ -30,6 +30,7 @@ import cc.quarkus.qcc.type.BooleanType;
 import cc.quarkus.qcc.type.FloatType;
 import cc.quarkus.qcc.type.FunctionType;
 import cc.quarkus.qcc.type.IntegerType;
+import cc.quarkus.qcc.type.PointerType;
 import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.Type;
 import cc.quarkus.qcc.type.VoidType;
@@ -145,6 +146,9 @@ public class LLVMGenerator implements Consumer<CompilationContext> {
         } else if (type instanceof ReferenceType) {
             // todo: lower class types to ref types at some earlier point
             res = ptrTo(i8);
+        } else if (type instanceof PointerType) {
+            Type pointeeType = ((PointerType) type).getPointeeType();
+            res = ptrTo(pointeeType instanceof VoidType ? i8 : map(pointeeType));
         } else {
             throw new IllegalStateException();
         }

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -28,6 +28,7 @@ import cc.quarkus.qcc.graph.Goto;
 import cc.quarkus.qcc.graph.If;
 import cc.quarkus.qcc.graph.Mod;
 import cc.quarkus.qcc.graph.Multiply;
+import cc.quarkus.qcc.graph.Narrow;
 import cc.quarkus.qcc.graph.Neg;
 import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.NodeVisitor;
@@ -387,6 +388,10 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
                     isSigned(javaInputType) ?
                     target.sext(inputType, llvmInput, outputType).asLocal() :
                     target.zext(inputType, llvmInput, outputType).asLocal();
+    }
+
+    public LLValue visit(final Void param, final Narrow node) {
+        return map(node.getInput());
     }
 
     public LLValue visit(final Void param, final Truncate node) {

--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/ExternExportTypeBuilder.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/ExternExportTypeBuilder.java
@@ -50,7 +50,6 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
             public MethodElement resolveMethod(final int index, final DefinedTypeDefinition enclosing) {
                 NativeInfo nativeInfo = NativeInfo.get(ctxt);
                 MethodElement origMethod = resolver.resolveMethod(index, enclosing);
-                boolean isNative = origMethod.hasAllModifiersOf(ClassFile.ACC_NATIVE);
                 // look for annotations that indicate that this method requires special handling
                 for (Annotation annotation : origMethod.getVisibleAnnotations()) {
                     ClassTypeDescriptor desc = annotation.getDescriptor();
@@ -70,7 +69,7 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
                             AnnotationValue nameVal = annotation.getValue("withName");
                             String name = nameVal == null ? origMethod.getName() : ((StringAnnotationValue) nameVal).getString();
                             Function exactFunction = ctxt.getExactFunction(origMethod);
-                            FunctionType fnType = exactFunction.getType();
+                            FunctionType fnType = origMethod.getType(classCtxt, List.of(/*todo*/));
                             Function function = ctxt.getOrAddProgramModule(enclosing).getOrAddSection(IMPLICIT_SECTION_NAME).addFunction(origMethod, name, fnType);
                             BasicBlockBuilder gf = classCtxt.newBasicBlockBuilder(origMethod);
                             BlockLabel entry = new BlockLabel();

--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/FunctionTypeResolver.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/FunctionTypeResolver.java
@@ -1,0 +1,116 @@
+package cc.quarkus.qcc.plugin.native_;
+
+import static cc.quarkus.qcc.runtime.CNative.*;
+
+import java.util.List;
+
+import cc.quarkus.qcc.context.CompilationContext;
+import cc.quarkus.qcc.type.FunctionType;
+import cc.quarkus.qcc.type.TypeSystem;
+import cc.quarkus.qcc.type.ValueType;
+import cc.quarkus.qcc.type.annotation.type.TypeAnnotationList;
+import cc.quarkus.qcc.type.definition.ClassContext;
+import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
+import cc.quarkus.qcc.type.definition.DescriptorTypeResolver;
+import cc.quarkus.qcc.type.descriptor.ClassTypeDescriptor;
+import cc.quarkus.qcc.type.descriptor.TypeDescriptor;
+import cc.quarkus.qcc.type.generic.AnyTypeArgument;
+import cc.quarkus.qcc.type.generic.BoundTypeArgument;
+import cc.quarkus.qcc.type.generic.ClassTypeSignature;
+import cc.quarkus.qcc.type.generic.ParameterizedSignature;
+import cc.quarkus.qcc.type.generic.ReferenceTypeSignature;
+import cc.quarkus.qcc.type.generic.TypeArgument;
+import cc.quarkus.qcc.type.generic.TypeSignature;
+import cc.quarkus.qcc.type.generic.Variance;
+
+/**
+ * A type resolver which resolves function types.
+ */
+public class FunctionTypeResolver implements DescriptorTypeResolver.Delegating {
+    private final ClassContext classCtxt;
+    private final CompilationContext ctxt;
+    private final DescriptorTypeResolver delegate;
+
+    public FunctionTypeResolver(final ClassContext classCtxt, final DescriptorTypeResolver delegate) {
+        this.classCtxt = classCtxt;
+        ctxt = classCtxt.getCompilationContext();
+        this.delegate = delegate;
+    }
+
+    public DescriptorTypeResolver getDelegate() {
+        return delegate;
+    }
+
+    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, final List<ParameterizedSignature> typeParamCtxt, final TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations) {
+        out: if (descriptor instanceof ClassTypeDescriptor) {
+            ClassTypeDescriptor ctd = (ClassTypeDescriptor) descriptor;
+            if (ctd.getPackageName().equals(Native.NATIVE_PKG)) {
+                if (ctd.getClassName().equals(Native.FUNCTION)) {
+                    FunctionType functionType;
+                    // check the signature
+                    TypeSystem ts = ctxt.getTypeSystem();
+                    if (signature instanceof ClassTypeSignature) {
+                        ClassTypeSignature sig = (ClassTypeSignature) signature;
+                        if (! sig.getIdentifier().equals(Native.FUNCTION)) {
+                            ctxt.warning("Incorrect generic signature (expected a %s but got \"%s\")", function.class, sig);
+                            break out;
+                        }
+                        List<TypeArgument> args = sig.getTypeArguments();
+                        if (args.size() != 1) {
+                            ctxt.warning("Incorrect number of generic signature arguments (expected a %s but got \"%s\")", function.class, sig);
+                            break out;
+                        }
+                        TypeArgument typeArgument = args.get(0);
+                        if (typeArgument instanceof AnyTypeArgument) {
+                            ctxt.error("Function types cannot be open-ended");
+                            functionType = ts.getFunctionType(ts.getVoidType());
+                        } else {
+                            assert typeArgument instanceof BoundTypeArgument;
+                            BoundTypeArgument bound = (BoundTypeArgument) typeArgument;
+                            if (bound.getVariance() != Variance.INVARIANT) {
+                                ctxt.error("Function types cannot be open-ended");
+                            }
+                            // looks right, get the proper pointee type
+                            ReferenceTypeSignature pointeeSig = bound.getBound();
+                            // todo: use context to resolve type variable bounds
+                            TypeDescriptor pointeeDesc = pointeeSig.asDescriptor(classCtxt);
+                            if (pointeeDesc instanceof ClassTypeDescriptor) {
+                                ClassTypeDescriptor classDesc = (ClassTypeDescriptor) pointeeDesc;
+                                String name = classDesc.getPackageName() + '/' + classDesc.getClassName();
+                                if (name.equals("java/lang/Object")) {
+                                    // special case: it's really an "any" pointer with extra front-end guards on it
+                                    return ts.getVoidType().asConst().getPointer();
+                                }
+                                DefinedTypeDefinition definedType = classCtxt.findDefinedType(name);
+                                if (definedType == null) {
+                                    ctxt.error("Function interface type \"%s\" is missing", name);
+                                    functionType = ts.getFunctionType(ts.getVoidType());
+                                } else {
+                                    if (definedType.isInterface()) {
+                                        return NativeInfo.get(ctxt).getTypeOfFunctionalInterface(definedType);
+                                    } else {
+                                        ctxt.error("Function interface type \"%s\" is not an interface", name);
+                                        functionType = ts.getFunctionType(ts.getVoidType());
+                                    }
+                                }
+                            } else {
+                                ctxt.error("Function pointee must be a functional interface");
+                                functionType = ts.getFunctionType(ts.getVoidType());
+                            }
+                        }
+                    } else {
+                        // todo: how can we cleanly get the location from here?
+                        ctxt.warning("Generic signature type mismatch (expected a %s but got a %s)", ClassTypeSignature.class, signature.getClass());
+                        functionType = ts.getFunctionType(ts.getVoidType());
+                    }
+                    return functionType;
+                } else {
+                    break out;
+                }
+            } else {
+                break out;
+            }
+        }
+        return getDelegate().resolveTypeFromDescriptor(descriptor, typeParamCtxt, signature, visibleAnnotations, invisibleAnnotations);
+    }
+}

--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/Native.java
@@ -24,10 +24,12 @@ final class Native {
     static final String ANN_SIZE_LIST = className(size.List.class);
     static final String ANN_CONST = className(c_const.class);
     static final String ANN_RESTRICT = className(restrict.class);
+    static final String ANN_ARRAY_SIZE = className(array_size.class);
 
     static final String OBJECT_INT_NAME = intName(object.class.getName());
     static final String WORD_INT_NAME = intName(word.class.getName());
     static final String PTR = className(ptr.class);
+    static final String FUNCTION = className(function.class);
 
     private static String className(Class<?> clz) {
         String name = clz.getName();

--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeInfo.java
@@ -1,15 +1,29 @@
 package cc.quarkus.qcc.plugin.native_;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 import cc.quarkus.qcc.context.AttachmentKey;
 import cc.quarkus.qcc.context.CompilationContext;
+import cc.quarkus.qcc.driver.Driver;
+import cc.quarkus.qcc.machine.probe.CProbe;
+import cc.quarkus.qcc.machine.probe.Qualifier;
+import cc.quarkus.qcc.type.CompoundType;
+import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.ValueType;
+import cc.quarkus.qcc.type.annotation.Annotation;
+import cc.quarkus.qcc.type.annotation.StringAnnotationValue;
+import cc.quarkus.qcc.type.definition.ClassContext;
 import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
-import cc.quarkus.qcc.type.definition.element.FieldElement;
+import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
 import cc.quarkus.qcc.type.definition.element.MethodElement;
+import cc.quarkus.qcc.type.definition.element.NestedClassElement;
+import cc.quarkus.qcc.type.definition.element.VariableElement;
+import cc.quarkus.qcc.type.descriptor.ClassTypeDescriptor;
 
 /**
  *
@@ -17,19 +31,199 @@ import cc.quarkus.qcc.type.definition.element.MethodElement;
 final class NativeInfo {
     static final AttachmentKey<NativeInfo> KEY = new AttachmentKey<>();
 
+    private final CompilationContext ctxt;
+
     final Map<MethodElement, NativeFunctionInfo> nativeFunctions = new ConcurrentHashMap<>();
-    final Map<DefinedTypeDefinition, ValueType> nativeTypes = new ConcurrentHashMap<>();
-    final Set<DefinedTypeDefinition> constantsResolved = ConcurrentHashMap.newKeySet(8192);
-    final Map<FieldElement, ConstantInfo> constants = new ConcurrentHashMap<>(128);
+    final Map<DefinedTypeDefinition, AtomicReference<ValueType>> nativeTypes = new ConcurrentHashMap<>();
+    final Map<DefinedTypeDefinition, MethodElement> functionalInterfaceMethods = new ConcurrentHashMap<>();
+
+    private NativeInfo(final CompilationContext ctxt) {
+        this.ctxt = ctxt;
+    }
 
     static NativeInfo get(final CompilationContext ctxt) {
         NativeInfo nativeInfo = ctxt.getAttachment(KEY);
         if (nativeInfo == null) {
-            NativeInfo appearing = ctxt.putAttachmentIfAbsent(KEY, nativeInfo = new NativeInfo());
+            NativeInfo appearing = ctxt.putAttachmentIfAbsent(KEY, nativeInfo = new NativeInfo(ctxt));
             if (appearing != null) {
                 nativeInfo = appearing;
             }
         }
         return nativeInfo;
+    }
+
+    ValueType resolveNativeType(final DefinedTypeDefinition definedType) {
+        AtomicReference<ValueType> ref = nativeTypes.get(definedType);
+        if (ref == null) {
+            return null;
+        }
+        ClassContext classContext = definedType.getContext();
+        CompilationContext ctxt = classContext.getCompilationContext();
+        ValueType resolved = ref.get();
+        if (resolved == null) {
+            synchronized (ref) {
+                resolved = ref.get();
+                if (resolved == null) {
+                    CProbe.Builder pb = CProbe.builder();
+                    String simpleName = null;
+                    Qualifier q = Qualifier.NONE;
+                    for (Annotation annotation : definedType.getVisibleAnnotations()) {
+                        ClassTypeDescriptor annDesc = annotation.getDescriptor();
+                        if (ProbeUtils.processCommonAnnotation(pb, annotation)) {
+                            continue;
+                        }
+                        if (annDesc.getPackageName().equals(Native.NATIVE_PKG)) {
+                            if (annDesc.getClassName().equals(Native.ANN_NAME)) {
+                                simpleName = ((StringAnnotationValue) annotation.getValue("value")).getString();
+                            }
+                        }
+                        // todo: lib (add to native info)
+                    }
+                    NestedClassElement enclosing = definedType.validate().getEnclosingNestedClass();
+                    while (enclosing != null) {
+                        DefinedTypeDefinition enclosingType = enclosing.getEnclosingType();
+                        for (Annotation annotation : enclosingType.getVisibleAnnotations()) {
+                            ProbeUtils.processCommonAnnotation(pb, annotation);
+                        }
+                        enclosing = enclosingType.validate().getEnclosingNestedClass();
+                    }
+                    if (simpleName == null) {
+                        String fullName = definedType.getInternalName();
+                        int idx = fullName.lastIndexOf('/');
+                        simpleName = idx == -1 ? fullName : fullName.substring(idx + 1);
+                        idx = simpleName.lastIndexOf('$');
+                        simpleName = idx == -1 ? simpleName : simpleName.substring(idx + 1);
+                        if (simpleName.startsWith("struct_")) {
+                            q = Qualifier.STRUCT;
+                            simpleName = simpleName.substring(7);
+                        } else if (simpleName.startsWith("union_")) {
+                            q = Qualifier.UNION;
+                            simpleName = simpleName.substring(6);
+                        }
+                    }
+                    // begin the real work
+                    ValidatedTypeDefinition vt = definedType.validate();
+                    NativeInfo nativeInfo = ctxt.getAttachment(NativeInfo.KEY);
+                    int fc = vt.getFieldCount();
+                    TypeSystem ts = ctxt.getTypeSystem();
+                    CProbe.Type.Builder tb = CProbe.Type.builder();
+                    tb.setName(simpleName);
+                    tb.setQualifier(q);
+                    for (int i = 0; i < fc; i ++) {
+                        ValueType type = vt.getField(i).getType(classContext, List.of(/*todo*/));
+                        // compound type
+                        tb.addMember(vt.getField(i).getName());
+                    }
+                    CProbe.Type probeType = tb.build();
+                    pb.probeType(probeType);
+                    CProbe probe = pb.build();
+                    CompoundType.Tag tag = q == Qualifier.NONE ? CompoundType.Tag.NONE : q == Qualifier.STRUCT ? CompoundType.Tag.STRUCT : CompoundType.Tag.UNION;
+                    try {
+                        CProbe.Result result = probe.run(ctxt.getAttachment(Driver.C_TOOL_CHAIN_KEY), ctxt.getAttachment(Driver.OBJ_PROVIDER_TOOL_KEY), ctxt);
+                        if (result != null) {
+                            CProbe.Type.Info typeInfo = result.getTypeInfo(probeType);
+                            long size = typeInfo.getSize();
+                            if (typeInfo.isFloating()) {
+                                if (size == 4) {
+                                    resolved = ts.getFloat32Type();
+                                } else if (size == 8) {
+                                    resolved = ts.getFloat64Type();
+                                } else {
+                                    resolved = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign());
+                                }
+                            } else if (typeInfo.isSigned()) {
+                                if (size == 1) {
+                                    resolved = ts.getSignedInteger8Type();
+                                } else if (size == 2) {
+                                    resolved = ts.getSignedInteger16Type();
+                                } else if (size == 4) {
+                                    resolved = ts.getSignedInteger32Type();
+                                } else if (size == 8) {
+                                    resolved = ts.getSignedInteger64Type();
+                                } else {
+                                    resolved = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign());
+                                }
+                            } else if (typeInfo.isUnsigned()) {
+                                if (size == 1) {
+                                    resolved = ts.getUnsignedInteger8Type();
+                                } else if (size == 2) {
+                                    resolved = ts.getUnsignedInteger16Type();
+                                } else if (size == 4) {
+                                    resolved = ts.getUnsignedInteger32Type();
+                                } else if (size == 8) {
+                                    resolved = ts.getUnsignedInteger64Type();
+                                } else {
+                                    resolved = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign());
+                                }
+                            } else {
+                                CompoundType.Member[] members = new CompoundType.Member[fc];
+                                for (int i = 0; i < fc; i ++) {
+                                    ValueType type = vt.getField(i).getType(classContext, List.of(/*todo*/));
+                                    // compound type
+                                    String name = vt.getField(i).getName();
+                                    CProbe.Type.Info member = result.getTypeInfoOfMember(probeType, name);
+                                    members[i] = ts.getCompoundTypeMember(name, type, (int) member.getOffset(), (int) member.getAlign());
+                                }
+                                resolved = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign(), members);
+                            }
+                        }
+                        ref.set(resolved);
+                    } catch (IOException e) {
+                        ctxt.error(e, "Failed to define native type " + simpleName);
+                        return ts.getPoisonType();
+                    }
+                }
+            }
+        }
+        return resolved;
+    }
+
+    public ValueType getTypeOfFunctionalInterface(final DefinedTypeDefinition definedType) {
+        MethodElement method = getFunctionalInterfaceMethod(definedType);
+        if (method == null) {
+            return ctxt.getTypeSystem().getFunctionType(ctxt.getTypeSystem().getVoidType());
+        }
+        return method.getType(definedType.getContext(), List.of(/* todo */));
+    }
+
+    public MethodElement getFunctionalInterfaceMethod(final DefinedTypeDefinition definedType) {
+        MethodElement element = functionalInterfaceMethods.get(definedType);
+        if (element != null) {
+            return element;
+        }
+        try {
+            element = computeFunctionalInterfaceMethod(definedType.validate(), new HashSet<>(), null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        if (element != null) {
+            MethodElement appearing = functionalInterfaceMethods.putIfAbsent(definedType, element);
+            if (appearing != null) {
+                return appearing;
+            }
+        } else {
+            ctxt.error("Interface \"%s\" is not a functional interface", definedType.getInternalName());
+        }
+        return element;
+    }
+
+    private MethodElement computeFunctionalInterfaceMethod(final ValidatedTypeDefinition type, final HashSet<ValidatedTypeDefinition> visited, MethodElement found) {
+        if (visited.add(type)) {
+            int methodCount = type.getMethodCount();
+            for (int i = 0; i < methodCount; i ++) {
+                MethodElement method = type.getMethod(i);
+                if (method.isAbstract() && method.isPublic()) {
+                    if (found == null) {
+                        found = method;
+                    } else {
+                        throw new IllegalArgumentException();
+                    }
+                }
+            }
+            int intCnt = type.getInterfaceCount();
+            for (int i = 0; i < intCnt; i ++) {
+                found = computeFunctionalInterfaceMethod(type.getInterface(i), visited, found);
+            }
+        }
+        return found;
     }
 }

--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeTypeBuilder.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeTypeBuilder.java
@@ -1,22 +1,11 @@
 package cc.quarkus.qcc.plugin.native_;
 
-import java.io.IOException;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import cc.quarkus.qcc.context.CompilationContext;
-import cc.quarkus.qcc.driver.Driver;
-import cc.quarkus.qcc.machine.probe.CProbe;
-import cc.quarkus.qcc.machine.probe.Qualifier;
-import cc.quarkus.qcc.type.CompoundType;
-import cc.quarkus.qcc.type.TypeSystem;
-import cc.quarkus.qcc.type.ValueType;
-import cc.quarkus.qcc.type.annotation.Annotation;
-import cc.quarkus.qcc.type.annotation.StringAnnotationValue;
 import cc.quarkus.qcc.type.definition.ClassContext;
 import cc.quarkus.qcc.type.definition.ConstructorResolver;
 import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
-import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
-import cc.quarkus.qcc.type.descriptor.ClassTypeDescriptor;
 
 /**
  *
@@ -58,106 +47,7 @@ public class NativeTypeBuilder implements DefinedTypeDefinition.Builder.Delegati
         // wrap up
         DefinedTypeDefinition builtType = getDelegate().build();
         if (isNative && ! builtType.isAbstract()) {
-            CProbe.Builder pb = CProbe.builder();
-            String simpleName = null;
-            Qualifier q = Qualifier.NONE;
-            for (Annotation annotation : builtType.getVisibleAnnotations()) {
-                ClassTypeDescriptor annDesc = annotation.getDescriptor();
-                if (annDesc.getPackageName().equals(Native.NATIVE_PKG)) {
-                    if (ProbeUtils.processCommonAnnotation(pb, annotation)) {
-                        continue;
-                    }
-                    if (annDesc.getClassName().equals(Native.ANN_NAME)) {
-                        simpleName = ((StringAnnotationValue) annotation.getValue("value")).getString();
-                    }
-                }
-                // todo: lib (add to native info)
-            }
-            if (simpleName == null) {
-                String fullName = builtType.getInternalName();
-                int idx = fullName.lastIndexOf('/');
-                simpleName = idx == -1 ? fullName : fullName.substring(idx + 1);
-                idx = simpleName.lastIndexOf('$');
-                simpleName = idx == -1 ? simpleName : simpleName.substring(idx + 1);
-                if (simpleName.startsWith("struct_")) {
-                    q = Qualifier.STRUCT;
-                    simpleName = simpleName.substring(7);
-                } else if (simpleName.startsWith("union_")) {
-                    q = Qualifier.UNION;
-                    simpleName = simpleName.substring(6);
-                }
-            }
-            // begin the real work
-            ValidatedTypeDefinition vt = builtType.validate();
-            NativeInfo nativeInfo = ctxt.getAttachment(NativeInfo.KEY);
-            int fc = vt.getFieldCount();
-            TypeSystem ts = ctxt.getTypeSystem();
-            CProbe.Type.Builder tb = CProbe.Type.builder();
-            tb.setName(simpleName);
-            tb.setQualifier(q);
-            for (int i = 0; i < fc; i ++) {
-                ValueType type = vt.getField(i).getType(classCtxt, List.of(/*todo*/));
-                // compound type
-                tb.addMember(vt.getField(i).getName());
-            }
-            CProbe.Type probeType = tb.build();
-            pb.probeType(probeType);
-            CProbe probe = pb.build();
-            CompoundType.Tag tag = q == Qualifier.NONE ? CompoundType.Tag.NONE : q == Qualifier.STRUCT ? CompoundType.Tag.STRUCT : CompoundType.Tag.UNION;
-            try {
-                CProbe.Result result = probe.run(ctxt.getAttachment(Driver.C_TOOL_CHAIN_KEY), ctxt.getAttachment(Driver.OBJ_PROVIDER_TOOL_KEY), ctxt);
-                if (result != null) {
-                    CProbe.Type.Info typeInfo = result.getTypeInfo(probeType);
-                    ValueType realType;
-                    long size = typeInfo.getSize();
-                    if (typeInfo.isFloating()) {
-                        if (size == 4) {
-                            realType = ts.getFloat32Type();
-                        } else if (size == 8) {
-                            realType = ts.getFloat64Type();
-                        } else {
-                            realType = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign());
-                        }
-                    } else if (typeInfo.isSigned()) {
-                        if (size == 1) {
-                            realType = ts.getSignedInteger8Type();
-                        } else if (size == 2) {
-                            realType = ts.getSignedInteger16Type();
-                        } else if (size == 4) {
-                            realType = ts.getSignedInteger32Type();
-                        } else if (size == 8) {
-                            realType = ts.getSignedInteger64Type();
-                        } else {
-                            realType = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign());
-                        }
-                    } else if (typeInfo.isUnsigned()) {
-                        if (size == 1) {
-                            realType = ts.getUnsignedInteger8Type();
-                        } else if (size == 2) {
-                            realType = ts.getUnsignedInteger16Type();
-                        } else if (size == 4) {
-                            realType = ts.getUnsignedInteger32Type();
-                        } else if (size == 8) {
-                            realType = ts.getUnsignedInteger64Type();
-                        } else {
-                            realType = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign());
-                        }
-                    } else {
-                        CompoundType.Member[] members = new CompoundType.Member[fc];
-                        for (int i = 0; i < fc; i ++) {
-                            ValueType type = vt.getField(i).getType(classCtxt, List.of(/*todo*/));
-                            // compound type
-                            String name = vt.getField(i).getName();
-                            CProbe.Type.Info member = result.getTypeInfoOfMember(probeType, name);
-                            members[i] = ts.getCompoundTypeMember(name, type, (int) member.getOffset(), (int) member.getAlign());
-                        }
-                        realType = ts.getCompoundType(tag, simpleName, size, (int) typeInfo.getAlign(), members);
-                    }
-                    nativeInfo.nativeTypes.put(builtType, realType);
-                }
-            } catch (IOException e) {
-                ctxt.error(e, "Failed to define native type " + simpleName);
-            }
+            NativeInfo.get(ctxt).nativeTypes.put(builtType, new AtomicReference<>());
         }
         return builtType;
     }

--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeTypeResolver.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeTypeResolver.java
@@ -1,9 +1,6 @@
 package cc.quarkus.qcc.plugin.native_;
 
 import cc.quarkus.qcc.context.CompilationContext;
-import cc.quarkus.qcc.graph.literal.ClassTypeIdLiteral;
-import cc.quarkus.qcc.graph.literal.TypeIdLiteral;
-import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.ValueType;
 import cc.quarkus.qcc.type.definition.ClassContext;
 import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
@@ -34,23 +31,7 @@ public class NativeTypeResolver implements DescriptorTypeResolver.Delegating {
         if (definedType == null) {
             return delegate.resolveTypeFromClassName(packageName, internalName);
         }
-        ValueType valueType = nativeInfo.nativeTypes.get(definedType);
+        ValueType valueType = nativeInfo.resolveNativeType(definedType);
         return valueType == null ? delegate.resolveTypeFromClassName(packageName, internalName) : valueType;
-    }
-
-    private ValueType translateType(NativeInfo nativeInfo, ValueType type) {
-        if (type instanceof ReferenceType) {
-            TypeIdLiteral upperBound = ((ReferenceType) type).getUpperBound();
-            if (upperBound instanceof ClassTypeIdLiteral) {
-                ClassTypeIdLiteral classId = (ClassTypeIdLiteral) upperBound;
-                DefinedTypeDefinition def = classCtxt.resolveDefinedTypeLiteral(classId);
-                ValueType nativeType = nativeInfo.nativeTypes.get(def);
-                if (nativeType != null) {
-                    return nativeType;
-                }
-            }
-        }
-        // not a native type
-        return type;
     }
 }

--- a/runtime/api/src/main/java/cc/quarkus/qcc/runtime/CNative.java
+++ b/runtime/api/src/main/java/cc/quarkus/qcc/runtime/CNative.java
@@ -558,6 +558,7 @@ public final class CNative {
     /**
      * The special type representing the platform-specific variable argument list.
      */
+    @include("<stdarg.h>")
     public static final class va_list extends object {
     }
 


### PR DESCRIPTION
Also adds an `InstanceOf` node type and more helpers for resolving descriptors from method types, and modifies `Narrow` to operate on types rather than type ID literals.  Fixes a bug where we couldn't figure out whether `char` is signed or unsigned so we punted it to an untagged `struct`, which LLVM does not like at present.