### PR TITLE
Add null test in appendAfterAddressSpace

### DIFF
--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractFunction.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractFunction.java
@@ -176,8 +176,10 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
     }
 
     void appendAfterAddressSpace(final Appendable target) throws IOException {
-        returnType.appendTo(target);
-        target.append(' ');
+        if(returnType != null) {
+            returnType.appendTo(target);
+            target.append(' ');
+        }
         appendAfterReturnType(target);
     }
 


### PR DESCRIPTION
Depending on timing, appendAfterAddressSpace() can cause NullPointerException because returnType is not set until returns() is called.   Note that appendAfterAddressSpace() is also called from AbstructFunciton .toString(), so this method can be called before all fields are appropriately filled in.