### PR TITLE
Stack maps

### DIFF
--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import cc.quarkus.qcc.context.CompilationContext;
 import cc.quarkus.qcc.context.Location;
+import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.Value;
 import cc.quarkus.qcc.graph.ValueVisitor;
 import cc.quarkus.qcc.graph.literal.ArrayLiteral;
@@ -50,14 +51,19 @@ import io.smallrye.common.constraint.Assert;
 final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue> {
     final Module module;
     final CompilationContext ctxt;
+    final LLValue stackMapFn;
+    final LLValue stackMapFnType;
 
     final Map<Type, LLValue> types = new HashMap<>();
     final Map<CompoundType.Member, LLValue> structureOffsets = new HashMap<>();
     final Map<Value, LLValue> globalValues = new HashMap<>();
+    final List<Node> callSites = new ArrayList<>();
 
-    LLVMModuleNodeVisitor(final Module module, final CompilationContext ctxt) {
+    LLVMModuleNodeVisitor(final Module module, final CompilationContext ctxt, LLValue stackMapFn) {
         this.module = module;
         this.ctxt = ctxt;
+        this.stackMapFn = stackMapFn;
+        stackMapFnType = Types.function(void_, List.of(i64, i32), true);
     }
 
     LLValue map(Type type) {

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -548,6 +548,9 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void, Ge
             map(type);
             map(arguments.get(i));
         }
+        int id = moduleVisitor.callSites.size();
+        moduleVisitor.callSites.add(node);
+        builder.call(moduleVisitor.stackMapFnType, moduleVisitor.stackMapFn).arg(i64, intConstant(id)).arg(i32, zeroinitializer);
         Call call = builder.call(llType, llTarget);
         for (int i = 0; i < arguments.size(); i++) {
             ValueType type = arguments.get(i).getType();
@@ -576,6 +579,9 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void, Ge
             map(functionType.getParameterType(i));
             map(arguments.get(i));
         }
+        int id = moduleVisitor.callSites.size();
+        moduleVisitor.callSites.add(node);
+        builder.call(moduleVisitor.stackMapFnType, moduleVisitor.stackMapFn).arg(i64, intConstant(id)).arg(i32, zeroinitializer);
         Call call = builder.invoke(llType, llTarget, map(try_.getResumeTarget()), mapCatch(try_.getExceptionHandler()));
         for (int i = 0; i < arguments.size(); i++) {
             call.arg(map(functionType.getParameterType(i)), map(arguments.get(i)));


### PR DESCRIPTION
Introduce stack maps at each call site, numbering the call site so that the call site address can be correlated back to the original node.

The information is not yet used.  The next iteration of this PR would read the stack map section of each object file to build a table of IP to method call information to lay the groundwork for a stack walker.

No value usage information is recorded; that is, a hypothetical GC would not yet be able to use this stack map information.  The discussion on #73 will outline some of the issues around that (the discussion is not concluded).

An alternative implementation could possibly use the information in the DWARF debug information section to correlate call sites with their addresses.  This would likely be somewhat more complex, but might be more portable (according to the LLVM documentation, stack maps are not yet supported for 32-bit platforms).