### PR TITLE
Support signext/zeroext for integer subtypes in function args/params.

### DIFF
--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Function.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Function.java
@@ -1,5 +1,7 @@
 package cc.quarkus.qcc.machine.llvm;
 
+import cc.quarkus.qcc.machine.llvm.op.Call;
+
 /**
  *
  */
@@ -42,6 +44,10 @@ public interface Function extends Metable {
         Parameter param(LLValue type);
 
         Parameter name(String name);
+
+        Parameter signExt();
+
+        Parameter zeroExt();
 
         LLValue type();
 

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractFunction.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractFunction.java
@@ -8,7 +8,9 @@ import cc.quarkus.qcc.machine.llvm.DllStorageClass;
 import cc.quarkus.qcc.machine.llvm.Function;
 import cc.quarkus.qcc.machine.llvm.Linkage;
 import cc.quarkus.qcc.machine.llvm.LLValue;
+import cc.quarkus.qcc.machine.llvm.SignExtension;
 import cc.quarkus.qcc.machine.llvm.Visibility;
+import cc.quarkus.qcc.machine.llvm.op.Call;
 import io.smallrye.common.constraint.Assert;
 
 abstract class AbstractFunction extends AbstractMetable implements Function {
@@ -245,6 +247,7 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
         final ParameterImpl prev;
         final AbstractFunction function;
         final AbstractValue type;
+        SignExtension ext = SignExtension.none;
 
         ParameterImpl(final ParameterImpl prev, final AbstractFunction function, final AbstractValue type) {
             this.prev = prev;
@@ -279,10 +282,23 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
                 target.append(',').append(' ');
             }
             type.appendTo(target);
+            if (ext != SignExtension.none) {
+                target.append(' ').append(ext.name());
+            }
             if (name != null) {
                 target.append(' ').append('%').append(name);
             }
             return target;
+        }
+
+        public ParameterImpl signExt() {
+            ext = SignExtension.signext;
+            return this;
+        }
+
+        public ParameterImpl zeroExt() {
+            ext = SignExtension.zeroext;
+            return this;
         }
     }
 }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/CallImpl.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/CallImpl.java
@@ -149,14 +149,14 @@ final class CallImpl extends AbstractYieldingInstruction implements Call {
                 prev.appendTo(target);
                 target.append(',').append(' ');
             }
-            if (ext != SignExtension.none) {
-                target.append(ext.name()).append(' ');
-            }
             if (inReg) {
                 target.append("inreg").append(' ');
             }
             type.appendTo(target);
             target.append(' ');
+            if (ext != SignExtension.none) {
+                target.append(ext.name()).append(' ');
+            }
             value.appendTo(target);
             return target;
         }


### PR DESCRIPTION
Add signext/zeroext between type and parameter name in function declaration and function call.
Java types (and corresponding LLValue) to add zeroext are `boolean` (i1) and `char` (i16), and those to add signext are `byte` (i8) and `short` (i16).

Support for return type will be added in a separate pull request.