### PR TITLE
Stub implementation of Cohen's display for supertypes

### DIFF
--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -33,6 +33,7 @@ import cc.quarkus.qcc.plugin.intrinsics.core.CoreIntrinsics;
 import cc.quarkus.qcc.plugin.layout.ObjectAccessLoweringBuilder;
 import cc.quarkus.qcc.plugin.instanceofcheckcast.InstanceOfCheckCastBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.instanceofcheckcast.RegisterHelperBasicBlockBuilder;
+import cc.quarkus.qcc.plugin.instanceofcheckcast.SupersDisplayBuilder;
 import cc.quarkus.qcc.plugin.layout.Layout;
 import cc.quarkus.qcc.plugin.linker.LinkStage;
 import cc.quarkus.qcc.plugin.llvm.LLVMCompileStage;
@@ -252,6 +253,7 @@ public class Main {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, InstanceOfCheckCastBasicBlockBuilder::new);
 
                                 builder.addPostHook(Phase.ANALYZE, new VTableBuilder());
+                                builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
                                 builder.addPostHook(Phase.ANALYZE, RTAInfo::clear);
 
                                 builder.addCopyFactory(Phase.LOWER, GotoRemovingVisitor::new);

--- a/plugins/instanceof-checkcast/pom.xml
+++ b/plugins/instanceof-checkcast/pom.xml
@@ -21,6 +21,10 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qcc-driver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qcc-plugin-reachability</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/plugins/instanceof-checkcast/src/main/java/cc/quarkus/qcc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/cc/quarkus/qcc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
@@ -1,0 +1,33 @@
+package cc.quarkus.qcc.plugin.instanceofcheckcast;
+
+import java.util.function.Consumer;
+
+import cc.quarkus.qcc.context.CompilationContext;
+import cc.quarkus.qcc.plugin.reachability.RTAInfo;
+import cc.quarkus.qcc.type.definition.ClassContext;
+import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
+import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
+
+/**
+ * Build Cohen's Display for Super types for all classes present in
+ * the RTAInfo.
+ */
+public class SupersDisplayBuilder implements Consumer<CompilationContext> {
+    
+    @Override
+    public void accept(CompilationContext ctxt) {
+        RTAInfo info = RTAInfo.get(ctxt);
+        SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
+        // Starting from java.lang.Object walk down the live class hierarchy and
+        // compute supers display that contain just the classes where RTAInfo
+        // marks the class as live
+        ClassContext classContext = ctxt.getBootstrapClassContext();
+        DefinedTypeDefinition jloDef = classContext.findDefinedType("java/lang/Object");
+        ValidatedTypeDefinition jlo = jloDef.validate();
+        tables.buildSupersDisplay(jlo);
+        info.visitLiveSubclasses(jlo, cls -> tables.buildSupersDisplay(cls));
+        if (SupersDisplayTables.DEBUG_SUPERSDISPLAY) {
+            tables.statistics();
+        }
+    }
+}

