### PR TITLE
Join float types

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/FloatType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/FloatType.java
@@ -39,6 +39,23 @@ public final class FloatType extends NumericType {
         return this;
     }
 
+    public ValueType join(ValueType other) {
+        if (other instanceof FloatType) {
+            return join((FloatType) other);
+        } else {
+            return super.join(other);
+        }
+    }
+
+    private FloatType join(FloatType other) {
+        boolean const_ = isConst() || other.isConst();
+        if (bits < other.bits) {
+            return const_ ? other.asConst() : other;
+        } else {
+            return const_ ? asConst() : this;
+        }
+    }
+
     public StringBuilder toString(final StringBuilder b) {
         return super.toString(b).append("float").append(bits);
     }


### PR DESCRIPTION
Related to the promotion work for #58, the following code:

```
int i = 2;
byte b = 0x1f;
float ff = b == 0 ? i : 4.0f;
putchar(0.25 == 1.0 / ff ? '.' : 'F');
```

throws:

```
Errors.java:10: error: Invalid extension of poison to float64
```

This is due to `FloatType` not having overriden `join` method.