### PR TITLE
initialize ReferenceArrayObject specific portions of object header

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/ReferenceArrayObjectType.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/ReferenceArrayObjectType.java
@@ -55,7 +55,7 @@ public final class ReferenceArrayObjectType extends ArrayObjectType {
         return elementType;
     }
 
-    public ValueType getLeafElementType() {
+    public ObjectType getLeafElementType() {
         if (elementType instanceof ReferenceArrayObjectType) {
             return ((ReferenceArrayObjectType) elementType).getLeafElementType();
         } else {

--- a/plugins/gc/nogc/src/main/java/cc/quarkus/qcc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
+++ b/plugins/gc/nogc/src/main/java/cc/quarkus/qcc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
@@ -20,6 +20,7 @@ import cc.quarkus.qcc.type.IntegerType;
 import cc.quarkus.qcc.type.ObjectType;
 import cc.quarkus.qcc.type.PhysicalObjectType;
 import cc.quarkus.qcc.type.ReferenceArrayObjectType;
+import cc.quarkus.qcc.type.ReferenceType;
 import cc.quarkus.qcc.type.TypeType;
 import cc.quarkus.qcc.type.ValueType;
 import cc.quarkus.qcc.type.WordType;
@@ -95,7 +96,9 @@ public class NoGcBasicBlockBuilder extends DelegatingBasicBlockBuilder {
 
         store(instanceFieldOf(arrayHandle, layout.getArrayLengthField()), truncate(size, ctxt.getTypeSystem().getSignedInteger32Type()), MemoryAtomicityMode.UNORDERED);
         if (arrayType instanceof ReferenceArrayObjectType) {
-            ctxt.warning(getLocation(),"Skipping initialization of reference array header fields");
+            ReferenceArrayObjectType refArrayType = (ReferenceArrayObjectType)arrayType;
+            store(instanceFieldOf(arrayHandle, layout.getRefArrayDimensionsField()), lf.literalOf(refArrayType.getDimensionCount()), MemoryAtomicityMode.UNORDERED);
+            store(instanceFieldOf(arrayHandle, layout.getRefArrayElementTypeIdField()), lf.literalOfType(refArrayType.getElementObjectType()), MemoryAtomicityMode.UNORDERED);
         }
         return arrayPtr;
     }

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -47,6 +47,7 @@ import cc.quarkus.qcc.type.CompoundType;
 import cc.quarkus.qcc.type.FloatType;
 import cc.quarkus.qcc.type.FunctionType;
 import cc.quarkus.qcc.type.IntegerType;
+import cc.quarkus.qcc.type.ObjectType;
 import cc.quarkus.qcc.type.PhysicalObjectType;
 import cc.quarkus.qcc.type.PointerType;
 import cc.quarkus.qcc.type.ReferenceType;
@@ -327,7 +328,7 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue> {
     }
 
     public LLValue visit(Void param, TypeLiteral node) {
-        return Values.intConstant(((PhysicalObjectType)node.getValue()).getDefinition().validate().getTypeId());
+        return Values.intConstant(((ObjectType)node.getValue()).getDefinition().validate().getTypeId());
     }
 
     public LLValue visitUnknown(final Void param, final Value node) {

--- a/plugins/reachability/src/main/java/cc/quarkus/qcc/plugin/reachability/RTAInfo.java
+++ b/plugins/reachability/src/main/java/cc/quarkus/qcc/plugin/reachability/RTAInfo.java
@@ -63,6 +63,10 @@ public class RTAInfo {
 
     public boolean isLiveInterface(ValidatedTypeDefinition type) { return interfaceHierarchy.containsKey(type); }
 
+    public void makeInterfaceLive(ValidatedTypeDefinition type) {
+        interfaceHierarchy.computeIfAbsent(type, t -> ConcurrentHashMap.newKeySet());
+    }
+
     public void addInterfaceEdge(ValidatedTypeDefinition child, ValidatedTypeDefinition parent) {
         interfaceHierarchy.computeIfAbsent(parent, t -> ConcurrentHashMap.newKeySet()).add(child);
     }


### PR DESCRIPTION
Initialize the dimensions and elementType fields of the ReferenceArray
object header for one dimensional arrays of classes.

Not handled: arrays of interface type and multi-dimensional arrays.