### PR TITLE
Auto-promote results of bytecodes which produce sub-integer values

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassFileImpl.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassFileImpl.java
@@ -1159,7 +1159,7 @@ final class ClassFileImpl extends AbstractBufferBacked implements ClassFile, Enc
                 ValueType type = elementParameters.get(i).getType(List.of());
                 parameters[i] = gf.parameter(type, i);
                 boolean class2 = elementParameters.get(i).hasClass2Type();
-                methodParser.setLocal(j, class2 ? methodParser.fatten(parameters[i]) : parameters[i]);
+                methodParser.setLocal(j, class2 ? methodParser.fatten(parameters[i]) : methodParser.promote(parameters[i]));
                 j += class2 ? 2 : 1;
             }
         } else {


### PR DESCRIPTION
This is preliminary to substantially more extensive type checking fixes, unfortunately.