--- a/plugins/instanceof-checkcast/src/main/java/cc/quarkus/qcc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/cc/quarkus/qcc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -1,0 +1,110 @@
+package cc.quarkus.qcc.plugin.instanceofcheckcast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import cc.quarkus.qcc.context.AttachmentKey;
+import cc.quarkus.qcc.context.CompilationContext;
+import cc.quarkus.qcc.plugin.reachability.RTAInfo;
+import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
+
+/**
+ * Build Cohen's display of accessible super types.
+ * This is initially just the array of the supertypes of Class C
+ * including itself.
+ */
+public class SupersDisplayTables {
+    private static final AttachmentKey<SupersDisplayTables> KEY = new AttachmentKey<>();
+    private static final ValidatedTypeDefinition[] INVALID_DISPLAY = new ValidatedTypeDefinition[0];
+    public static final boolean DEBUG_SUPERSDISPLAY = true;
+
+    private final CompilationContext ctxt;
+    private final Map<ValidatedTypeDefinition, ValidatedTypeDefinition[]> supers = new ConcurrentHashMap<>();
+
+    private int maxDisplaySizeElements;
+
+    private SupersDisplayTables(final CompilationContext ctxt) {
+        this.ctxt = ctxt;
+    }
+
+    public static SupersDisplayTables get(CompilationContext ctxt) {
+        SupersDisplayTables dt = ctxt.getAttachment(KEY);
+        if (dt == null) {
+            dt = new SupersDisplayTables(ctxt);
+            SupersDisplayTables appearing = ctxt.putAttachmentIfAbsent(KEY, dt);
+            if (appearing != null) {
+                dt = appearing;
+            }
+        }
+        return dt;
+    }
+
+    public ValidatedTypeDefinition[] getSupersDisplay(ValidatedTypeDefinition cls) {
+        if (cls.getSuperClass() == null) {
+            // java/lang/Object case
+            return supers.computeIfAbsent(cls, theCls -> new ValidatedTypeDefinition[] { theCls });
+        } else if (cls.isInterface()) {
+            // Interfaces only have Object as their superclass
+            // TODO: Should the interface be in the display?  no for the Click paper
+            return supers.computeIfAbsent(cls, theCls -> new ValidatedTypeDefinition[] { theCls });
+        }
+        // Display should have been built before this point so return the built one
+        // or an easy to identify invalid one.
+        return supers.getOrDefault(cls, INVALID_DISPLAY);
+    }
+
+    void buildSupersDisplay(ValidatedTypeDefinition cls) {
+        if (DEBUG_SUPERSDISPLAY) ctxt.debug("Building SupersDisplay for: " + cls.getDescriptor());
+        ValidatedTypeDefinition[] supersArray = getSupersDisplay(cls);
+        if (supersArray == INVALID_DISPLAY) {
+            RTAInfo info = RTAInfo.get(ctxt);
+            ArrayList<ValidatedTypeDefinition> superDisplay = new ArrayList<>();
+            ValidatedTypeDefinition next = cls;
+            do {
+                superDisplay.add(next);
+                if (!info.isLiveClass(next)) {
+                    // TODO - can we optimize here if RTA doesn't see this class as live? Can that happen?
+                    if (DEBUG_SUPERSDISPLAY) ctxt.debug("Found RTA non-live super: " + cls.getDescriptor());
+                }
+                next = next.getSuperClass();
+            } while (next != null);
+            Collections.reverse(superDisplay);
+            // TODO some kind of assert that display size == depth
+            // TODO: ValidatedTypeDefinition needs to have its depth set
+            maxDisplaySizeElements = Math.max(maxDisplaySizeElements, superDisplay.size());
+            supersArray = superDisplay.toArray(INVALID_DISPLAY); // Use this to ensure toArray result has right type
+            supers.put(cls, supersArray); 
+        }
+        if (DEBUG_SUPERSDISPLAY) ctxt.debug("Display size: " + supersArray.length);
+    }
+
+    public void statistics() {
+        HashMap<Integer, Integer> histogram = new HashMap<>();
+        supers.values().stream().forEach(vtd -> {
+            Integer column = Integer.valueOf(vtd.length);
+            Integer count = histogram.getOrDefault(column, 0);
+            count += 1;
+            histogram.put(column, count);
+        });
+        ctxt.debug("Supers display statistics: [size, occurrance]");
+        histogram.entrySet().stream().forEach(es -> {
+            ctxt.debug("\t["+ es.getKey() +", " + es.getValue()+ "]");
+        });
+        int numClasses = supers.size();
+        ctxt.debug("Classes: "+ numClasses);
+        ctxt.debug("Max display size: "+ maxDisplaySizeElements);
+        ctxt.debug("Slots of storage: " + numClasses * maxDisplaySizeElements);
+        int emptySlots = histogram.entrySet().stream().flatMapToInt(es -> {
+            int waste = maxDisplaySizeElements - es.getKey(); // max - needed number
+            waste *= es.getValue(); // * number of classes in bucket
+            return IntStream.of(waste);
+        }).sum();
+        ctxt.debug("Slots of waste: " + emptySlots);
+        
+    }
+}
+


### PR DESCRIPTION
This is the initial stub of Cohen's display for tracking super types.
It only handles the Class supertypes so far and doesn't address
array classes or interfaces (yet).

It calculates some data on the sizes of the displays which will hopefully
come in handy in the future when compiling larger programs.

TODOs:
* interfaces
* array types
* investigate typeids for each class
* add a "depth" to each class
* update to use the new Logging support

Signed-off-by: Dan Heidinga <heidinga@redhat.com>