### PR TITLE
Fix couple of bugs in exception handlers

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/MethodParser.java
@@ -184,7 +184,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     gf.begin(block);
                     processNewBlock();
                 } else {
-                    processBlock(from);
+                    processBlock(innerFrom);
                 }
                 // restore everything like nothing happened...
                 buffer.position(pos);

--- a/plugins/optimization/src/main/java/cc/quarkus/qcc/plugin/opt/PhiOptimizerVisitor.java
+++ b/plugins/optimization/src/main/java/cc/quarkus/qcc/plugin/opt/PhiOptimizerVisitor.java
@@ -53,7 +53,7 @@ public class PhiOptimizerVisitor implements NodeVisitor.Delegating<Node.Copier, 
             }
         }
         // *no* inputs; should be impossible!
-        context.error("internal: phi block with no inputs");
+        context.error("internal: phi block with no inputs (element: " + node.getElement() + ")");
         return context.getLiteralFactory().literalOfNull();
     }
 }

--- a/plugins/try-catch/src/main/java/cc/quarkus/qcc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
+++ b/plugins/try-catch/src/main/java/cc/quarkus/qcc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
@@ -77,7 +77,7 @@ public class SynchronizedMethodBasicBlockBuilder extends DelegatingBasicBlockBui
                 // generate the new handler body
                 begin(label);
                 // release the lock
-                monitorEnter(monitor);
+                monitorExit(monitor);
                 // hopefully the delegate simply rethrows
                 BasicBlock ourFrom = goto_(delegate.getHandler());
                 delegate.enterHandler(ourFrom, phi);


### PR DESCRIPTION
1. Source block for a catch block is not correctly set.
2. Incorret monitorEnter() call in the handler set up by
SynchronizedMethodBasicBlockBuilder.

Another change is to display the element name in the compilation error
message when PhiOptimizerVisitor reaches unexpected condition.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>