### PR TITLE
Properly detect LLVM version

### DIFF
--- a/machine/tool/llvm/src/main/java/cc/quarkus/qcc/tool/llvm/Llvm.java
+++ b/machine/tool/llvm/src/main/java/cc/quarkus/qcc/tool/llvm/Llvm.java
@@ -1,0 +1,13 @@
+package cc.quarkus.qcc.tool.llvm;
+
+import java.util.regex.Pattern;
+
+import org.jboss.logging.Logger;
+
+final class Llvm {
+    static final Pattern LLVM_VERSION_PATTERN = Pattern.compile("LLVM version (\\d+(?:\\.\\d+)*)");
+
+    private Llvm() {}
+
+    static final Logger log = Logger.getLogger("cc.quarkus.qcc.tool.llvm");
+}

--- a/machine/tool/llvm/src/main/java/cc/quarkus/qcc/tool/llvm/LlvmToolChain.java
+++ b/machine/tool/llvm/src/main/java/cc/quarkus/qcc/tool/llvm/LlvmToolChain.java
@@ -1,17 +1,22 @@
 package cc.quarkus.qcc.tool.llvm;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 
 import cc.quarkus.qcc.machine.arch.Platform;
 import cc.quarkus.qcc.machine.tool.Tool;
 import cc.quarkus.qcc.machine.tool.ToolUtil;
+import cc.quarkus.qcc.machine.tool.process.InputSource;
+import cc.quarkus.qcc.machine.tool.process.OutputDestination;
 
 /**
  *
  */
 public interface LlvmToolChain extends Tool {
+
     default String getToolName() {
         return "llvm";
     }
@@ -30,8 +35,20 @@ public interface LlvmToolChain extends Tool {
             Path optPath = ToolUtil.findExecutable("opt");
             if (optPath != null) {
                 // check versions
-                // (todo)
-                return List.of(new LlvmToolChainImpl(llcPath, optPath, platform, "10" /*todo*/));
+                ProcessBuilder pb = new ProcessBuilder(List.of(llcPath.toString(), "--version"));
+                StringBuilder stdOut = new StringBuilder();
+                try {
+                    InputSource.empty().transferTo(OutputDestination.of(pb, OutputDestination.discarding(), OutputDestination.of(stdOut)));
+                } catch (IOException e) {
+                    Llvm.log.warn("Failed to execute LLVM tool chain version command", e);
+                    return List.of();
+                }
+                Matcher matcher = Llvm.LLVM_VERSION_PATTERN.matcher(stdOut);
+                if (matcher.find()) {
+                    String version = matcher.group(1);
+                    return List.of(new LlvmToolChainImpl(llcPath, optPath, platform, version));
+                }
+                Llvm.log.warn("Failed to identify LLVM version string; skipping");
             }
         }
         return List.of();


### PR DESCRIPTION
Builders and visitors in the LLVM plugin can check the LLVM version.

For example:

```java
if (context.getAttachment(Driver.LLVM_TOOL_KEY).compareVersionTo("10") >= 0) {
    // it's LLVM 10 or later
}
```