### PR TITLE
Detect missed lowering of `typeIdOf`

### DIFF
--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -279,8 +279,9 @@ public class Main implements Callable<DiagnosticContext> {
                                 }
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, InvocationLoweringBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, StaticFieldLoweringBasicBlockBuilder::new);
-                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectAccessLoweringBuilder::new);
+                                // InstanceOfCheckCastBB must come before ObjectAccessLoweringBuilder or typeIdOf won't be lowered correctly
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, InstanceOfCheckCastBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectAccessLoweringBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectMonitorBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LLVMCompatibleBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, LowerVerificationBasicBlockBuilder::new);

--- a/plugins/layout/src/main/java/cc/quarkus/qcc/plugin/layout/ObjectAccessLoweringBuilder.java
+++ b/plugins/layout/src/main/java/cc/quarkus/qcc/plugin/layout/ObjectAccessLoweringBuilder.java
@@ -13,8 +13,6 @@ import cc.quarkus.qcc.graph.ValueHandle;
 import cc.quarkus.qcc.graph.ValueHandleVisitor;
 import cc.quarkus.qcc.type.ArrayObjectType;
 import cc.quarkus.qcc.type.ObjectType;
-import cc.quarkus.qcc.type.PhysicalObjectType;
-import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.ValueType;
 import cc.quarkus.qcc.type.definition.element.FieldElement;
 

--- a/plugins/verification/src/main/java/cc/quarkus/qcc/plugin/verification/LowerVerificationBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/cc/quarkus/qcc/plugin/verification/LowerVerificationBasicBlockBuilder.java
@@ -10,6 +10,7 @@ import cc.quarkus.qcc.graph.DelegatingBasicBlockBuilder;
 import cc.quarkus.qcc.graph.DispatchInvocation;
 import cc.quarkus.qcc.graph.Node;
 import cc.quarkus.qcc.graph.Value;
+import cc.quarkus.qcc.graph.ValueHandle;
 import cc.quarkus.qcc.graph.literal.BlockLiteral;
 import cc.quarkus.qcc.type.ArrayObjectType;
 import cc.quarkus.qcc.type.ClassObjectType;
@@ -108,6 +109,11 @@ public class LowerVerificationBasicBlockBuilder extends DelegatingBasicBlockBuil
     public Value multiNewArray(final ArrayObjectType arrayType, final List<Value> dimensions) {
         invalidNode("new");
         return ctxt.getLiteralFactory().zeroInitializerLiteralOfType(arrayType.getReference());
+    }
+
+    public Value typeIdOf(ValueHandle valueHandle) {
+        invalidNode("typeIdOf");
+        return ctxt.getLiteralFactory().literalOf(0);
     }
 
     private void invalidNode(String name) {


### PR DESCRIPTION
`typeIdOf` is lowered by the ObjectAccessLoweringBuilder.  Any builder
after that can't rely on using `typeIdOf()` calls.

Detect this and mark the `typeIdOf` node as invalid in the
LowerVerificationBasicBlockBuilder and reorder the BBBs so that
the InstanceOfCheckCastBasicBlockBuilder, which generates `typeIdOf()`
calls comes first.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>