### PR TITLE
Improve method descriptor factories (fixes #178)

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/descriptor/MethodDescriptor.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/descriptor/MethodDescriptor.java
@@ -95,5 +95,9 @@ public final class MethodDescriptor extends Descriptor {
         return Cache.get(classContext).getMethodDescriptor(paramTypes, TypeDescriptor.parse(classContext, buf));
     }
 
+    public static MethodDescriptor synthesize(ClassContext classContext, TypeDescriptor returnType, List<TypeDescriptor> paramTypes) {
+        return cc.quarkus.qcc.type.descriptor.Cache.get(classContext).getMethodDescriptor(paramTypes, returnType);
+    }
+
     public static final MethodDescriptor VOID_METHOD_DESCRIPTOR = new MethodDescriptor(List.of(), BaseTypeDescriptor.V);
 }

--- a/interpreter/src/main/java/cc/quarkus/qcc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/cc/quarkus/qcc/interpreter/impl/VmImpl.java
@@ -1,7 +1,7 @@
 package cc.quarkus.qcc.interpreter.impl;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -20,6 +20,7 @@ import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
 import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 import cc.quarkus.qcc.type.definition.element.MethodElement;
+import cc.quarkus.qcc.type.descriptor.ClassTypeDescriptor;
 import cc.quarkus.qcc.type.descriptor.MethodDescriptor;
 import io.smallrye.common.constraint.Assert;
 
@@ -34,8 +35,8 @@ public final class VmImpl implements Vm {
         loadClass = bcc.findDefinedType("java/lang/ClassLoader")
             .validate()
             .resolveMethodElementExact("loadClass",
-                MethodDescriptor.parse(bcc, ByteBuffer.wrap("(Ljava/lang/String;)Ljava/lang/Class;".getBytes(StandardCharsets.UTF_8)))
-            );
+                MethodDescriptor.synthesize(bcc, ClassTypeDescriptor.synthesize(bcc, "java/lang/String"),
+                                            List.of(ClassTypeDescriptor.synthesize(bcc, "java/lang/Class"))));
     }
 
     public CompilationContext getCompilationContext() {

--- a/plugins/main/src/main/java/cc/quarkus/qcc/plugin/main_method/UserMainIntrinsic.java
+++ b/plugins/main/src/main/java/cc/quarkus/qcc/plugin/main_method/UserMainIntrinsic.java
@@ -1,7 +1,5 @@
 package cc.quarkus.qcc.plugin.main_method;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import cc.quarkus.qcc.context.CompilationContext;
@@ -12,6 +10,8 @@ import cc.quarkus.qcc.plugin.intrinsics.Intrinsics;
 import cc.quarkus.qcc.plugin.intrinsics.StaticIntrinsic;
 import cc.quarkus.qcc.type.definition.ClassContext;
 import cc.quarkus.qcc.type.definition.element.MethodElement;
+import cc.quarkus.qcc.type.descriptor.BaseTypeDescriptor;
+import cc.quarkus.qcc.type.descriptor.ClassTypeDescriptor;
 import cc.quarkus.qcc.type.descriptor.MethodDescriptor;
 import cc.quarkus.qcc.type.descriptor.TypeDescriptor;
 
@@ -32,8 +32,9 @@ public class UserMainIntrinsic implements StaticIntrinsic {
     public static void register(CompilationContext ctxt, MethodElement mainMethod) {
         Intrinsics intrinsics = Intrinsics.get(ctxt);
         ClassContext classContext = ctxt.getBootstrapClassContext();
-        TypeDescriptor runtimeMainDesc = TypeDescriptor.parseClassConstant(classContext, ByteBuffer.wrap("cc/quarkus/qcc/runtime/main/Main".getBytes(StandardCharsets.UTF_8)));
-        MethodDescriptor runtimeMainMethodDesc = MethodDescriptor.parse(classContext, ByteBuffer.wrap(("([L" + "java/lang/String;)V").getBytes(StandardCharsets.UTF_8)));
+        TypeDescriptor runtimeMainDesc = ClassTypeDescriptor.synthesize(classContext, "cc/quarkus/qcc/runtime/main/Main");
+        MethodDescriptor runtimeMainMethodDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V,
+            List.of(ClassTypeDescriptor.synthesize(classContext, "java/lang/String")));
         intrinsics.registerIntrinsic(runtimeMainDesc, "userMain", runtimeMainMethodDesc, new UserMainIntrinsic(mainMethod));
     }
 }


### PR DESCRIPTION
- I assume the intended `synthesize` method is a `MethodDescriptor` method, not `MethodSignature`'s (if anything to respect package visibility)
- If I have understood it correctly the method is really a oneliner
- I think I have replaced all usages of `MethodDescriptor#parse` to `MethodDescriptor#synthesize` 
    - except one usage in `Descriptor#parse` where the buffer is passed from outside; that seems to be only used in `ClassFileImpl#getDescriptorConstant` -- those should be all
- I haven't updated usages of `TypeDescriptor#parse`