### PR TITLE
flip order of machine-file dependency to try to break linux integration tests

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -56,11 +56,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qcc-machine-file-elf</artifactId>
+            <artifactId>qcc-machine-file-macho</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qcc-machine-file-macho</artifactId>
+            <artifactId>qcc-machine-file-elf</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
do not merge....if I'm right, this will fail integration tests because running with -jar won't load the `elf` ObjectFileProvider.
