### PR TITLE
[DRAFT] Correctness plugin: Integer division by zero

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -57,6 +57,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qcc-plugin-correctness</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qcc-plugin-dispatch</artifactId>
         </dependency>
         <dependency>

--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -24,6 +24,7 @@ import cc.quarkus.qcc.machine.tool.CToolChain;
 import cc.quarkus.qcc.plugin.constants.ConstantBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.conversion.CloneConversionBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.conversion.NumericalConversionBasicBlockBuilder;
+import cc.quarkus.qcc.plugin.correctness.ZeroDivisorChecking;
 import cc.quarkus.qcc.plugin.dispatch.DevirtualizingBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.dispatch.VTableBuilder;
 import cc.quarkus.qcc.plugin.dot.DotGenerator;
@@ -227,6 +228,7 @@ public class Main {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, MemberResolvingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, LocalThrowHandlingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, SynchronizedMethodBasicBlockBuilder::createIfNeeded);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, ZeroDivisorChecking::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.OPTIMIZE, SimpleOptBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addPostHook(Phase.ADD, ctxt -> RTAInfo.clear(ctxt));

--- a/plugins/correctness/pom.xml
+++ b/plugins/correctness/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cc.quarkus</groupId>
+        <artifactId>qcc-plugin-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>qcc-plugin-correctness</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qcc-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qcc-driver</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/plugins/correctness/src/main/java/cc/quarkus/qcc/plugin/correctness/ZeroDivisorChecking.java
+++ b/plugins/correctness/src/main/java/cc/quarkus/qcc/plugin/correctness/ZeroDivisorChecking.java
@@ -1,0 +1,50 @@
+package cc.quarkus.qcc.plugin.correctness;
+
+import cc.quarkus.qcc.context.CompilationContext;
+import cc.quarkus.qcc.graph.BasicBlockBuilder;
+import cc.quarkus.qcc.graph.BlockLabel;
+import cc.quarkus.qcc.graph.DelegatingBasicBlockBuilder;
+import cc.quarkus.qcc.graph.Value;
+import cc.quarkus.qcc.graph.literal.IntegerLiteral;
+import cc.quarkus.qcc.graph.literal.LiteralFactory;
+import cc.quarkus.qcc.type.IntegerType;
+import cc.quarkus.qcc.type.ValueType;
+import cc.quarkus.qcc.type.definition.ClassContext;
+import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
+import cc.quarkus.qcc.type.descriptor.MethodDescriptor;
+
+import java.util.List;
+
+/**
+ * This builder checks for zero divisor in integer divisions.
+ */
+public class ZeroDivisorChecking extends DelegatingBasicBlockBuilder {
+    private final CompilationContext ctxt;
+
+    public ZeroDivisorChecking(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+        super(delegate);
+        this.ctxt = ctxt;
+    }
+
+    @Override
+    public Value divide(Value v1, Value v2) {
+        ValueType v1Type = v1.getType();
+        ValueType v2Type = v2.getType();
+        if (v1Type instanceof IntegerType && v2Type instanceof IntegerType) {
+            LiteralFactory lf = ctxt.getLiteralFactory();
+            final IntegerLiteral zero = lf.literalOf(0);
+            final BlockLabel throwIt = new BlockLabel();
+            final BlockLabel goAhead = new BlockLabel();
+
+            if_(cmpEq(v2, zero), throwIt, goAhead);
+            begin(throwIt);
+            ClassContext classContext = getCurrentElement().getEnclosingType().getContext();
+            ValidatedTypeDefinition ae = classContext.findDefinedType("java/lang/ArithmeticException").validate();
+            Value ex = new_(ae.getClassType());
+            ex = invokeConstructor(ex, ae.resolveConstructorElement(MethodDescriptor.VOID_METHOD_DESCRIPTOR), List.of());
+            throw_(ex); // Throw java.lang.ArithmeticException
+            begin(goAhead);
+        }
+        return super.divide(v1, v2);
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>constants</module>
         <module>conversion</module>
+        <module>correctness</module>
         <module>dispatch</module>
         <module>dot</module>
         <module>intrinsics</module>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,12 @@
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>qcc-plugin-correctness</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>qcc-plugin-dispatch</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
An attempt to implement the integer division by zero correctness plugin from https://github.com/quarkuscc/qcc/issues/58

I think this is in the right direction but I can't test it. Comments are welcome.

A simple test:
```java
    @export
    public static int main() {
    	int i = 0;
    	int d = 5/i;
    	putchar(d);
    }
```

results in:
```
Exception in thread "main" java.lang.IllegalStateException: Invoke of unresolved constructor
        at cc.quarkus.qcc.graph.SimpleBasicBlockBuilder.invokeConstructor(SimpleBasicBlockBuilder.java:448)
        at cc.quarkus.qcc.graph.DelegatingBasicBlockBuilder.invokeConstructor(DelegatingBasicBlockBuilder.java:416)
        at cc.quarkus.qcc.graph.DelegatingBasicBlockBuilder.invokeConstructor(DelegatingBasicBlockBuilder.java:416)
        at cc.quarkus.qcc.graph.DelegatingBasicBlockBuilder.invokeConstructor(DelegatingBasicBlockBuilder.java:416)
        at cc.quarkus.qcc.graph.DelegatingBasicBlockBuilder.invokeConstructor(DelegatingBasicBlockBuilder.java:416)
        at cc.quarkus.qcc.type.definition.classfile.MethodParser.processNewBlock(MethodParser.java:1274)
        at cc.quarkus.qcc.type.definition.classfile.ExactMethodHandleImpl.getOrCreateMethodBody(ExactMethodHandleImpl.java:109)
        at cc.quarkus.qcc.driver.Driver.execute(Driver.java:406)
        at cc.quarkus.qcc.main.Main.main(Main.java:267)
```

The PR also depends on:
* #139 
* `new` 