### PR TITLE
Lower "throw" by calling _Unwind_RaiseException

### DIFF
--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -40,6 +40,8 @@ import cc.quarkus.qcc.plugin.llvm.LLVMCompileStage;
 import cc.quarkus.qcc.plugin.llvm.LLVMGenerator;
 import cc.quarkus.qcc.plugin.lowering.InvocationLoweringBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.lowering.StaticFieldLoweringBasicBlockBuilder;
+import cc.quarkus.qcc.plugin.lowering.ThrowExceptionHelper;
+import cc.quarkus.qcc.plugin.lowering.ThrowLoweringBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.main_method.AddMainClassHook;
 import cc.quarkus.qcc.plugin.main_method.MainMethod;
 import cc.quarkus.qcc.plugin.native_.ConstTypeResolver;
@@ -237,6 +239,7 @@ public class Main {
 
                                 builder.addPreHook(Phase.ADD, CoreIntrinsics::register);
                                 builder.addPreHook(Phase.ADD, Layout::get);
+                                builder.addPreHook(Phase.ADD, ThrowExceptionHelper::get);
                                 builder.addPreHook(Phase.ADD, new AddMainClassHook());
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, IntrinsicBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, CloneConversionBasicBlockBuilder::new);
@@ -268,6 +271,7 @@ public class Main {
 
                                 builder.addCopyFactory(Phase.LOWER, GotoRemovingVisitor::new);
 
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ThrowLoweringBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, InvocationLoweringBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, StaticFieldLoweringBasicBlockBuilder::new);

--- a/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowExceptionHelper.java
+++ b/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowExceptionHelper.java
@@ -1,0 +1,64 @@
+package cc.quarkus.qcc.plugin.lowering;
+
+import cc.quarkus.qcc.context.AttachmentKey;
+import cc.quarkus.qcc.context.CompilationContext;
+import cc.quarkus.qcc.type.definition.ClassContext;
+import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
+import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
+import cc.quarkus.qcc.type.definition.classfile.ClassFile;
+import cc.quarkus.qcc.type.definition.element.FieldElement;
+import cc.quarkus.qcc.type.definition.element.MethodElement;
+import cc.quarkus.qcc.type.descriptor.ClassTypeDescriptor;
+import cc.quarkus.qcc.type.generic.TypeSignature;
+
+public class ThrowExceptionHelper {
+    private static final AttachmentKey<ThrowExceptionHelper> KEY = new AttachmentKey<>();
+
+    private final CompilationContext ctxt;
+    private final FieldElement unwindExceptionField;
+    private final MethodElement raiseExceptionMethod;
+
+    private ThrowExceptionHelper(final CompilationContext ctxt) {
+        this.ctxt = ctxt;
+
+        /* Inject a field "unwindException" of type Unwind$_Unwind_Exception in j.l.Thread */
+        FieldElement.Builder builder = FieldElement.builder();
+        builder.setName("unwindException");
+        ClassContext classContext = ctxt.getBootstrapClassContext();
+        ClassTypeDescriptor desc = ClassTypeDescriptor.synthesize(classContext, "cc/quarkus/qcc/runtime/unwind/Unwind$struct__Unwind_Exception");
+        builder.setDescriptor(desc);
+        builder.setSignature(TypeSignature.synthesize(classContext, desc));
+        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.I_ACC_HIDDEN);
+        DefinedTypeDefinition jltDefined = classContext.findDefinedType("java/lang/Thread");
+        builder.setEnclosingType(jltDefined);
+        FieldElement field = builder.build();
+        jltDefined.validate().injectField(field);
+        unwindExceptionField = field;
+
+        /* Get the symbol to Unwind#_Unwind_RaiseException */
+        DefinedTypeDefinition unwindDefined = classContext.findDefinedType("cc/quarkus/qcc/runtime/unwind/Unwind");
+        ValidatedTypeDefinition unwindValidated = unwindDefined.validate();
+        int index = unwindValidated.findMethodIndex(e -> e.getName().equals("_Unwind_RaiseException"));
+        raiseExceptionMethod = unwindValidated.getMethod(index);
+    }
+
+    public static ThrowExceptionHelper get(CompilationContext ctxt) {
+        ThrowExceptionHelper helper = ctxt.getAttachment(KEY);
+        if (helper == null) {
+            helper = new ThrowExceptionHelper(ctxt);
+            ThrowExceptionHelper appearing = ctxt.putAttachmentIfAbsent(KEY, helper);
+            if (appearing != null) {
+                helper = appearing;
+            }
+        }
+        return helper;
+    }
+
+    public FieldElement getUnwindExceptionField() {
+        return this.unwindExceptionField;
+    }
+
+    public MethodElement getRaiseExceptionMethod() {
+        return this.raiseExceptionMethod;
+    }
+}

--- a/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
@@ -1,0 +1,23 @@
+package cc.quarkus.qcc.plugin.lowering;
+
+import cc.quarkus.qcc.context.CompilationContext;
+import cc.quarkus.qcc.graph.*;
+import cc.quarkus.qcc.object.Function;
+
+import java.util.List;
+
+public class ThrowLoweringBasicBlockBuilder extends DelegatingBasicBlockBuilder {
+    private final CompilationContext ctxt;
+
+    public ThrowLoweringBasicBlockBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+        super(delegate);
+        this.ctxt = ctxt;
+    }
+
+    public BasicBlock throw_(final Value value) {
+        Value unwindException = readInstanceField(ctxt.getCurrentThreadValue(), ThrowExceptionHelper.get(ctxt).getUnwindExceptionField(), JavaAccessMode.PLAIN);
+        Function function = ctxt.getExactFunction(ThrowExceptionHelper.get(ctxt).getRaiseExceptionMethod());
+        super.callFunction(ctxt.getLiteralFactory().literalOfSymbol(function.getName(), function.getType()), List.of(unwindException));
+        return unreachable();
+    }
+}


### PR DESCRIPTION
Added ThrowLoweringBasicBlockBuilder that lowers "throw" by
adding a call to _Unwind_RaiseException().
A new "hidden" field "unwindException" of type Unwind$_Unwind_Exception
is added to j.l.Thread to store the unwind exception object.
Note that this change does not handle initialization of
Thread.unwindException field.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>