### PR TITLE
Add intrinsic for ClassLoader.registerNatives()

### DIFF
--- a/plugins/intrinsics/src/main/java/cc/quarkus/qcc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/cc/quarkus/qcc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -47,6 +47,7 @@ public final class CoreIntrinsics {
     public static void register(CompilationContext ctxt) {
         registerJavaLangClassIntrinsics(ctxt);
         registerJavaLangStringUTF16Intrinsics(ctxt);
+        registerJavaLangClassLoaderIntrinsics(ctxt);
         registerJavaLangSystemIntrinsics(ctxt);
         registerJavaLangThreadIntrinsics(ctxt);
         registerJavaLangThrowableIntrinsics(ctxt);
@@ -147,6 +148,20 @@ public final class CoreIntrinsics {
         } catch (IOException e) {
             ctxt.error(e, "Failed to probe target endianness");
         }
+    }
+
+    public static void registerJavaLangClassLoaderIntrinsics(CompilationContext ctxt) {
+
+        Intrinsics intrinsics = Intrinsics.get(ctxt);
+        ClassContext classContext = ctxt.getBootstrapClassContext();
+
+        ClassTypeDescriptor jlclDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/ClassLoader");
+
+        MethodDescriptor emptyToVoid = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of());
+
+        StaticIntrinsic registerNatives = (builder, owner, name, descriptor, arguments) -> builder.nop();
+
+        intrinsics.registerIntrinsic(jlclDesc, "registerNatives", emptyToVoid, registerNatives);
     }
 
     public static void registerJavaLangSystemIntrinsics(CompilationContext ctxt) {


### PR DESCRIPTION
Breaks compilation, presumably due to more interesting code being reachable.