### PR TITLE
Rename `ClassName/output.ll` to `ClassName.ll` #192

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/context/CompilationContext.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/context/CompilationContext.java
@@ -50,6 +50,8 @@ public interface CompilationContext extends DiagnosticContext {
 
     Path getOutputDirectory();
 
+    Path getOutputFile(DefinedTypeDefinition type, String suffix);
+
     Path getOutputDirectory(DefinedTypeDefinition type);
 
     Path getOutputDirectory(MemberElement element);

--- a/compiler/src/test/java/cc/quarkus/qcc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/cc/quarkus/qcc/type/generic/TestClassContext.java
@@ -77,6 +77,10 @@ public class TestClassContext implements ClassContext {
             return null;
         }
 
+        public Path getOutputFile(final DefinedTypeDefinition type, final String suffix) {
+            return null;
+        }
+
         public Path getOutputDirectory(final DefinedTypeDefinition type) {
             return null;
         }

--- a/driver/src/main/java/cc/quarkus/qcc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/CompilationContextImpl.java
@@ -191,6 +191,12 @@ final class CompilationContextImpl implements CompilationContext {
         return outputDir;
     }
 
+    public Path getOutputFile(final DefinedTypeDefinition type, final String suffix) {
+        Path basePath = getOutputDirectory(type);
+        String fileName = basePath.getFileName().toString() + '.' + suffix;
+        return basePath.resolveSibling(fileName);
+    }
+
     public Path getOutputDirectory(final DefinedTypeDefinition type) {
         Path base = outputDir;
         String internalName = type.getInternalName();

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMGenerator.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMGenerator.java
@@ -78,7 +78,7 @@ public class LLVMGenerator implements Consumer<CompilationContext>, ValueVisitor
     public void accept(final CompilationContext ctxt) {
         for (ProgramModule programModule : ctxt.getAllProgramModules()) {
             DefinedTypeDefinition def = programModule.getTypeDefinition();
-            Path path = ctxt.getOutputDirectory(def);
+            Path outputFile = ctxt.getOutputFile(def, "ll");
             final Module module = Module.newModule();
 
             final LLValue diVersionTuple = module.metadataTuple()
@@ -156,7 +156,6 @@ public class LLVMGenerator implements Consumer<CompilationContext>, ValueVisitor
                     }
                 }
             }
-            Path outputFile = path.resolve("output.ll");
             try {
                 Files.createDirectories(outputFile.getParent());
                 try (BufferedWriter writer = Files.newBufferedWriter(outputFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {


### PR DESCRIPTION
fixes #192 

- adds a `Path getOutputFile(DefinedTypeDefinition type, String suffix)` to `CompilationContext`
- delegates to `getOutputDirectory(final DefinedTypeDefinition type)`, appending `'.' + suffix`

metadata (e.g. GraphViz diagrams) is still being written to directories

e.g:

```
> find /tmp/output
/tmp/output
/tmp/output/a.out
/tmp/output/hello
/tmp/output/hello/world
/tmp/output/hello/world/Main.o
/tmp/output/hello/world/Main.s
/tmp/output/hello/world/Main
/tmp/output/hello/world/Main/methods
/tmp/output/hello/world/Main/methods/main.id3
/tmp/output/hello/world/Main/methods/main.id3/gen.dot
/tmp/output/hello/world/Main/methods/main.id2
/tmp/output/hello/world/Main/methods/main.id2/gen.dot
/tmp/output/hello/world/Main.ll
```