### PR TITLE
Add "pc" to the regex for gcc's target string

### DIFF
--- a/machine/tool/gnu/src/main/java/cc/quarkus/qcc/machine/tool/gnu/GnuToolProvider.java
+++ b/machine/tool/gnu/src/main/java/cc/quarkus/qcc/machine/tool/gnu/GnuToolProvider.java
@@ -38,7 +38,7 @@ public class GnuToolProvider implements ToolProvider {
         }
     }
 
-    static final Pattern TARGET_PATTERN = Pattern.compile("^Target:\\s+(x86_64|arm|i[3-6]86|aarch64|powerpc64)(?:-(redhat|apple|ibm|unknown))?-(linux|darwin)(?:-(gnu|gnueabi))?");
+    static final Pattern TARGET_PATTERN = Pattern.compile("^Target:\\s+(x86_64|arm|i[3-6]86|aarch64|powerpc64)(?:-(redhat|apple|ibm|pc|unknown))?-(linux|darwin)(?:-(gnu|gnueabi))?");
     static final Pattern VERSION_PATTERN = Pattern.compile("^gcc version (\\S+)");
 
     private <T extends Tool> void tryGcc(final Class<T> type, final Platform platform, final ArrayList<T> list, final Path path) {


### PR DESCRIPTION
gcc version may contain string "x86_64-pc-linux-gnu" as the Target value,
which does not match the `TARGET_PATTERN` used by `GnuToolProvider`, and may
result in `TestProbes` to fail.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>