### PR TITLE
Split up different types of declarations in LLVM modules

### DIFF
--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/FunctionDefinitionImpl.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/FunctionDefinitionImpl.java
@@ -177,7 +177,6 @@ final class FunctionDefinitionImpl extends AbstractFunction implements FunctionD
         target.append(System.lineSeparator());
         lastBlock.appendAsBlockTo(target);
         target.append('}');
-        target.append(System.lineSeparator());
     }
 
     void assignName(final BasicBlockImpl basicBlock) {


### PR DESCRIPTION
Previously, different kinds of declarations in LLVM modules would be
emitted in whatever order they happened to be constructed. This would
mean mixing metadata, function declarations, and type declarations in a
difficult-to-read manner. This also caused an issue with a hidden
requirement in LLVM's parsing of LL files which requires that types be
fully declared before being used in a GEP, load, store, or alloca
instruction so that it can check that the type is sized.

This has been fixed by splitting LLVM module declarations into different
sections based on the type of declaration, which closely mirrors how
LLVM itself will emit LL files.

Fixes: #259