### PR TITLE
Convert NPE to compilation error when not able to find Unwind class

### DIFF
--- a/examples/helloworld/hello/world/Main.java
+++ b/examples/helloworld/hello/world/Main.java
@@ -7,7 +7,7 @@
 // $ jar cvf main.jar hello/world/Main.class
 //
 // Build the native executable in /tmp/output with:
-// $ jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT --boot-module-path ~/.m2/repository/cc/quarkus/qccrt-java.base/11.0.1-SNAPSHOT/qccrt-java.base-11.0.1-SNAPSHOT.jar:main.jar --output-path /tmp/output hello.world.Main
+// $ jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT --boot-module-path $HOME/.m2/repository/cc/quarkus/qccrt-java.base/11.0.1-SNAPSHOT/qccrt-java.base-11.0.1-SNAPSHOT.jar:$HOME/.m2/repository/cc/quarkus/qcc-runtime-api/1.0.0-SNAPSHOT/qcc-runtime-api-1.0.0-SNAPSHOT.jar:$HOME/.m2/repository/cc/quarkus/qcc-runtime-unwind/1.0.0-SNAPSHOT/qcc-runtime-unwind-1.0.0-SNAPSHOT.jar:main.jar --output-path /tmp/output hello.world.Main
 //
 // Run the executable
 // $ /tmp/output/a.out

--- a/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowExceptionHelper.java
+++ b/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowExceptionHelper.java
@@ -36,10 +36,16 @@ public class ThrowExceptionHelper {
         unwindExceptionField = field;
 
         /* Get the symbol to Unwind#_Unwind_RaiseException */
-        DefinedTypeDefinition unwindDefined = classContext.findDefinedType("cc/quarkus/qcc/runtime/unwind/Unwind");
-        ValidatedTypeDefinition unwindValidated = unwindDefined.validate();
-        int index = unwindValidated.findMethodIndex(e -> e.getName().equals("_Unwind_RaiseException"));
-        raiseExceptionMethod = unwindValidated.getMethod(index);
+        String unwindClass = "cc/quarkus/qcc/runtime/unwind/Unwind";
+        DefinedTypeDefinition unwindDefined = classContext.findDefinedType(unwindClass);
+        if (unwindDefined != null) {
+            ValidatedTypeDefinition unwindValidated = unwindDefined.validate();
+            int index = unwindValidated.findMethodIndex(e -> e.getName().equals("_Unwind_RaiseException"));
+            raiseExceptionMethod = unwindValidated.getMethod(index);
+        } else {
+            raiseExceptionMethod = null;
+            ctxt.error("Required class \"%s\" is not found on boot classpath", unwindClass);
+        }
     }
 
     public static ThrowExceptionHelper get(CompilationContext ctxt) {


### PR DESCRIPTION
If the jar file hosting Unwind class is not specified on boot classpath,
then the compilation should fail with a proper exception message.
Also updated the example to include required jar files on the boot
classpath.

Fixes: #209 

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>