### PR TITLE
CurrentThreadRead node does not get added to the dependency list

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/SimpleBasicBlockBuilder.java
@@ -409,7 +409,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
 
     public Value currentThread() {
         ClassObjectType type = element.getEnclosingType().getContext().findDefinedType("java/lang/Thread").validate().getClassType();
-        return new CurrentThreadRead(callSite, element, line, bci, requireDependency(), type.getReference());
+        return asDependency(new CurrentThreadRead(callSite, element, line, bci, requireDependency(), type.getReference()));
     }
 
     public PhiValue phi(final ValueType type, final BlockLabel owner) {


### PR DESCRIPTION
CurrentThreadRead, being an OrderedNode, should be part of the
dependency list.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>