### PR TITLE
Narrow the return type for ireturn

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/MethodParser.java
@@ -1171,7 +1171,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     return;
                 }
                 case OP_IRETURN:
-                    // TODO: narrow the return type if it's narrower than i32
+                    // Narrow the return type in LLVMNodeVisitor if it's narrower than i32
                 case OP_FRETURN:
                 case OP_ARETURN:
                     gf.return_(pop1());

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -165,7 +165,12 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     public Void visit(final Void param, final ValueReturn node) {
         map(node.getBasicDependency(0));
         LLBasicBlock block = map(schedule.getBlockForNode(node));
-        block.ret(map(node.getReturnValue().getType()), map(node.getReturnValue()));
+        ValueType funcType = functionObj.getType().getReturnType();
+        if (funcType.getSize() < 4 /*bytes*/) { // Narrows the return type for boolean, byte, short, or char
+            block.ret(map(funcType), map(node.getReturnValue()));
+        } else {
+            block.ret(map(node.getReturnValue().getType()), map(node.getReturnValue()));
+        }
         return null;
     }
 


### PR DESCRIPTION
This change narrows the return type less than i32 for boolean, byte, short, or char if needed. I changed LLVMNodeVisitor, but the initial intention was to change MethodParser side...?