### PR TITLE
implement vtable-based invokevirtual dispatch sequence

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/FunctionCall.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/FunctionCall.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import cc.quarkus.qcc.type.FunctionType;
+import cc.quarkus.qcc.type.PointerType;
 import cc.quarkus.qcc.type.ValueType;
 import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 
@@ -29,7 +30,11 @@ public final class FunctionCall extends AbstractValue implements Triable {
     }
 
     public FunctionType getFunctionType() {
-        return (FunctionType) callTarget.getType();
+        if (callTarget.getType() instanceof PointerType) {
+            return (FunctionType) ((PointerType)callTarget.getType()).getPointeeType();
+        } else {
+            return (FunctionType) callTarget.getType();
+        }
     }
 
     public int getArgumentCount() {

--- a/plugins/dispatch/src/main/java/cc/quarkus/qcc/plugin/dispatch/DispatchTables.java
+++ b/plugins/dispatch/src/main/java/cc/quarkus/qcc/plugin/dispatch/DispatchTables.java
@@ -106,4 +106,16 @@ public class DispatchTables {
         return symbol;
     }
 
+    public int getVTableIndex(MethodElement target) {
+        ValidatedTypeDefinition definingType = target.getEnclosingType().validate();
+        MethodElement[] vtable = getVTable(definingType);
+        for (int i=0; i<vtable.length; i++) {
+            if (target.getName().equals(vtable[i].getName()) && target.getDescriptor().equals(vtable[i].getDescriptor())) {
+                return i;
+            }
+        }
+        ctxt.error("No vtable entry found for "+target);
+        return 0;
+    }
+
 }

--- a/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
@@ -7,12 +7,19 @@ import cc.quarkus.qcc.context.CompilationContext;
 import cc.quarkus.qcc.graph.BasicBlockBuilder;
 import cc.quarkus.qcc.graph.DelegatingBasicBlockBuilder;
 import cc.quarkus.qcc.graph.DispatchInvocation;
+import cc.quarkus.qcc.graph.JavaAccessMode;
+import cc.quarkus.qcc.graph.MemoryAccessMode;
+import cc.quarkus.qcc.graph.MemoryAtomicityMode;
 import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.Value;
 import cc.quarkus.qcc.graph.literal.SymbolLiteral;
 import cc.quarkus.qcc.object.Function;
 import cc.quarkus.qcc.plugin.dispatch.DispatchTables;
+import cc.quarkus.qcc.type.ArrayType;
 import cc.quarkus.qcc.type.ClassObjectType;
+import cc.quarkus.qcc.type.PointerType;
+import cc.quarkus.qcc.type.TypeSystem;
+import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
 import cc.quarkus.qcc.type.definition.element.ConstructorElement;
 import cc.quarkus.qcc.type.definition.element.MethodElement;
 
@@ -38,17 +45,23 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
     }
 
     public Node invokeInstance(final DispatchInvocation.Kind kind, final Value instance, final MethodElement target, final List<Value> arguments) {
-        if (kind == DispatchInvocation.Kind.INTERFACE || kind == DispatchInvocation.Kind.VIRTUAL) {
-            ctxt.warning(getLocation(), "Virtual invocation not supported yet");
-            // but continue anyway just to see what would happen
+        Value callTarget;
+        Function invokeTarget = ctxt.getExactFunction(target);
+        if (kind == DispatchInvocation.Kind.INTERFACE) {
+            ctxt.warning(getLocation(), "interface invocation not supported yet");
+            // but continue with bogus call target just to see what would happen
+            callTarget = functionLiteral(invokeTarget);
+        } else if (kind == DispatchInvocation.Kind.VIRTUAL) {
+            callTarget = expandVirtualDispatch(instance, target, invokeTarget);
+        } else {
+            callTarget = functionLiteral(invokeTarget);
         }
-        Function function = ctxt.getExactFunction(target);
         List<Value> args = new ArrayList<>(arguments.size() + 2);
         args.add(ctxt.getCurrentThreadValue());
         args.add(instance);
         args.addAll(arguments);
         ctxt.enqueue(target);
-        return super.callFunction(functionLiteral(function), args);
+        return super.callFunction(callTarget, args);
     }
 
     public Value invokeValueStatic(final MethodElement target, final List<Value> arguments) {
@@ -62,17 +75,23 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
     }
 
     public Value invokeValueInstance(final DispatchInvocation.Kind kind, final Value instance, final MethodElement target, final List<Value> arguments) {
-        if (kind == DispatchInvocation.Kind.INTERFACE || kind == DispatchInvocation.Kind.VIRTUAL) {
-            ctxt.warning(getLocation(), "Virtual invocation not supported yet");
-            // but continue anyway just to see what would happen
+        Value callTarget;
+        Function invokeTarget = ctxt.getExactFunction(target);
+        if (kind == DispatchInvocation.Kind.INTERFACE) {
+            ctxt.warning(getLocation(), "interface invocation not supported yet");
+            // but continue with bogus call target just to see what would happen
+            callTarget = functionLiteral(invokeTarget);
+        } else if (kind == DispatchInvocation.Kind.VIRTUAL) {
+            callTarget = expandVirtualDispatch(instance, target, invokeTarget);
+        } else {
+            callTarget = functionLiteral(invokeTarget);
         }
-        Function function = ctxt.getExactFunction(target);
         List<Value> args = new ArrayList<>(arguments.size() + 2);
         args.add(ctxt.getCurrentThreadValue());
         args.add(instance);
         args.addAll(arguments);
         ctxt.enqueue(target);
-        return super.callFunction(functionLiteral(function), args);
+        return super.callFunction(callTarget, args);
     }
 
     public Value invokeConstructor(final Value instance, final ConstructorElement target, final List<Value> arguments) {
@@ -95,8 +114,19 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
         return super.new_(type);
     }
 
-
     private SymbolLiteral functionLiteral(final Function function) {
         return ctxt.getLiteralFactory().literalOfSymbol(function.getName(), function.getType());
+    }
+
+    /*
+     * Implement naive scheme where first word of an object simply contains the vtable pointer.
+     * Eventually we will need to do more (mask off bottom bits, or load an index and then index into a vtable table, etc).
+     */
+    private Value expandVirtualDispatch(Value instance, MethodElement target, Function invokeTarget) {
+        DispatchTables dt = DispatchTables.get(ctxt);
+        Value vtable = pointerLoad(bitCast(instance, ctxt.getTypeSystem().getVoidType().getPointer().getPointer().getPointer()), MemoryAccessMode.PLAIN, MemoryAtomicityMode.UNORDERED);
+        Value index = ctxt.getLiteralFactory().literalOf(dt.getVTableIndex(target));
+        Value fptr = pointerLoad(add(vtable, index), MemoryAccessMode.PLAIN, MemoryAtomicityMode.UNORDERED);
+        return bitCast(fptr, invokeTarget.getType().getPointer());
     }
 }


### PR DESCRIPTION
Straightforward expansion of a viable-based invokevirtual, assuming that the first word of an object header is simply a viable pointer.

Here's a snippet of the llvm bitcode we get for an invocation `this.m2()`
```
  %L0 = bitcast i64 %this to i8***, !dbg !15
  %L1 = load i8**, i8*** %L0, !dbg !13
  %L2 = getelementptr i8*, i8** %L1, i32 1
  %L3 = load i8*, i8** %L2, !dbg !12
  %L4 = bitcast i8* %L3 to i32 (i64, i64)*, !dbg !17
  %L5 = call i32 (i64, i64) %L4(i64 %thr, i64 %this), !dbg !11
```