### PR TITLE
docs: Simplifed example compilation instructions using more Jbang

### DIFF
--- a/examples/helloworld/hello/world/Main.java
+++ b/examples/helloworld/hello/world/Main.java
@@ -1,17 +1,15 @@
 // Basic helloworld example with the commands to execute it. 
 //
-// Compile the example with:
-// $ javac -cp ~/.m2/repository/cc/quarkus/qcc-runtime-api/1.0.0-SNAPSHOT/qcc-runtime-api-1.0.0-SNAPSHOT.jar hello/world/Main.java
-//
-// Jar the Main.class
-// $ jar cvf main.jar hello/world/Main.class
+// Compile the example with jbang (0.65.1+):
+// $ jbang build hello/world/Main.java
 //
 // Build the native executable in /tmp/output with:
-// $ jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT --boot-module-path $HOME/.m2/repository/cc/quarkus/qccrt-java.base/11.0.1-SNAPSHOT/qccrt-java.base-11.0.1-SNAPSHOT.jar:$HOME/.m2/repository/cc/quarkus/qcc-runtime-api/1.0.0-SNAPSHOT/qcc-runtime-api-1.0.0-SNAPSHOT.jar:$HOME/.m2/repository/cc/quarkus/qcc-runtime-unwind/1.0.0-SNAPSHOT/qcc-runtime-unwind-1.0.0-SNAPSHOT.jar:main.jar --output-path /tmp/output hello.world.Main
+// $ jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT --boot-module-path $(jbang info classpath --deps cc.quarkus:qccrt-java.base:11.0.1-SNAPSHOT --deps cc.quarkus:qcc-runtime-main:1.0.0-SNAPSHOT --deps cc.quarkus:qcc-runtime-unwind:1.0.0-SNAPSHOT examples/helloworld/hello/world/Main.java) --output-path /tmp/output hello.world.Main
 //
 // Run the executable
 // $ /tmp/output/a.out
-
+//
+//DEPS cc.quarkus:qcc-runtime-api:1.0.0-SNAPSHOT
 package hello.world;
 
 import static cc.quarkus.qcc.runtime.CNative.*;


### PR DESCRIPTION
TL;DR Invoking the compiler is now much easier using Jbang

The latest versions of Jbang have now fixed an issue which prevented us from obtaining the full classpath for a script. But now that we can it simplifies the required steps. First we can build the app using `jbang build`, like this:

```
jbang build hello/world/Main.java
```

The problem is finding the resulting JAR file. But `jbang info classpath hello/world/Main.java` now gives us that information, including any dependencies that were defined in the java file using Jbang's //DEPS mechanism.

After that running the compiler becomes much easier:

```
jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT --boot-module-path $(jbang info classpath hello/world/Main.java) --output-path /tmp/output hello.world.Main
```

The whole list of dependencies that had to be passed is now just a single extra invocation of Jbang.

NB: We can do without the `//DEPS` lines in the java file, but it would make the above commands longer because we'd have to add those dependencies on the command line using `--deps`. This way just seems easier for now.