### PR TITLE
Compare upper limit equals and use a max within range

### DIFF
--- a/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
+++ b/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
@@ -176,6 +176,7 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
                     upperLit = lf.literalOf(upper);
                     lowerLit = lf.literalOf(lower);
                 }
+                FloatLiteral max = lf.literalOf(upper);
 
                 // create the necessary Java bounds check
 
@@ -183,7 +184,7 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
                 final BlockLabel notOverMax = new BlockLabel();
                 final BlockLabel underMin = new BlockLabel();
                 final BlockLabel resume = new BlockLabel();
-                if_(cmpGt(from, upperLit), overMax, notOverMax);
+                if_(cmpGe(from, upperLit), overMax, notOverMax);
                 begin(overMax);
                 goto_(resume);
                 begin(notOverMax);
@@ -192,7 +193,7 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
                 goto_(resume);
                 begin(resume);
                 PhiValue result = phi(toType, resume);
-                result.setValueForBlock(ctxt, getCurrentElement(), overMax, super.valueConvert(upperLit, toType));
+                result.setValueForBlock(ctxt, getCurrentElement(), overMax, super.valueConvert(max, toType));
                 result.setValueForBlock(ctxt, getCurrentElement(), underMin, super.valueConvert(lowerLit, toType));
                 result.setValueForBlock(ctxt, getCurrentElement(), notOverMax, super.valueConvert(from, toType));
                 return result;


### PR DESCRIPTION
This is a first attempt attempting to fix the following problem. I don't think it's the right fix, but it's a good starting point for better fixes:

```
int high = Integer.MAX_VALUE - 1;
putchar(high - (int)((float) high) == -1 ? '1' : '0');
```

The code above should print `1` but instead shows `0`. The reason it should print `1` is because in Java, when `Integer.MAX_VALUE - 1` is converted to a `float`, the resulting `float` value is equals to `Integer.MAX_VALUE`. Therefore, when doing `((Integer.MAX_VALUE - 1) - Integer.MAX_VALUE)` you get `-1`.

In QCC, the code above is returning `-2`. The `ll` code looks before the patch looked like this:

```
%L0 = sitofp i32 2147483646 to float
%L1 = fcmp ogt float %L0, 0x41e0000000000000
%L3 = fptosi float %L0 to i32 ; false branch
...
%L6 = fptosi float 0x41e0000000000000 to i32 ; true branch
```

The first problem is the comparison of `%L0`. When `2147483646` is converted to float, it's actually `0x41e0000000000000`, but since the comparison is `gt` then it goes to the false branch. Then, converting `0x41e0000000000000` to i32 gives you `Integer.MAX_VALUE + 1`, hence the substration ends is `-2`.

So, the first thing the patch does is move from `gt` to `ge`. That way you'd go to the true branch. Ideally, I'd would have liked to do this:

```
%L6 = fptosi float 0x41dfffffffc00000 to i32
```

The reason for trying to do this is because `0x41dfffffffc00000` is `2147483647`, the max integer, but `0x41dfffffffc00000` cannot be represented as a `float` so instead I tried to switch that to a `double`... And here is where it gets interesting:

```
                // the highest allowed value (inclusive)
                double upper;
...
                LiteralFactory lf = ctxt.getLiteralFactory();
                FloatLiteral upperLit, lowerLit;
                if (fromType.getMinBits() == 32) {
                    upperLit = lf.literalOf((float) upper);
                    lowerLit = lf.literalOf((float) lower);
                } else {
                    upperLit = lf.literalOf(upper);
                    lowerLit = lf.literalOf(lower);
                }
****
```

`upper` is supposed to be inclusive. But, when doing floats, the `(float) upper` makes `upperLit` actually exclusive, it becomes `Integer.MAX_VALUE + 1` which is `0x41e0000000000000`. So, in the patch I created an actual inclusive literal called `max` that is inclusive, which is done by not casting it.

A potential better fix would be to do this: keep `gt` but compare with `Integer.MAX_VALUE`. I did try to do this but you'd then have issues with the `gt` comparison because `Integer.MAX_VALUE` cannot be represented as a float:

```
lli: output.ll:4:29: error: floating point constant invalid for type
  %L1 = fcmp ogt float %L0, 2.147483647E9
```

I didn't know how to fix it this way because the type `float` comes from the `Value from` and didn't know how to override it. If that could be made a `double` then I think it'd work but not sure if doable somehow. In the fix in this PR, I could just create a new float literal and make it work.