### PR TITLE
Add interface Unschedulable to identify nodes that cannot be scheduled

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ParameterValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ParameterValue.java
@@ -8,7 +8,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public final class ParameterValue extends AbstractValue {
+public final class ParameterValue extends AbstractValue implements Unschedulable {
     private final ValueType type;
     private final int index;
 

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ThisValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ThisValue.java
@@ -9,7 +9,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public final class ThisValue extends AbstractValue {
+public final class ThisValue extends AbstractValue implements Unschedulable {
     private final ReferenceType type;
 
     ThisValue(final Node callSite, final ExecutableElement element, final ReferenceType type) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Unschedulable.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Unschedulable.java
@@ -1,0 +1,7 @@
+package cc.quarkus.qcc.graph;
+
+/**
+ * Represents a Value that cannot be scheduled.
+ */
+public interface Unschedulable extends Value {
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/literal/Literal.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/literal/Literal.java
@@ -1,5 +1,6 @@
 package cc.quarkus.qcc.graph.literal;
 
+import cc.quarkus.qcc.graph.Unschedulable;
 import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.Value;
 import cc.quarkus.qcc.type.definition.element.ExecutableElement;
@@ -7,7 +8,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  * A literal is a value that was directly specified in a program.
  */
-public abstract class Literal implements Value {
+public abstract class Literal implements Unschedulable {
     Literal() {}
 
     public Node getCallSite() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/schedule/Schedule.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/schedule/Schedule.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import cc.quarkus.qcc.graph.BasicBlock;
+import cc.quarkus.qcc.graph.Unschedulable;
 import cc.quarkus.qcc.graph.literal.Literal;
 import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.PhiValue;
@@ -45,6 +46,7 @@ public interface Schedule {
             // trivial schedule
             return new Schedule() {
                 public BasicBlock getBlockForNode(final Node node) {
+                    Assert.assertFalse(node instanceof Unschedulable);
                     return entryBlock;
                 }
             };
@@ -70,6 +72,7 @@ public interface Schedule {
         }
         return new Schedule() {
             public BasicBlock getBlockForNode(final Node node) {
+                Assert.assertFalse(node instanceof Unschedulable);
                 return finalMapping.get(Assert.checkNotNullParam("node", node));
             }
         };
@@ -118,7 +121,7 @@ public interface Schedule {
         if (node instanceof PinnedNode) {
             // pinned to a block; always select that block.
             return scheduleToPinnedBlock(root, blockInfos, scheduledNodes, node, ((PinnedNode) node).getPinnedBlock());
-        } else if (node instanceof Literal) {
+        } else if (node instanceof Unschedulable) {
             // always considered available; do not schedule
             return root;
         } else {

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -55,6 +55,7 @@ import cc.quarkus.qcc.graph.TriableVisitor;
 import cc.quarkus.qcc.graph.Truncate;
 import cc.quarkus.qcc.graph.Try;
 import cc.quarkus.qcc.graph.Unreachable;
+import cc.quarkus.qcc.graph.Unschedulable;
 import cc.quarkus.qcc.graph.Value;
 import cc.quarkus.qcc.graph.ValueReturn;
 import cc.quarkus.qcc.graph.Xor;
@@ -621,6 +622,9 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     }
 
     private LLValue map(Value value) {
+        if (value instanceof Unschedulable) {
+            return value.accept(this, null);
+        }
         LLValue mapped = mappedValues.get(value);
         if (mapped != null) {
             return mapped;


### PR DESCRIPTION
Literal, ThisValue and ParameterVaue nodes should not be scheduled.
These nodes now extend interface Unschedulable so that LLVMNodeVisitor
can avoid scheduling them.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>