### PR TITLE
Automatically bind native methods when possible

### DIFF
--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/Native.java
@@ -2,6 +2,9 @@ package cc.quarkus.qcc.plugin.native_;
 
 import static cc.quarkus.qcc.runtime.CNative.*;
 
+import java.util.List;
+import java.util.function.IntFunction;
+
 import cc.quarkus.qcc.runtime.CNative;
 
 final class Native {
@@ -46,5 +49,25 @@ final class Native {
 
     private static String intName(Class<?> clz) {
         return intName(clz.getName());
+    }
+
+    static <T> List<T> copyWithPrefix(List<T> orig, T newVal, IntFunction<T[]> generator) {
+        int size = orig.size();
+        if (size == 0) {
+            return List.of(newVal);
+        } else if (size == 1) {
+            return List.of(newVal, orig.get(0));
+        } else if (size == 2) {
+            return List.of(newVal, orig.get(0), orig.get(1));
+        } else if (size == 3) {
+            return List.of(newVal, orig.get(0), orig.get(1), orig.get(2));
+        } else {
+            T[] array = generator.apply(size + 1);
+            array[0] = newVal;
+            for (int i = 0; i < size; i ++) {
+                array[i + 1] = orig.get(i);
+            }
+            return List.of(array);
+        }
     }
 }

--- a/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/cc/quarkus/qcc/plugin/native_/NativeInfo.java
@@ -44,6 +44,7 @@ final class NativeInfo {
     final ClassTypeDescriptor cObjectDesc;
 
     final Map<TypeDescriptor, Map<String, Map<MethodDescriptor, NativeFunctionInfo>>> nativeFunctions = new ConcurrentHashMap<>();
+    final Map<TypeDescriptor, Map<String, Map<MethodDescriptor, MethodElement>>> nativeBindings = new ConcurrentHashMap<>();
     final Map<DefinedTypeDefinition, AtomicReference<ValueType>> nativeTypes = new ConcurrentHashMap<>();
     final Map<DefinedTypeDefinition, MethodElement> functionalInterfaceMethods = new ConcurrentHashMap<>();
     final Set<InitializerElement> initializers = ConcurrentHashMap.newKeySet();
@@ -257,5 +258,15 @@ final class NativeInfo {
 
     public boolean registerInitializer(final InitializerElement initializerElement) {
         return initializers.add(initializerElement);
+    }
+
+    public void registerNativeBinding(final MethodElement origMethod, final MethodElement nativeMethod) {
+        nativeBindings.computeIfAbsent(origMethod.getEnclosingType().getDescriptor(), NativeInfo::newMap)
+            .computeIfAbsent(origMethod.getName(), NativeInfo::newMap)
+            .put(origMethod.getDescriptor(), nativeMethod);
+    }
+
+    public MethodElement getNativeBinding(final TypeDescriptor owner, final String name, final MethodDescriptor descriptor) {
+        return nativeBindings.getOrDefault(owner, Map.of()).getOrDefault(name, Map.of()).get(descriptor);
     }
 }


### PR DESCRIPTION
Add a mechanism to allow for easier implementation of `native` methods.  When a `native` method is encountered, the native block builder searches for a corresponding `static` method on a class whose name equals the `native` method's enclosing class plus the string `$_native`.  The corresponding `static` method's name and signature must exactly match the `native` method's signature, unless the `native` method is not `static` in which case the `static` method must accept the instance as its first parameter with the `native` method's parameters following.

The block builder presently just substitutes the call to the native method with a call to the bound method, so there is no extra overhead introduced.  The call is always an exact call, so virtual native methods may not work as expected.