### PR TITLE
Add a function declaration for _Unwind_RaiseException

### DIFF
--- a/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
@@ -2,7 +2,7 @@ package cc.quarkus.qcc.plugin.lowering;
 
 import cc.quarkus.qcc.context.CompilationContext;
 import cc.quarkus.qcc.graph.*;
-import cc.quarkus.qcc.object.Function;
+import cc.quarkus.qcc.type.definition.element.MethodElement;
 
 import java.util.List;
 
@@ -16,8 +16,10 @@ public class ThrowLoweringBasicBlockBuilder extends DelegatingBasicBlockBuilder 
 
     public BasicBlock throw_(final Value value) {
         Value unwindException = readInstanceField(ctxt.getCurrentThreadValue(), ThrowExceptionHelper.get(ctxt).getUnwindExceptionField(), JavaAccessMode.PLAIN);
-        Function function = ctxt.getExactFunction(ThrowExceptionHelper.get(ctxt).getRaiseExceptionMethod());
-        super.callFunction(ctxt.getLiteralFactory().literalOfSymbol(function.getName(), function.getType()), List.of(unwindException));
+        MethodElement raiseException = ThrowExceptionHelper.get(ctxt).getRaiseExceptionMethod();
+        ctxt.getImplicitSection(getCurrentElement())
+            .declareFunction(raiseException, raiseException.getName(), raiseException.getType(List.of()));
+        super.callFunction(ctxt.getLiteralFactory().literalOfSymbol(raiseException.getName(), raiseException.getType(List.of())), List.of(unwindException));
         return unreachable();
     }
 }


### PR DESCRIPTION
`_Unwind_RaiseException` is incorrectly registered as an `exact` function.
Since it is an external function, it doesn't have any body. We should
instead create a declaration for this function.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>