### PR TITLE
Add options to control generation of graph

### DIFF
--- a/driver/src/main/java/cc/quarkus/qcc/driver/GraphGenConfig.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/GraphGenConfig.java
@@ -1,0 +1,58 @@
+package cc.quarkus.qcc.driver;
+
+import cc.quarkus.qcc.type.definition.element.Element;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+
+public class GraphGenConfig {
+    public static final String ALL_METHODS = "all";
+    public static final String ALL_PHASES = "all";
+
+    private static final HashSet<String> ALL_METHODS_SET = new HashSet<>();
+
+    private EnumMap<Phase, HashSet<String>> phaseToMethodsMap = new EnumMap<>(Phase.class);
+
+    public void addMethodAndPhase(String method, String phaseString) {
+        List<Phase> phaseList = new ArrayList<>();
+        if (phaseString.equalsIgnoreCase(ALL_PHASES)) {
+            phaseList.addAll(Arrays.asList(Phase.values()));
+        } else {
+            phaseList.add(Phase.getPhase(phaseString));
+        }
+        for (Phase p: phaseList) {
+            if (method.equalsIgnoreCase(ALL_METHODS)) {
+                phaseToMethodsMap.compute(p, (k, v) -> ALL_METHODS_SET);
+            } else {
+                // convert to internal representation
+                //  eg convert java/lang/String.length() to java/lang.String.length()
+                StringBuilder internalName = new StringBuilder(method);
+                int endOfPackage = internalName.lastIndexOf("/");
+                if (endOfPackage != -1) {
+                    internalName = internalName.replace(endOfPackage, endOfPackage + 1, ".");
+                }
+                phaseToMethodsMap.computeIfAbsent(p, k -> new HashSet<>()).add(internalName.toString());
+            }
+        }
+    }
+
+    public GraphGenFilter getFilter() {
+        return new GraphGenOptionsFilter();
+    }
+
+    class GraphGenOptionsFilter implements GraphGenFilter {
+        public boolean accept(Element element, Phase phase) {
+            HashSet<String> methodSet = phaseToMethodsMap.get(phase);
+            if (methodSet != null) {
+                if (methodSet == ALL_METHODS_SET) {
+                    return true;
+                }
+                return methodSet.contains(element.toString());
+            }
+            return false;
+        }
+    }
+}

--- a/driver/src/main/java/cc/quarkus/qcc/driver/GraphGenFilter.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/GraphGenFilter.java
@@ -1,0 +1,8 @@
+package cc.quarkus.qcc.driver;
+
+import cc.quarkus.qcc.type.definition.element.Element;
+
+@FunctionalInterface
+public interface GraphGenFilter {
+    boolean accept(Element element, Phase phase);
+}

--- a/driver/src/main/java/cc/quarkus/qcc/driver/Phase.java
+++ b/driver/src/main/java/cc/quarkus/qcc/driver/Phase.java
@@ -8,20 +8,42 @@ public enum Phase {
     /**
      * The first stage, where classes are loaded and initialized.
      */
-    ADD,
+    ADD ("add"),
     /**
      * The second stage where closed-world analysis is done and all build-time code is eliminated.
      */
-    ANALYZE,
+    ANALYZE ("analyze"),
     /**
      * The third stage where high level nodes such as type IDs, invocations, and field access are lowered to
      * backend-compatible representations.
      */
-    LOWER,
+    LOWER ("lower"),
     /**
      * The final stage where all reachable elements and nodes are visited by the back end generator(s) to produce
      * a runnable image.
      */
-    GENERATE,
+    GENERATE ("generate"),
     ;
+
+    private final String phase;
+
+    Phase(String phase) {
+        this.phase = phase;
+    }
+
+    public String toString() {
+        return phase;
+    }
+
+    public static Phase getPhase(String phase) {
+        if (phase.equalsIgnoreCase("add")) {
+            return ADD;
+        } else if (phase.equalsIgnoreCase("analyze")) {
+            return ANALYZE;
+        } else if (phase.equalsIgnoreCase("lower")) {
+            return LOWER;
+        } else {
+            return GENERATE;
+        }
+    }
 }


### PR DESCRIPTION
Added following set of options to control generation of node graph of
the methods:
1. -g or --gen-graph : this is mandatory option if the user wants to
generate graph.
2. -m or --methods : this option allows to control the methods for
which graphs are generated. If not specified, then the default value is
all methods.
Format of the methods is:
	`<package name>/<class name>.<method name><method descriptor>`
        eg `my/example/package/Test.foo()V`
3 -p or --phase : this option allows to control the compilation phase
for which graphs are generated. If not specified, then the default value
is all phases.

Examples:
- Generate graphs for all methods in all phases
	`$ jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT -g <other args>`

- Generate graphs for `hello/world/Main.main()I` method for all phases
	`$ jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT -g -m
"hello/world/Main.main()I" <other args>`

- Generate graphs for all methods in add and analyze phase
	`$ jbang cc.quarkus:qcc-main:1.0.0-SNAPSHOT -g -p add,analyze
<other args>`

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>