### PR TITLE
Add `--debug-supers` option and convert to Logging

### DIFF
--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -101,6 +101,8 @@ public class Main {
                     Logger.getLogger("cc.quarkus.qcc.plugin.dispatch.vtables").setLevel(Level.DEBUG);
                 } else if (arg.equals("--debug-rta")) {
                     Logger.getLogger("cc.quarkus.qcc.plugin.reachability.rta").setLevel(Level.DEBUG);
+                } else if (arg.equals("--debug-supers")) {
+                    Logger.getLogger("cc.quarkus.qcc.plugin.instanceofcheckcast.supers").setLevel(Level.DEBUG);
                 } else {
                     initialContext.error("Unrecognized argument \"%s\"", arg);
                     break;

--- a/main/src/main/resources/logging.properties
+++ b/main/src/main/resources/logging.properties
@@ -2,6 +2,7 @@
 
 loggers=\
   cc.quarkus.qcc.plugin.dispatch.vtables,\
+  cc.quarkus.qcc.plugin.instanceofcheckcast.supers,\
   cc.quarkus.qcc.plugin.reachability.rta
 
 # Root logger configuration
@@ -9,7 +10,9 @@ logger.level=INFO
 logger.handlers=CONSOLE
 
 logger.cc.quarkus.qcc.plugin.dispatch.vtables.level=INFO
+logger.cc.quarkus.qcc.plugin.instanceofcheckcast.supers.level=INFO
 logger.cc.quarkus.qcc.plugin.reachability.rta.level=INFO
+
 
 # A handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/plugins/instanceof-checkcast/src/main/java/cc/quarkus/qcc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/cc/quarkus/qcc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
@@ -26,8 +26,6 @@ public class SupersDisplayBuilder implements Consumer<CompilationContext> {
         ValidatedTypeDefinition jlo = jloDef.validate();
         tables.buildSupersDisplay(jlo);
         info.visitLiveSubclasses(jlo, cls -> tables.buildSupersDisplay(cls));
-        if (SupersDisplayTables.DEBUG_SUPERSDISPLAY) {
-            tables.statistics();
-        }
+        tables.statistics();
     }
 }


### PR DESCRIPTION
Replace ctxt.debug calls with Log.debug calls in the
SupersDisplayTables code.

Stats on the supers[] are only printed with the new
option is added

Signed-off-by: Dan Heidinga <heidinga@redhat.com>