### PR TITLE
Support signext/zeroext for integer subtypes in function retrun type

### DIFF
--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Function.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/Function.java
@@ -32,6 +32,10 @@ public interface Function extends Metable {
 
     Function comment(String comment);
 
+    Function signExt();
+
+    Function zeroExt();
+
     LLValue asGlobal();
 
     interface Parameter {

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractFunction.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/AbstractFunction.java
@@ -21,6 +21,8 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
     CallingConvention callingConvention = CallingConvention.C;
     AddressNaming addressNaming = AddressNaming.NAMED;
     AbstractValue returnType;
+    SignExtension ext = SignExtension.none;
+
     int addressSpace = 0;
     // todo: return type attribute
     int alignment = 0;
@@ -37,6 +39,16 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
         Assert.checkNotNullParam("returnType", returnType);
         // todo with attributes...
         this.returnType = (AbstractValue) returnType;
+        return this;
+    }
+
+    public Function signExt() {
+        ext = SignExtension.signext;
+        return this;
+    }
+
+    public Function zeroExt() {
+        ext = SignExtension.zeroext;
         return this;
     }
 
@@ -179,6 +191,10 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
 
     void appendAfterAddressSpace(final Appendable target) throws IOException {
         if(returnType != null) {
+            if(ext != SignExtension.none) {
+                target.append(ext.name());
+                target.append(' ');
+            }
             returnType.appendTo(target);
             target.append(' ');
         }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/CallImpl.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/CallImpl.java
@@ -18,6 +18,7 @@ final class CallImpl extends AbstractYieldingInstruction implements Call {
     Set<FastMathFlag> flags = Set.of();
     TailType tailType = TailType.notail;
     CallingConvention cconv = CallingConvention.C;
+    SignExtension ext = SignExtension.none;
     ArgImpl lastArg;
     int addressSpace;
 
@@ -70,6 +71,16 @@ final class CallImpl extends AbstractYieldingInstruction implements Call {
         return this;
     }
 
+    public Call signExt() {
+        ext = SignExtension.signext;
+        return this;
+    }
+
+    public Call zeroExt() {
+        ext = SignExtension.zeroext;
+        return this;
+    }
+
     public Argument arg(final LLValue type, final LLValue value) {
         return lastArg = new ArgImpl(this, lastArg, (AbstractValue) type, (AbstractValue) value);
     }
@@ -91,6 +102,9 @@ final class CallImpl extends AbstractYieldingInstruction implements Call {
         // todo ret attrs
         if (addressSpace != 0) {
             target.append("addrspace").append('(').append(Integer.toString(addressSpace)).append(')').append(' ');
+        }
+        if(ext != SignExtension.none) {
+            target.append(ext.name()).append(' ');
         }
         type.appendTo(target).append(' ');
         function.appendTo(target);

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/InvokeImpl.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/impl/InvokeImpl.java
@@ -74,6 +74,14 @@ final class InvokeImpl extends AbstractYieldingInstruction implements Call {
         return this;
     }
 
+    public Call signExt() {
+        throw new IllegalArgumentException("Use CallImpl instance to record signext attribute");
+    }
+
+    public Call zeroExt() {
+        throw new IllegalArgumentException("Use CallImpl instance to record zeronext attribute");
+    }
+
     public Argument arg(final LLValue type, final LLValue value) {
         return lastArg = new ArgImpl(this, lastArg, (AbstractValue) type, (AbstractValue) value);
     }

--- a/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/op/Call.java
+++ b/machine/llvm/src/main/java/cc/quarkus/qcc/machine/llvm/op/Call.java
@@ -22,6 +22,10 @@ public interface Call extends YieldingInstruction {
 
     // todo ret attrs
 
+    Call signExt();
+
+    Call zeroExt();
+
     Call addrSpace(int num);
 
     Call comment(String comment);

--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -154,7 +154,17 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void, Ge
             }
             mappedValues.put(value, param.asValue());
         }
-        func.returns(map(funcType.getReturnType()));
+        ValueType retType = funcType.getReturnType();
+        func.returns(map(retType));
+        if(retType instanceof IntegerType && ((IntegerType)retType).getMinBits() < 32) {
+            if(retType instanceof SignedIntegerType) {
+                func.signExt();
+            } else {
+                func.zeroExt();
+            }
+        } else if(retType instanceof BooleanType) {
+            func.zeroExt();
+        }
         map(entryBlock);
     }
 
@@ -643,6 +653,16 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void, Ge
                 arg.zeroExt();
             }
         }
+        ValueType retType = functionType.getReturnType();
+        if(retType instanceof IntegerType && ((IntegerType)retType).getMinBits() < 32) {
+            if(retType instanceof SignedIntegerType) {
+                call.signExt();
+            } else {
+                call.zeroExt();
+            }
+        } else if(retType instanceof BooleanType) {
+            call.zeroExt();
+        }
         return call.asLocal();
     }
 
@@ -670,6 +690,16 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void, Ge
             } else if (type instanceof BooleanType) {
                 arg.zeroExt();
             }
+        }
+        ValueType retType = functionType.getReturnType();
+        if(retType instanceof IntegerType && ((IntegerType)retType).getMinBits() < 32) {
+            if(retType instanceof SignedIntegerType) {
+                call.signExt();
+            } else {
+                call.zeroExt();
+            }
+        } else if(retType instanceof BooleanType) {
+            call.zeroExt();
         }
         return call.asLocal();
     }


### PR DESCRIPTION
This is a patch to support signext/zeroext attribute in function return type.

I had to implement `signext()`/`zeroext()` in `InvokeImpl` since they are added in `Call` interface, though sign extension attribute should be get from `Function` instance.  So my implementation throws `IllegalArgumentException`.  Please give me comments if there is more suitable way to report an error.