### PR TITLE
Allow BooleanType to be extended to both signed/unsigned types

### DIFF
--- a/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
+++ b/plugins/conversion/src/main/java/cc/quarkus/qcc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
@@ -9,6 +9,7 @@ import cc.quarkus.qcc.graph.Value;
 import cc.quarkus.qcc.graph.literal.FloatLiteral;
 import cc.quarkus.qcc.graph.literal.Literal;
 import cc.quarkus.qcc.graph.literal.LiteralFactory;
+import cc.quarkus.qcc.type.BooleanType;
 import cc.quarkus.qcc.type.FloatType;
 import cc.quarkus.qcc.type.IntegerType;
 import cc.quarkus.qcc.type.PointerType;
@@ -100,7 +101,7 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
                     return super.extend(from, toType);
                 }
                 // otherwise not OK (fall out)
-            } else if (fromType instanceof UnsignedIntegerType) {
+            } else if ((fromType instanceof UnsignedIntegerType) || (fromType instanceof BooleanType)) {
                 if (toType instanceof UnsignedIntegerType) {
                     if (fromType.getMinBits() < toType.getMinBits()) {
                         // OK


### PR DESCRIPTION
Seeing a lot of errors like:
```
Throwable.java:115: error: Invalid extension of bool to s32
  location: type Throwable
Class.java:3485: error: Invalid extension of bool to s32
    member: method desiredAssertionStatus@ bci 50
  location: type Class
Class.java:3482: error: Invalid extension of bool to s32
    member: method desiredAssertionStatus@ bci 33
  location: type Class
```

due to missing conversions from BooleanType -> other types.

Added BooleanType to the UnsignedIntegerType case as boolean should only
ever be 1 | 0.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>