### PR TITLE
Use the TypeSystem's notion of typeId size to lay out struct

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/TypeSystem.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/TypeSystem.java
@@ -158,7 +158,7 @@ public final class TypeSystem {
     }
 
     /**
-     * Get the size of type ID values for this type system.
+     * Get the size of type ID values (in bytes) for this type system.
      *
      * @return the size of type ID values for this type system
      */


### PR DESCRIPTION
The TypeSystem sets the size of the typeId field and exposes
it using `ts.getTypeIdSize();`.  Laying out the `qcc_typeid_array`
should use the TypeSystem's view rather than a hardcoded u16.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>