### PR TITLE
Use max long literal for i64 over max comparisons

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/IntegerType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/IntegerType.java
@@ -49,5 +49,9 @@ public abstract class IntegerType extends NumericType {
 
     public abstract long getMinValue();
 
+    public abstract double getUpperInclusiveBound();
+
+    public abstract double getLowerInclusiveBound();
+
     public abstract String toString(final IntegerLiteral literal);
 }

--- a/compiler/src/main/java/cc/quarkus/qcc/type/SignedIntegerType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/SignedIntegerType.java
@@ -53,6 +53,16 @@ public final class SignedIntegerType extends IntegerType {
         return ~getMaxValue();
     }
 
+    @Override
+    public double getUpperInclusiveBound() {
+        return Math.scalb(1.0, minBits - 1) - 1.0;
+    }
+
+    @Override
+    public double getLowerInclusiveBound() {
+        return -Math.scalb(1.0, minBits - 1);
+    }
+
     public ValueType join(final ValueType other) {
         if (other instanceof SignedIntegerType) {
             return join((SignedIntegerType) other);

--- a/compiler/src/main/java/cc/quarkus/qcc/type/UnsignedIntegerType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/UnsignedIntegerType.java
@@ -42,6 +42,16 @@ public final class UnsignedIntegerType extends IntegerType {
         return 0;
     }
 
+    @Override
+    public double getUpperInclusiveBound() {
+        return Math.scalb(1.0, minBits) - 1.0;
+    }
+
+    @Override
+    public double getLowerInclusiveBound() {
+        return 0;
+    }
+
     public ValueType join(final ValueType other) {
         if (other instanceof UnsignedIntegerType) {
             return join((UnsignedIntegerType) other);

--- a/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
+++ b/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
@@ -155,28 +155,13 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
             if (toTypeRaw instanceof IntegerType) {
                 LiteralFactory lf = ctxt.getLiteralFactory();
                 IntegerType toType = (IntegerType) toTypeRaw;
-                // insert a bounds check
-                boolean signed = toType instanceof SignedIntegerType;
-                // number of bits for desired target type
-                int numBits;
                 // the lowest allowed value (inclusive)
-                double lower;
-                // subtracting 1.0 should be safe here since the ulp for these values should always be smaller than 1.0...
-                if (signed) {
-                    numBits = toType.getMinBits() - 1;
-                    lower = -Math.scalb(1.0, numBits);
-                } else {
-                    numBits = toType.getMinBits();
-                    lower = 0;
-                }
-
+                double lower = toType.getLowerInclusiveBound();
                 // the highest allowed value (inclusive)
-                double upper;
+                double upper = toType.getUpperInclusiveBound();
                 // the highest allowed value literal
                 // it cannot be the same as the literal used in cmp cos they're different types
-                Literal upperLit;
-                upper = Math.scalb(1.0, numBits) - 1.0;
-                upperLit = lf.literalOf(toType, toType.getMaxValue());
+                Literal upperLit = lf.literalOf(toType, toType.getMaxValue());
 
                 FloatLiteral upperLitCmp, lowerLit;
                 if (fromType.getMinBits() == 32) {


### PR DESCRIPTION
Anything over the max double should be promoted to max long. However, that value cannot be represented with fp. Hence, for such high value assign it to a literal built from applying identity function to max long. This fixes `long` widening tests.

A cleaner fix might be to use the cheapest identity function around (is `add ... 0` the best?) for all over max literals.