### PR TITLE
Lowering throw still must use callFunction

### DIFF
--- a/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
@@ -19,7 +19,7 @@ public class ThrowLoweringBasicBlockBuilder extends DelegatingBasicBlockBuilder 
     public BasicBlock throw_(final Value value) {
         ThrowExceptionHelper teh = ThrowExceptionHelper.get(ctxt);
         Value ptr = addressOf(instanceFieldOf(referenceHandle(currentThread()), teh.getUnwindExceptionField()));
-        invokeStatic(teh.getRaiseExceptionMethod(), List.of(ptr));
+        callFunction(ctxt.getLiteralFactory().literalOfSymbol("_Unwind_RaiseException", teh.getRaiseExceptionMethod().getType(List.of(/**/))), List.of(ptr));
         return unreachable();
     }
 }


### PR DESCRIPTION
Unless we move it before NativeBasicBlockBuilder (or duplicate that builder to both stages) it will not find its corresponding native function.