### PR TITLE
populate class itables and vtable with error stubs

### DIFF
--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -53,6 +53,7 @@ import cc.quarkus.qcc.plugin.lowering.InvocationLoweringBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.lowering.StaticFieldLoweringBasicBlockBuilder;
 import cc.quarkus.qcc.plugin.lowering.ThrowExceptionHelper;
 import cc.quarkus.qcc.plugin.lowering.ThrowLoweringBasicBlockBuilder;
+import cc.quarkus.qcc.plugin.lowering.VMHelpersSetupHook;
 import cc.quarkus.qcc.plugin.main_method.AddMainClassHook;
 import cc.quarkus.qcc.plugin.main_method.MainMethod;
 import cc.quarkus.qcc.plugin.native_.ConstTypeResolver;
@@ -242,6 +243,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPreHook(Phase.ADD, CoreIntrinsics::register);
                                 builder.addPreHook(Phase.ADD, Layout::get);
                                 builder.addPreHook(Phase.ADD, ThrowExceptionHelper::get);
+                                builder.addPreHook(Phase.ADD, new VMHelpersSetupHook());
                                 builder.addPreHook(Phase.ADD, new AddMainClassHook());
                                 if (nogc) {
                                     builder.addPreHook(Phase.ADD, new NoGcSetupHook());

--- a/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/VMHelpersSetupHook.java
+++ b/plugins/lowering/src/main/java/cc/quarkus/qcc/plugin/lowering/VMHelpersSetupHook.java
@@ -1,0 +1,19 @@
+package cc.quarkus.qcc.plugin.lowering;
+
+import java.util.function.Consumer;
+
+import cc.quarkus.qcc.context.CompilationContext;
+
+/**
+ * Unconditionally register VMHelper methods that we may not actually refer to until lowering.
+ */
+public class VMHelpersSetupHook implements Consumer<CompilationContext> {
+    public void accept(final CompilationContext ctxt) {
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseAbstractMethodError"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArithmeticException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArrayIndexOutOfBoundsException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseNullPointerException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError"));
+    }
+}

--- a/runtime/main/src/main/java/cc/quarkus/qcc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/cc/quarkus/qcc/runtime/main/VMHelpers.java
@@ -65,6 +65,11 @@ public final class VMHelpers {
     }
 
     // TODO: mark this with a "NoInline" annotation
+    static void raiseAbstractMethodError() {
+        throw new AbstractMethodError();
+    }
+
+    // TODO: mark this with a "NoInline" annotation
     static void raiseArithmeticException() {
         throw new ArithmeticException();
     }


### PR DESCRIPTION
Clear out the lingering todos in corner-cases of the invokevirtual and invokeinterface implementations.
