### PR TITLE
emit master vtable*[]

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/ValueVisitor.java
@@ -1,6 +1,7 @@
 package cc.quarkus.qcc.graph;
 
 import cc.quarkus.qcc.graph.literal.ArrayLiteral;
+import cc.quarkus.qcc.graph.literal.BitCastLiteral;
 import cc.quarkus.qcc.graph.literal.BlockLiteral;
 import cc.quarkus.qcc.graph.literal.BooleanLiteral;
 import cc.quarkus.qcc.graph.literal.CompoundLiteral;
@@ -46,6 +47,10 @@ public interface ValueVisitor<T, R> {
     }
 
     default R visit(T param, BitCast node) {
+        return visitUnknown(param, node);
+    }
+
+    default R visit(T param, BitCastLiteral node) {
         return visitUnknown(param, node);
     }
 

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/literal/BitCastLiteral.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/literal/BitCastLiteral.java
@@ -1,0 +1,38 @@
+package cc.quarkus.qcc.graph.literal;
+
+import cc.quarkus.qcc.graph.ValueVisitor;
+import cc.quarkus.qcc.type.WordType;
+
+public class BitCastLiteral extends Literal {
+    final Literal value;
+    final WordType toType;
+
+    BitCastLiteral(final Literal value, final WordType toType) {
+        this.value = value;
+        this.toType = toType;
+    }
+
+    public WordType getType() {
+        return toType;
+    }
+
+    public Literal getValue() { return value; }
+
+    public boolean equals(final Literal other) {
+        return other instanceof BitCastLiteral && equals((BitCastLiteral) other);
+    }
+
+    public boolean equals(final BitCastLiteral other) {
+        return other == this || other != null && toType.equals(other.toType) && value.equals(other.value);
+    }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+
+    public int hashCode() { return value.hashCode() * 19 + toType.hashCode(); }
+
+    public String toString() {
+        return "bitcast ("+value+" to "+toType+")";
+    }
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/literal/LiteralFactory.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/literal/LiteralFactory.java
@@ -16,6 +16,7 @@ import cc.quarkus.qcc.type.IntegerType;
 import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.TypeSystem;
 import cc.quarkus.qcc.type.ValueType;
+import cc.quarkus.qcc.type.WordType;
 import io.smallrye.common.constraint.Assert;
 
 /**
@@ -64,6 +65,8 @@ public interface LiteralFactory {
     ArrayLiteral literalOf(ArrayType type, List<Literal> values);
 
     CompoundLiteral literalOf(CompoundType type, Map<CompoundType.Member, Literal> values);
+
+    BitCastLiteral bitcastLiteral(Literal value, WordType toType);
 
     static LiteralFactory create(TypeSystem typeSystem) {
         return new LiteralFactory() {
@@ -184,6 +187,12 @@ public interface LiteralFactory {
                 Assert.checkNotNullParam("type", type);
                 Assert.checkNotNullParam("values", values);
                 return new CompoundLiteral(type, values);
+            }
+
+            public BitCastLiteral bitcastLiteral(final Literal value, final WordType toType) {
+                Assert.checkNotNullParam("value", value);
+                Assert.checkNotNullParam("toType", toType);
+                return new BitCastLiteral(value, toType);
             }
         };
     }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Values.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Values.java
@@ -18,6 +18,8 @@ public final class Values {
 
     public static final LLValue zeroinitializer = LLVM.zeroinitializer;
 
+    public static LLValue bitcastConstant(LLValue value, LLValue fromType, LLValue toType) { return LLVM.bitcastConstant(value, fromType, toType); }
+
     public static LLValue intConstant(int val) {
         return LLVM.intConstant(val);
     }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/BitcastConstant.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/BitcastConstant.java
@@ -1,0 +1,28 @@
+package cc.quarkus.qcc.machine.llvm.impl;
+
+import cc.quarkus.qcc.machine.llvm.LLValue;
+
+import java.io.IOException;
+
+public class BitcastConstant extends AbstractValue {
+    final LLValue value;
+    final LLValue fromType;
+    final LLValue toType;
+
+    BitcastConstant(LLValue value, LLValue fromType, LLValue toType) {
+        this.value = value;
+        this.fromType = fromType;
+        this.toType = toType;
+    }
+
+    public Appendable appendTo(Appendable target) throws IOException {
+        target.append("bitcast (");
+        ((AbstractValue)fromType).appendTo(target);
+        target.append(" ");
+        ((AbstractValue)value).appendTo(target);
+        target.append(" to ");
+        ((AbstractValue)toType).appendTo(target);
+        target.append(")");
+        return target;
+    }
+}

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/LLVM.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/LLVM.java
@@ -79,6 +79,8 @@ public final class LLVM {
         return new DoubleConstant(val);
     }
 
+    public static LLValue bitcastConstant(LLValue val, LLValue fromType, LLValue toType) { return new BitcastConstant(val, fromType, toType); }
+
     public static Array array(LLValue elementType) {
         return new ArrayImpl(elementType);
     }

--- a/plugins/dispatch/src/main/java/cc/quarkus/qcc/plugin/dispatch/DispatchTableEmitter.java
+++ b/plugins/dispatch/src/main/java/cc/quarkus/qcc/plugin/dispatch/DispatchTableEmitter.java
@@ -10,16 +10,20 @@ import cc.quarkus.qcc.type.definition.ValidatedTypeDefinition;
 import java.util.function.Consumer;
 
 public class DispatchTableEmitter implements Consumer<CompilationContext>  {
+
     @Override
     public void accept(CompilationContext ctxt) {
         RTAInfo info = RTAInfo.get(ctxt);
         DispatchTables tables = DispatchTables.get(ctxt);
 
-        // Walk down the live class hierarchy and emit vtables
+        // Walk down the live class hierarchy and emit vtables for each class
         ClassContext classContext = ctxt.getBootstrapClassContext();
         DefinedTypeDefinition jloDef = classContext.findDefinedType("java/lang/Object");
         ValidatedTypeDefinition jlo = jloDef.validate();
         tables.emitVTable(jlo);
         info.visitLiveSubclassesPreOrder(jlo, cls -> tables.emitVTable(cls));
+
+        // Emit the master table of all program vtables in the object file for java.lang.Object
+        tables.emitVTableTable(jlo);
     }
 }

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -14,6 +14,7 @@ import cc.quarkus.qcc.context.Location;
 import cc.quarkus.qcc.graph.Value;
 import cc.quarkus.qcc.graph.ValueVisitor;
 import cc.quarkus.qcc.graph.literal.ArrayLiteral;
+import cc.quarkus.qcc.graph.literal.BitCastLiteral;
 import cc.quarkus.qcc.graph.literal.BooleanLiteral;
 import cc.quarkus.qcc.graph.literal.CompoundLiteral;
 import cc.quarkus.qcc.graph.literal.FloatLiteral;
@@ -195,6 +196,13 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue> {
             array.item(map(values.get(i)));
         }
         return array;
+    }
+
+    public LLValue visit(final Void param, final BitCastLiteral node) {
+        LLValue input = map(node.getValue());
+        LLValue fromType = map(node.getValue().getType());
+        LLValue toType = map(node.getType());
+        return Values.bitcastConstant(input, fromType, toType);
     }
 
     public LLValue visit(final Void param, final CompoundLiteral node) {


### PR DESCRIPTION
Emit an array containing pointers to all vtables for use in
typeId-based dipsatching.

Add support for LLVM's bitcast constant expression.