### PR TITLE
Object.getClass() should return the class object rather than the type ID, using the correct node type

### DIFF
--- a/plugins/intrinsics/src/main/java/cc/quarkus/qcc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/cc/quarkus/qcc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -159,9 +159,8 @@ public final class CoreIntrinsics {
         MethodDescriptor getClassDesc =
             MethodDescriptor.synthesize(classContext,
                 ClassTypeDescriptor.synthesize(classContext, "java/lang/Class"), List.of());
-        final FieldElement classFieldElement = layout.getObjectClassField();
         InstanceValueIntrinsic getClassIntrinsic = (builder, kind, instance, owner, name, descriptor, arguments) ->
-            builder.load(builder.instanceFieldOf(builder.referenceHandle(instance), classFieldElement), MemoryAtomicityMode.UNORDERED);
+            builder.classOf(builder.typeIdOf(builder.referenceHandle(instance)));
         intrinsics.registerIntrinsic(classDesc, "getClass", getClassDesc, getClassIntrinsic);
     }
 }


### PR DESCRIPTION
The `TypeIdOf` node is lowered by the object access builder.  The `ClassOf` node isn't lowered yet but would likely best be lowered to a global array access by type ID.