### PR TITLE
Ignore unused commandline options for gcc / clang

### DIFF
--- a/machine/tool/clang/src/main/java/cc/quarkus/qcc/machine/tool/clang/ClangCCompilerInvokerImpl.java
+++ b/machine/tool/clang/src/main/java/cc/quarkus/qcc/machine/tool/clang/ClangCCompilerInvokerImpl.java
@@ -82,7 +82,11 @@ final class ClangCCompilerInvokerImpl extends AbstractClangInvoker implements Cl
         Platform platform = getTool().getPlatform();
         cmd.add("-target");
         cmd.add(platform.getCpu().toString() + "-" + platform.getOs().toString() + "-" + platform.getAbi().toString());
-        Collections.addAll(cmd, "-Wno-unused-command-line-argument", "-std=gnu11", "-f" + "input-charset=UTF-8", "-pipe");
+        if (sourceLanguage != SourceLanguage.ASM) {
+            cmd.add("-std=gnu11");
+        }
+        cmd.add("-pipe");
+
         for (Path includePath : includePaths) {
             cmd.add("-I" + includePath.toString());
         }

--- a/machine/tool/gnu/src/main/java/cc/quarkus/qcc/machine/tool/gnu/GnuCCompilerInvokerImpl.java
+++ b/machine/tool/gnu/src/main/java/cc/quarkus/qcc/machine/tool/gnu/GnuCCompilerInvokerImpl.java
@@ -79,7 +79,10 @@ final class GnuCCompilerInvokerImpl extends AbstractGccInvoker implements GnuCCo
         if (getTool().isM32()) {
             cmd.add("-m32");
         }
-        Collections.addAll(cmd, "-Wno-unused-command-line-argument", "-std=gnu11", "-f" + "input-charset=UTF-8", "-pipe");
+        if (sourceLanguage != SourceLanguage.ASM) {
+            cmd.add("-std=gnu11");
+        }
+        cmd.add("-pipe");
         for (Path includePath : includePaths) {
             cmd.add("-I" + includePath.toString());
         }


### PR DESCRIPTION
Work around CI test failures due to the compiler warning about
unused commandline options.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>