### PR TITLE
Early access to VMHelpers class

### DIFF
--- a/runtime/main/src/main/java/cc/quarkus/qcc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/cc/quarkus/qcc/runtime/main/VMHelpers.java
@@ -1,0 +1,22 @@
+package cc.quarkus.qcc.runtime.main;
+
+/**
+ * Runtime Helpers to support the operation of the compiled code.
+ */
+public final class VMHelpers {
+
+	// TODO: mark this with a "AlwaysInline" annotation
+	public static final int fast_instanceof(Object instance, Class<?> castClass) {
+		if (instance == null) return 0;	// null isn't an instance of anything
+		Class<?> instanceClass = instance.getClass();
+		if (instanceClass == castClass) {
+			return 1;
+		}
+		return full_instanceof(instance, castClass);
+	}
+
+	// TODO: mark this with a "NoInline" annotation
+	public static final int full_instanceof(Object instance, Class<?> castClass) {
+		return 0; // TODO: full instance of support
+	}
+}


### PR DESCRIPTION
This class is intended to be a home for methods that are required
by the Runtime to support the compiled code.

Currently it has the `fast` & `full` versions of instanceof but they
aren't yet functional and the signatures may change further in the
future.

Pushing now so other methods (ie: monitor support) can be homed here
as well if necessary.

Using this class requires having
`$HOME/.m2/repository/cc/quarkus/qcc-runtime-main/1.0.0-SNAPSHOT/qcc-runtime-main-1.0.0-SNAPSHOT.jar`
on the --boot-modules path as well

Signed-off-by: Dan Heidinga <heidinga@redhat.com>