### PR TITLE
New "program-ordered" dependency type

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ArrayElementRead.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ArrayElementRead.java
@@ -8,7 +8,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  * A read of an array element.
  */
-public final class ArrayElementRead extends AbstractValue implements ArrayElementOperation {
+public final class ArrayElementRead extends AbstractValue implements ArrayElementOperation, OrderedNode {
     private final Node dependency;
     private final ValueType type;
     private final Value instance;
@@ -46,6 +46,11 @@ public final class ArrayElementRead extends AbstractValue implements ArrayElemen
 
     public Value getValueDependency(final int index) throws IndexOutOfBoundsException {
         return index == 0 ? instance : index == 1 ? this.index : Util.throwIndexOutOfBounds(index);
+    }
+
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ArrayElementWrite.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ArrayElementWrite.java
@@ -7,7 +7,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public final class ArrayElementWrite extends AbstractNode implements ArrayElementOperation, WriteOperation, Action {
+public final class ArrayElementWrite extends AbstractNode implements ArrayElementOperation, WriteOperation, Action, OrderedNode {
     private final Node dependency;
     private final Value instance;
     private final Value index;
@@ -39,20 +39,17 @@ public final class ArrayElementWrite extends AbstractNode implements ArrayElemen
         return mode;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {
-        return 2;
+        return 3;
     }
 
     public Value getValueDependency(int index) throws IndexOutOfBoundsException {
-        return index == 0 ? getInstance() : index == 1 ? getWriteValue() : Util.throwIndexOutOfBounds(index);
+        return index == 0 ? getInstance() : index == 1 ? getIndex() : index == 2 ? getWriteValue() : Util.throwIndexOutOfBounds(index);
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ClassCastErrorNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ClassCastErrorNode.java
@@ -33,12 +33,9 @@ public final class ClassCastErrorNode extends AbstractNode implements Error {
         return toType;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ClassNotFoundErrorNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ClassNotFoundErrorNode.java
@@ -23,12 +23,9 @@ public final class ClassNotFoundErrorNode extends AbstractNode implements Error 
         return terminatedBlock;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public String getName() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Clone.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Clone.java
@@ -6,7 +6,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public class Clone extends AbstractValue implements UnaryValue {
+public class Clone extends AbstractValue implements UnaryValue, OrderedNode {
     private final Node dependency;
     private final Value original;
 
@@ -44,12 +44,9 @@ public class Clone extends AbstractValue implements UnaryValue {
         return index == 0 ? original : Util.throwIndexOutOfBounds(index);
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ConstructorInvocation.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ConstructorInvocation.java
@@ -10,7 +10,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  * An invocation on an object instance which returns a value.
  */
-public final class ConstructorInvocation extends AbstractValue implements InstanceOperation, Invocation, Triable {
+public final class ConstructorInvocation extends AbstractValue implements InstanceOperation, Invocation, Triable, OrderedNode {
     private final Node dependency;
     private final Value instance;
     private final ConstructorElement target;
@@ -48,12 +48,9 @@ public final class ConstructorInvocation extends AbstractValue implements Instan
         return instance;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/DynamicInvocation.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/DynamicInvocation.java
@@ -9,7 +9,7 @@ import cc.quarkus.qcc.type.definition.element.MethodElement;
 /**
  *
  */
-public final class DynamicInvocation extends AbstractNode implements /* MethodInvocation, TODO: am I a MethodInvocation? */ Triable, Action {
+public final class DynamicInvocation extends AbstractNode implements /* MethodInvocation, TODO: am I a MethodInvocation? */ Triable, Action, OrderedNode {
     private final Node dependency;
     private final MethodElement bootstrapMethod;
     private final List<Value> staticArguments;
@@ -48,12 +48,9 @@ public final class DynamicInvocation extends AbstractNode implements /* MethodIn
         return arguments;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/DynamicInvocationValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/DynamicInvocationValue.java
@@ -10,7 +10,7 @@ import cc.quarkus.qcc.type.definition.element.MethodElement;
 /**
  * An invoke dynamic invocation which returns a value.
  */
-public final class DynamicInvocationValue extends AbstractValue implements /* MethodInvocation, TODO: am I a MethodInvocation? */ Triable {
+public final class DynamicInvocationValue extends AbstractValue implements /* MethodInvocation, TODO: am I a MethodInvocation? */ Triable, OrderedNode {
     private final Node dependency;
     private final MethodElement bootstrapMethod;
     private final List<Value> staticArguments;
@@ -54,12 +54,9 @@ public final class DynamicInvocationValue extends AbstractValue implements /* Me
         return arguments;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Fence.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Fence.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 
-public class Fence extends AbstractNode implements Action {
+public class Fence extends AbstractNode implements Action, OrderedNode {
     private final Node dependency;
     private final MemoryAtomicityMode atomicityMode;
 
@@ -14,20 +14,17 @@ public class Fence extends AbstractNode implements Action {
         this.atomicityMode = atomicityMode;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
-    }
-
     public MemoryAtomicityMode getAtomicityMode() {
         return atomicityMode;
     }
 
     int calcHashCode() {
         return Objects.hash(Fence.class, dependency, atomicityMode);
+    }
+
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public boolean equals(Object other) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/FunctionCall.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/FunctionCall.java
@@ -10,7 +10,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public final class FunctionCall extends AbstractValue implements Triable {
+public final class FunctionCall extends AbstractValue implements Triable, OrderedNode {
     // todo: fixed flags (such as "nothrow", "noreturn")
     // todo: native calling convention (fastcc, ccc, etc)
     private final Node dependency;
@@ -48,12 +48,9 @@ public final class FunctionCall extends AbstractValue implements Triable {
         return callTarget;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Goto.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Goto.java
@@ -27,12 +27,9 @@ public final class Goto extends AbstractNode implements Resume {
         return targetLabel;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getSuccessorCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/If.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/If.java
@@ -47,12 +47,9 @@ public final class If extends AbstractNode implements Terminator {
         return BlockLabel.getTargetOf(falseBranchLabel);
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceFieldRead.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceFieldRead.java
@@ -9,7 +9,7 @@ import cc.quarkus.qcc.type.definition.element.FieldElement;
 /**
  * A read of an instance field.
  */
-public final class InstanceFieldRead extends AbstractValue implements FieldRead, InstanceOperation {
+public final class InstanceFieldRead extends AbstractValue implements FieldRead, InstanceOperation, OrderedNode {
     private final Node dependency;
     private final Value instance;
     private final FieldElement fieldElement;
@@ -41,12 +41,9 @@ public final class InstanceFieldRead extends AbstractValue implements FieldRead,
         return instance;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceFieldWrite.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceFieldWrite.java
@@ -8,7 +8,7 @@ import cc.quarkus.qcc.type.definition.element.FieldElement;
 /**
  * A write of an instance field.
  */
-public final class InstanceFieldWrite extends AbstractNode implements FieldWrite, InstanceOperation, Action {
+public final class InstanceFieldWrite extends AbstractNode implements FieldWrite, InstanceOperation, Action, OrderedNode {
     private final Node dependency;
     private final Value instance;
     private final FieldElement fieldElement;
@@ -40,12 +40,9 @@ public final class InstanceFieldWrite extends AbstractNode implements FieldWrite
         return mode;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceInvocation.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceInvocation.java
@@ -9,7 +9,7 @@ import cc.quarkus.qcc.type.definition.element.MethodElement;
 /**
  * An invocation on an object instance.
  */
-public final class InstanceInvocation extends AbstractNode implements InstanceOperation, MethodInvocation, DispatchInvocation, Triable, Action {
+public final class InstanceInvocation extends AbstractNode implements InstanceOperation, MethodInvocation, DispatchInvocation, Triable, Action, OrderedNode {
     private final Node dependency;
     private final DispatchInvocation.Kind kind;
     private final Value instance;
@@ -49,12 +49,9 @@ public final class InstanceInvocation extends AbstractNode implements InstanceOp
         return instance;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceInvocationValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/InstanceInvocationValue.java
@@ -10,7 +10,7 @@ import cc.quarkus.qcc.type.definition.element.MethodElement;
 /**
  * An invocation on an object instance which returns a value.
  */
-public final class InstanceInvocationValue extends AbstractValue implements InstanceOperation, MethodInvocation, DispatchInvocation, Triable {
+public final class InstanceInvocationValue extends AbstractValue implements InstanceOperation, MethodInvocation, DispatchInvocation, Triable, OrderedNode {
     private final Node dependency;
     private final DispatchInvocation.Kind kind;
     private final Value instance;
@@ -56,12 +56,9 @@ public final class InstanceInvocationValue extends AbstractValue implements Inst
         return instance;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Jsr.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Jsr.java
@@ -42,12 +42,9 @@ public final class Jsr extends AbstractNode implements Resume, Terminator {
         return returnAddress;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getSuccessorCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/MonitorEnter.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/MonitorEnter.java
@@ -7,7 +7,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public class MonitorEnter extends AbstractNode implements Action, InstanceOperation {
+public class MonitorEnter extends AbstractNode implements Action, InstanceOperation, OrderedNode {
     private final Node dependency;
     private final Value instance;
 
@@ -21,12 +21,9 @@ public class MonitorEnter extends AbstractNode implements Action, InstanceOperat
         return instance;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/MonitorExit.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/MonitorExit.java
@@ -7,7 +7,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public class MonitorExit extends AbstractNode implements Action, InstanceOperation {
+public class MonitorExit extends AbstractNode implements Action, InstanceOperation, OrderedNode {
     private final Node dependency;
     private final Value instance;
 
@@ -21,12 +21,9 @@ public class MonitorExit extends AbstractNode implements Action, InstanceOperati
         return instance;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/MultiNewArray.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/MultiNewArray.java
@@ -11,7 +11,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  * A {@code new} allocation operation for multi-dimensional array objects.
  */
-public final class MultiNewArray extends AbstractValue {
+public final class MultiNewArray extends AbstractValue implements OrderedNode {
     private final Node dependency;
     private final ArrayObjectType type;
     private final List<Value> dimensions;
@@ -39,12 +39,9 @@ public final class MultiNewArray extends AbstractValue {
         return type;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/NewArray.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/NewArray.java
@@ -10,7 +10,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  * A {@code new} allocation operation for array objects.
  */
-public final class NewArray extends AbstractValue {
+public final class NewArray extends AbstractValue implements OrderedNode {
     private final Node dependency;
     private final ArrayObjectType type;
     private final Value size;
@@ -38,12 +38,9 @@ public final class NewArray extends AbstractValue {
         return type;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/NoSuchMethodErrorNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/NoSuchMethodErrorNode.java
@@ -29,12 +29,9 @@ public final class NoSuchMethodErrorNode extends AbstractNode implements Error {
         return terminatedBlock;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public ObjectType getOwner() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Node.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Node.java
@@ -61,23 +61,6 @@ public interface Node {
         throw new IndexOutOfBoundsException(index);
     }
 
-    default int getBasicDependencyCount() {
-        return 0;
-    }
-
-    default Node getBasicDependency(int index) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException(index);
-    }
-
-    default Node getDependency() {
-        int cnt = getBasicDependencyCount();
-        if (cnt == 1) {
-            return getBasicDependency(0);
-        } else {
-            throw new IllegalStateException();
-        }
-    }
-
     /**
      * A node copier, which uses a visitor chain to allow observation and transformation of the graph nodes as they
      * are copied.
@@ -274,7 +257,7 @@ public interface Node {
             }
 
             public Node visit(Copier param, ArrayElementWrite node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().writeArrayValue(param.copyValue(node.getInstance()), param.copyValue(node.getIndex()), param.copyValue(node.getWriteValue()), node.getMode());
             }
 
@@ -283,27 +266,27 @@ public interface Node {
             }
 
             public Node visit(Copier param, InstanceFieldWrite node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().writeInstanceField(param.copyValue(node.getInstance()), node.getFieldElement(), param.copyValue(node.getWriteValue()), node.getMode());
             }
 
             public Node visit(Copier param, DynamicInvocation node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().invokeDynamic(node.getBootstrapMethod(), param.copyValues(node.getStaticArguments()), param.copyValues(node.getArguments()));
             }
 
             public Node visit(Copier param, InstanceInvocation node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().invokeInstance(node.getKind(), param.copyValue(node.getInstance()), node.getInvocationTarget(), param.copyValues(node.getArguments()));
             }
 
             public Node visit(Copier param, MonitorEnter node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().monitorEnter(param.copyValue(node.getInstance()));
             }
 
             public Node visit(Copier param, MonitorExit node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().monitorExit(param.copyValue(node.getInstance()));
             }
 
@@ -313,52 +296,52 @@ public interface Node {
             }
 
             public Node visit(Copier param, StaticFieldWrite node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().writeStaticField(node.getFieldElement(), param.copyValue(node.getWriteValue()), node.getMode());
             }
 
             public Node visit(Copier param, StaticInvocation node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().invokeStatic(node.getInvocationTarget(), param.copyValues(node.getArguments()));
             }
 
             public Node visit(Copier param, Fence node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().fence(node.getAtomicityMode());
             }
 
             public BasicBlock visit(Copier param, Goto node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().goto_(param.copyBlock(node.getResumeTarget()));
             }
 
             public BasicBlock visit(Copier param, If node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().if_(param.copyValue(node.getCondition()), param.copyBlock(node.getTrueBranch()), param.copyBlock(node.getFalseBranch()));
             }
 
             public BasicBlock visit(Copier param, Jsr node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().jsr(param.copyBlock(node.getResumeTarget()), (BlockLiteral) param.copyValue(node.getReturnAddressValue()));
             }
 
             public BasicBlock visit(Copier param, Ret node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().ret(param.copyValue(node.getReturnAddressValue()));
             }
 
             public BasicBlock visit(Copier param, Return node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().return_();
             }
 
             public BasicBlock visit(Copier param, Unreachable node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().unreachable();
             }
 
             public BasicBlock visit(Copier param, Switch node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 int cnt = node.getNumberOfValues();
                 BlockLabel[] targetsCopy = new BlockLabel[cnt];
                 for (int i = 0; i < cnt; i ++) {
@@ -368,12 +351,12 @@ public interface Node {
             }
 
             public BasicBlock visit(Copier param, Throw node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().throw_(param.copyValue(node.getThrownValue()));
             }
 
             public BasicBlock visit(Copier param, Try node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 Node copied = param.copyTriable(node.getDelegateOperation());
                 BlockLabel resumeLabel = param.copyBlock(node.getResumeTarget());
                 if (copied instanceof Triable) {
@@ -384,22 +367,22 @@ public interface Node {
             }
 
             public BasicBlock visit(Copier param, ValueReturn node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().return_(param.copyValue(node.getReturnValue()));
             }
 
             public BasicBlock visit(Copier param, ClassCastErrorNode node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().classCastException(param.copyValue(node.getFromType()), param.copyValue(node.getToType()));
             }
 
             public BasicBlock visit(Copier param, NoSuchMethodErrorNode node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().noSuchMethodError(node.getOwner(), node.getDescriptor(), node.getName());
             }
 
             public BasicBlock visit(Copier param, ClassNotFoundErrorNode node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().classNotFoundError(node.getName());
             }
 
@@ -412,6 +395,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final ArrayElementRead node) {
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().readArrayValue(param.copyValue(node.getInstance()), param.copyValue(node.getIndex()), node.getMode());
             }
 
@@ -440,7 +424,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final Clone node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().clone(param.copyValue(node.getInput()));
             }
 
@@ -473,7 +457,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final ConstructorInvocation node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().invokeConstructor(param.copyValue(node.getInstance()), node.getInvocationTarget(), param.copyValues(node.getArguments()));
             }
 
@@ -494,6 +478,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final DynamicInvocationValue node) {
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().invokeValueDynamic(node.getBootstrapMethod(), param.copyValues(node.getStaticArguments()), node.getType(), param.copyValues(node.getArguments()));
             }
 
@@ -506,17 +491,17 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final FunctionCall node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().callFunction(param.copyValue(node.getCallTarget()), param.copyValues(node.getArguments()));
             }
 
             public Value visit(final Copier param, final InstanceFieldRead node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().readInstanceField(param.copyValue(node.getInstance()), node.getFieldElement(), node.getMode());
             }
 
             public Value visit(final Copier param, final InstanceInvocationValue node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().invokeValueInstance(node.getKind(), param.copyValue(node.getInstance()), node.getInvocationTarget(), param.copyValues(node.getArguments()));
             }
 
@@ -545,6 +530,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final MultiNewArray node) {
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().multiNewArray(node.getArrayType(), param.copyValues(node.getDimensions()));
             }
 
@@ -565,7 +551,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final NewArray node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().newArray(node.getArrayType(), param.copyValue(node.getSize()));
             }
 
@@ -599,7 +585,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final PointerLoad node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().pointerLoad(param.copyValue(node.getPointer()), node.getAccessMode(), node.getAtomicityMode());
             }
 
@@ -628,12 +614,12 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final StaticFieldRead node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().readStaticField(node.getFieldElement(), node.getMode());
             }
 
             public Value visit(final Copier param, final StaticInvocationValue node) {
-                param.copyNode(node.getBasicDependency(0));
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().invokeValueStatic(node.getInvocationTarget(), param.copyValues(node.getArguments()));
             }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/OrderedNode.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/OrderedNode.java
@@ -1,0 +1,14 @@
+package cc.quarkus.qcc.graph;
+
+/**
+ * A node which is ordered after another node in the program order.
+ */
+public interface OrderedNode extends Node {
+    /**
+     * Get the program-ordered predecessor of this node, which may or may not in turn be
+     * program-ordered.
+     *
+     * @return the predecessor (must not be {@code null})
+     */
+    Node getDependency();
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/PointerLoad.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/PointerLoad.java
@@ -9,7 +9,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  * A pointer load operation.
  */
-public final class PointerLoad extends AbstractValue {
+public final class PointerLoad extends AbstractValue implements OrderedNode {
     private final Node dependency;
     private final Value pointer;
     private final MemoryAccessMode accessMode;
@@ -23,6 +23,7 @@ public final class PointerLoad extends AbstractValue {
         this.atomicityMode = atomicityMode;
     }
 
+    @Override
     public Node getDependency() {
         return dependency;
     }
@@ -62,14 +63,6 @@ public final class PointerLoad extends AbstractValue {
 
     public Value getValueDependency(final int index) throws IndexOutOfBoundsException {
         return index == 0 ? pointer : Util.throwIndexOutOfBounds(index);
-    }
-
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/PointerStore.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/PointerStore.java
@@ -7,7 +7,7 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public final class PointerStore extends AbstractNode implements Action {
+public final class PointerStore extends AbstractNode implements Action, OrderedNode {
     private final Node dependency;
     private final Value pointer;
     private final Value value;
@@ -23,6 +23,7 @@ public final class PointerStore extends AbstractNode implements Action {
         this.atomicityMode = atomicityMode;
     }
 
+    @Override
     public Node getDependency() {
         return dependency;
     }
@@ -62,14 +63,6 @@ public final class PointerStore extends AbstractNode implements Action {
 
     public Value getValueDependency(final int index) throws IndexOutOfBoundsException {
         return index == 0 ? pointer : index == 1 ? value : Util.throwIndexOutOfBounds(index);
-    }
-
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Ret.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Ret.java
@@ -35,12 +35,9 @@ public final class Ret extends AbstractNode implements Terminator {
         return index == 0 ? returnAddressValue : Util.throwIndexOutOfBounds(index);
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final TerminatorVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Return.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Return.java
@@ -21,12 +21,9 @@ public final class Return extends AbstractNode implements Terminator {
         return terminatedBlock;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final TerminatorVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/StaticFieldRead.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/StaticFieldRead.java
@@ -9,7 +9,7 @@ import cc.quarkus.qcc.type.definition.element.FieldElement;
 /**
  *
  */
-public final class StaticFieldRead extends AbstractValue implements FieldRead {
+public final class StaticFieldRead extends AbstractValue implements FieldRead, OrderedNode {
     private final Node dependency;
     private final FieldElement fieldElement;
     private final ValueType type;
@@ -35,12 +35,9 @@ public final class StaticFieldRead extends AbstractValue implements FieldRead {
         return mode;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/StaticFieldWrite.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/StaticFieldWrite.java
@@ -8,7 +8,7 @@ import cc.quarkus.qcc.type.definition.element.FieldElement;
 /**
  *
  */
-public final class StaticFieldWrite extends AbstractNode implements FieldWrite, Action {
+public final class StaticFieldWrite extends AbstractNode implements FieldWrite, Action, OrderedNode {
     private final Node dependency;
     private final FieldElement fieldElement;
     private final Value value;
@@ -34,12 +34,9 @@ public final class StaticFieldWrite extends AbstractNode implements FieldWrite, 
         return mode;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/StaticInvocation.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/StaticInvocation.java
@@ -9,7 +9,7 @@ import cc.quarkus.qcc.type.definition.element.MethodElement;
 /**
  *
  */
-public final class StaticInvocation extends AbstractNode implements MethodInvocation, Triable, Action {
+public final class StaticInvocation extends AbstractNode implements MethodInvocation, Triable, Action, OrderedNode {
     private final Node dependency;
     private final MethodElement target;
     private final List<Value> arguments;
@@ -37,12 +37,9 @@ public final class StaticInvocation extends AbstractNode implements MethodInvoca
         return arguments;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/StaticInvocationValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/StaticInvocationValue.java
@@ -10,7 +10,7 @@ import cc.quarkus.qcc.type.definition.element.MethodElement;
 /**
  * An invoke instruction which returns a value.
  */
-public final class StaticInvocationValue extends AbstractValue implements MethodInvocation, Triable {
+public final class StaticInvocationValue extends AbstractValue implements MethodInvocation, Triable, OrderedNode {
     private final Node dependency;
     private final MethodElement target;
     private final ValueType type;
@@ -44,12 +44,9 @@ public final class StaticInvocationValue extends AbstractValue implements Method
         return type;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Switch.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Switch.java
@@ -97,12 +97,9 @@ public final class Switch extends AbstractNode implements Terminator {
         return index == 0 ? switchValue : Util.throwIndexOutOfBounds(index);
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getSuccessorCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Terminator.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Terminator.java
@@ -3,7 +3,7 @@ package cc.quarkus.qcc.graph;
 /**
  * A construct which terminates a block.  It holds a dependency on the preceding sequence of inter-thread actions.
  */
-public interface Terminator extends Node {
+public interface Terminator extends OrderedNode {
     <T, R> R accept(TerminatorVisitor<T, R> visitor, T param);
 
     BasicBlock getTerminatedBlock();

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Throw.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Throw.java
@@ -36,12 +36,9 @@ public final class Throw extends AbstractNode implements Terminator {
         return index == 0 ? thrownValue : Util.throwIndexOutOfBounds(index);
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final TerminatorVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Try.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Try.java
@@ -41,12 +41,9 @@ public final class Try extends AbstractNode implements Resume {
         return resumeTargetLabel;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? delegateOperation : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return delegateOperation;
     }
 
     public int getSuccessorCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/Unreachable.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/Unreachable.java
@@ -18,12 +18,9 @@ public class Unreachable extends AbstractNode implements Terminator {
         return terminatedBlock;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public <T, R> R accept(final TerminatorVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ValueReturn.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ValueReturn.java
@@ -28,12 +28,9 @@ public final class ValueReturn extends AbstractNode implements Terminator {
         return returnValue;
     }
 
-    public int getBasicDependencyCount() {
-        return 1;
-    }
-
-    public Node getBasicDependency(final int index) throws IndexOutOfBoundsException {
-        return index == 0 ? dependency : Util.throwIndexOutOfBounds(index);
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/schedule/Schedule.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/schedule/Schedule.java
@@ -4,8 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import cc.quarkus.qcc.graph.BasicBlock;
+import cc.quarkus.qcc.graph.OrderedNode;
 import cc.quarkus.qcc.graph.Unschedulable;
-import cc.quarkus.qcc.graph.literal.Literal;
 import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.PhiValue;
 import cc.quarkus.qcc.graph.PinnedNode;
@@ -99,14 +99,11 @@ public interface Schedule {
                 selected = candidate;
             }
         }
-        cnt = node.getBasicDependencyCount();
-        for (int i = 0; i < cnt; i ++) {
-            Node dependency = node.getBasicDependency(i);
-            if (dependency != null) {
-                BlockInfo candidate = scheduleEarly(root, blockInfos, scheduledNodes, dependency);
-                if (candidate.domDepth > selected.domDepth) {
-                    selected = candidate;
-                }
+        if (node instanceof OrderedNode) {
+            Node dependency = ((OrderedNode) node).getDependency();
+            BlockInfo candidate = scheduleEarly(root, blockInfos, scheduledNodes, dependency);
+            if (candidate.domDepth > selected.domDepth) {
+                selected = candidate;
             }
         }
         return selected;

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -163,7 +163,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     }
 
     public Void visit(final Void param, final Fence node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         MemoryAtomicityMode mode = node.getAtomicityMode();
         switch (mode) {
             case ACQUIRE:
@@ -185,32 +185,32 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     // terminators
 
     public Void visit(final Void param, final Goto node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         builder.br(map(node.getResumeTarget()));
         return null;
     }
 
     public Void visit(final Void param, final If node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         builder.br(map(node.getCondition()), map(node.getTrueBranch()), map(node.getFalseBranch()));
         return null;
     }
 
     public Void visit(final Void param, final Return node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         builder.ret();
         return null;
     }
 
     public Void visit(final Void param, final Unreachable node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         builder.unreachable();
         return null;
     }
 
 
     public Void visit(final Void param, final Switch node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         cc.quarkus.qcc.machine.llvm.op.Switch switchInst = builder.switch_(i32, map(node.getSwitchValue()), map(node.getDefaultTarget()));
 
         for (int i = 0; i < node.getNumberOfValues(); i++)
@@ -225,7 +225,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     }
 
     public Void visit(final Void param, final ValueReturn node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         builder.ret(map(node.getReturnValue().getType()), map(node.getReturnValue()));
         return null;
     }
@@ -383,7 +383,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     }
 
     public LLValue visit(final Void param, final PointerLoad node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         LLValue ptr = map(node.getPointer());
         LLValue ptrType = map(node.getPointer().getType());
         LLValue type = map(node.getType());
@@ -517,7 +517,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     // calls
 
     public LLValue visit(final Void param, final FunctionCall node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         FunctionType functionType = node.getFunctionType();
         List<Value> arguments = node.getArguments();
         LLValue llType = map(functionType);
@@ -535,7 +535,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void> {
     }
 
     public LLValue visit(final Try try_, final FunctionCall node) {
-        map(node.getBasicDependency(0));
+        map(node.getDependency());
         FunctionType functionType = node.getFunctionType();
         List<Value> arguments = node.getArguments();
         LLValue llType = map(functionType);

--- a/plugins/optimization/src/main/java/cc/quarkus/qcc/plugin/opt/GotoRemovingVisitor.java
+++ b/plugins/optimization/src/main/java/cc/quarkus/qcc/plugin/opt/GotoRemovingVisitor.java
@@ -34,7 +34,7 @@ public class GotoRemovingVisitor implements NodeVisitor.Delegating<Node.Copier, 
         if (target.getIncoming().size() == 1) {
             // delete the goto target and fold it into the current block
             deleted.add(target);
-            param.copyNode(node.getBasicDependency(0));
+            param.copyNode(node.getDependency());
             return target.getTerminator().accept(this, param);
         } else {
             return getDelegateTerminatorVisitor().visit(param, node);


### PR DESCRIPTION
The `getDependency` and `getBasicDependency` methods on `Node` were misleading.  Some node types had "basic" dependency information and some do not, with no way to distinguish between the two cases based on the node type.

The ordering created by these dependency links (presently) is actually a *partial* "program order" across all nodes that may cause or observe side-effects of any kind.  Right now, the existing code preserves this initial program order exactly, even when lowering to the final LLVM bitcode.  However, in the future we want to be able to use Global Memory Analysis (GMA) techniques to establish a more optimal global order among these nodes.  Once that information is computed, we will either want to rewrite the graph with all new dependency links, or else maintain a secondary dependency graph which is then used for scheduling and lowering in the final stages; this decision will be made later.

This change is a step towards formalizing this idea, by adding the `getDependency` method on to a new interface, `OrderedNode`.  The `getBasicDependency*()` and `getDependency()` methods are removed from `Node`.

While doing this work, I discovered two nodes that are missing ordering information: `ArrayElementRead` and `DynamicInvocationValue`. I also discovered that `ArrayElementWrite` did not have a value dependency on its index, and that `MultiNewArray` was not copied correctly (its program-order dependency was not processed).
