### PR TITLE
Fix minor bugs in exception handling code

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/SimpleBasicBlockBuilder.java
@@ -126,7 +126,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
             return null;
         } else {
             ExceptionHandler handler = policy.computeCurrentExceptionHandler(this);
-            return handler == this ? null : this;
+            return handler == this ? null : handler;
         }
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/MethodParser.java
@@ -67,6 +67,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
     private final LiteralFactory lf;
     private final TypeSystem ts;
     private final DefinedTypeDefinition throwable;
+    private int currentbci;
     /**
      * Exception handlers by index, then by delegate.
      */
@@ -81,6 +82,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
         stack = new Value[info.getMaxStack()];
         locals = new Value[info.getMaxLocals()];
         this.buffer = buffer;
+        currentbci = buffer.position();
         int cnt = info.getEntryPointCount();
         BlockLabel[] blockHandles = new BlockLabel[cnt];
         // make a "canonical" node handle for each block
@@ -103,10 +105,9 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
     public BasicBlockBuilder.ExceptionHandler computeCurrentExceptionHandler(BasicBlockBuilder.ExceptionHandler delegate) {
         int etl = info.getExTableLen();
         if (etl > 0) {
-            int pos = buffer.position();
             ExceptionHandlerImpl handler;
             for (int i = etl - 1; i >= 0; i --) {
-                if (info.getExTableEntryStartPc(i) <= pos && pos < info.getExTableEntryEndPc(i)) {
+                if (info.getExTableEntryStartPc(i) <= currentbci && currentbci < info.getExTableEntryEndPc(i)) {
                     // in range...
                     Map<BasicBlockBuilder.ExceptionHandler, ExceptionHandlerImpl> handlerMap = exceptionHandlers.get(i);
                     if (handlerMap == null) {
@@ -476,7 +477,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
         boolean wide;
         ClassMethodInfo info = this.info;
         while (buffer.hasRemaining()) {
-            src = buffer.position();
+            currentbci = src = buffer.position();
             gf.setBytecodeIndex(src);
             gf.setLineNumber(info.getLineNumber(src));
             opcode = buffer.get() & 0xff;


### PR DESCRIPTION
This patch fixes couple of bugs:
1. `MethodParser#computeCurrentExceptionHandler()` incorrectly uses the next
bytecode index to check for an entry in the exception table.
2. `SimpleBasicBlockBuilder#getExceptionHandler()` incorrectly returns the
last `ExceptionHandler` in the chain (the one which throws the exception
if the exception thrown does match the exception handler is catching).

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>