### PR TITLE
Fix NPE in LLVM codegen when getting parameter values

### DIFF
--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -622,12 +622,13 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     }
 
     private LLValue map(Value value) {
-        if (value instanceof Unschedulable) {
-            return value.accept(this, null);
-        }
         LLValue mapped = mappedValues.get(value);
         if (mapped != null) {
             return mapped;
+        }
+
+        if (value instanceof Unschedulable) {
+            return value.accept(this, null);
         }
 
         LLValue oldBuilderDebugLocation = builder.setDebugLocation(dbg(value));


### PR DESCRIPTION
In a previous fix for a NPE caused by some special types of Nodes being
considered unschedulable since they don't emit LLVM instructions, an
error was introduced that caused NPEs when getting parameter values.
These parameter values are populated directly in mappedValues, but the
check against mappedValues was being done after checking against
unschedulable node types. This would cause these nodes to go through the
visitor, resulting in an error due to them being unhandled.