### PR TITLE
fix bugs in RTA / lowering interaction

### DIFF
--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -268,7 +268,6 @@ public class Main {
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addPostHook(Phase.ANALYZE, new VTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
-                                builder.addPostHook(Phase.ANALYZE, RTAInfo::clear);
 
                                 builder.addCopyFactory(Phase.LOWER, GotoRemovingVisitor::new);
 
@@ -282,7 +281,6 @@ public class Main {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LLVMCompatibleBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, LowerVerificationBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
-                                builder.addPostHook(Phase.LOWER, RTAInfo::clear);
 
                                 builder.addPreHook(Phase.GENERATE, new LLVMGenerator());
 

--- a/plugins/dispatch/src/main/java/cc/quarkus/qcc/plugin/dispatch/DispatchTables.java
+++ b/plugins/dispatch/src/main/java/cc/quarkus/qcc/plugin/dispatch/DispatchTables.java
@@ -60,11 +60,13 @@ public class DispatchTables {
                 for (int j=0; j<inherited.length; j++) {
                     if (m.getName().equals(inherited[j].getName()) && m.getDescriptor().equals(inherited[j].getDescriptor())) {
                         vtLog.debugf("\tfound override for %s%s", m.getName(), m.getDescriptor().toString());
+                        ctxt.registerEntryPoint(m);
                         vtableVector.set(j, m);
                         continue  outer;
                     }
                 }
                 vtLog.debugf("\tadded new method  %s%s", m.getName(), m.getDescriptor().toString());
+                ctxt.registerEntryPoint(m);
                 vtableVector.add(m);
             }
         }


### PR DESCRIPTION
RTA can only correctly do the reachability analysis for
virtual methods _before_ we lower the high level Nodes
that represent new and invokevirtual bytecodes to primitive
operations. Therefore:
  1. Don't clear the live class information after the last run of
     RTA with these nodes intact.
  2. Register all methods in vtables as entrypoints (failure
     to do this results in them not being visited in latter
     compilation stages, since we can't do RTA anymore).