### PR TITLE
Strict type checking based on stack maps

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/PhiValue.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/PhiValue.java
@@ -11,9 +11,6 @@ import cc.quarkus.qcc.type.definition.element.ExecutableElement;
 import io.smallrye.common.constraint.Assert;
 
 public final class PhiValue extends AbstractValue implements PinnedNode {
-    // todo: this is TEMPORARY (not an API) and should not be reused or replicated elsewhere
-    private static final boolean STRICT_JOINS = Boolean.parseBoolean(System.getProperty("qcc.strict-joins", "false"));
-
     private ValueType type;
     private final BlockLabel blockLabel;
     private final HashMap<Terminator, Value> incomingValues = new HashMap<>();
@@ -32,16 +29,8 @@ public final class PhiValue extends AbstractValue implements PinnedNode {
         Assert.checkNotNullParam("value", value);
         ValueType expected = getType();
         ValueType actual = value.getType();
-        if (STRICT_JOINS) {
-            if (! actual.join(expected).equals(expected)) {
-                ctxt.error(element, this, "Invalid input value for phi: expected %s, got %s (join is %s)", expected, actual, actual.join(expected));
-            }
-        } else {
-            try {
-                type = actual.join(expected);
-            } catch (IllegalArgumentException e) {
-                ctxt.error(element, this, "Failed to derive type for phi: %s", e.getMessage());
-            }
+        if (! actual.join(expected).equals(expected)) {
+            ctxt.error(element, this, "Invalid input value for phi: expected %s, got %s (join is %s)", expected, actual, actual.join(expected));
         }
         if (incomingValues.containsKey(input)) {
             ctxt.error(element, this, "Phi already has a value for block %s", input.getTerminatedBlock());

--- a/compiler/src/main/java/cc/quarkus/qcc/type/ValueType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/ValueType.java
@@ -91,7 +91,9 @@ public abstract class ValueType extends Type {
      * @return the meet type (not {@code null})
      */
     public ValueType join(final ValueType other) {
-        return equals(other) ? this : getTypeSystem().getPoisonType();
+        boolean const_ = isConst() || other.isConst();
+        boolean ok = const_ ? asConst().equals(other.asConst()) : equals(other);
+        return ok ? const_ ? asConst() : this : getTypeSystem().getPoisonType();
     }
 
     public StringBuilder toString(final StringBuilder b) {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassMethodInfo.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassMethodInfo.java
@@ -241,7 +241,7 @@ final class ClassMethodInfo {
         }
         this.exTable = exTable;
         int attrCnt = codeAttr.getShort() & 0xffff;
-        int stackMapTableOffs = -1;
+        int stackMapTableOffs = classFile.getMajorVersion() < 50 ? -1 : 0;
         int stackMapTableLen = 0;
         int visibleTypeAnnotationsOffs = -1;
         int visibleTypeAnnotationsLen = 0;
@@ -723,6 +723,10 @@ final class ClassMethodInfo {
             }
         }
         return -low - 1;
+    }
+
+    int getEntryPointTarget(final int index) {
+        return entryPoints[index];
     }
 
     int getLineNumber(int bci) {


### PR DESCRIPTION
Currently, phi types cannot be correctly inferred by a single pass through the method's bytecodes.  Additionally, the current scheme of tracking class 2 values on the stack and in local variables by value identity breaks down in the presence of optimization and coalescing of values.

This change alters the way that class 2 values are tracked, and sets the type and lifetime of phi values based on the stack map information.  It also more correctly (and somewhat more pessimistically) tracks the nullability of values.