### PR TITLE
Use fsub instead of sub for floating type substractions

### DIFF
--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -357,7 +357,10 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     public LLValue visit(final Void param, final Sub node) {
         LLValue llvmLeft = map(node.getLeftInput());
         LLValue llvmRight = map(node.getRightInput());
-        return map(schedule.getBlockForNode(node)).sub(map(node.getType()), llvmLeft, llvmRight).asLocal();
+        final var target = map(schedule.getBlockForNode(node));
+        return isFloating(node.getLeftInput().getType())
+            ? target.fsub(map(node.getType()), llvmLeft, llvmRight).asLocal()
+            : target.sub(map(node.getType()), llvmLeft, llvmRight).asLocal();
     }
 
     public LLValue visit(final Void param, final Div node) {


### PR DESCRIPTION
Float substractions such as:

```
float low = Float.MIN_VALUE + 1;
putchar(low - low == 0 ? '.' : 'F');
```

fail with:

```
lli: /tmp/qoccido/widening/example/Example/output.ll:21:13: error: invalid operand type for instruction
  %L0 = sub float 0x3ff0000000000000, 0x3ff0000000000000
```