### PR TITLE
Compute unsigned short indexes correctly

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassMethodInfo.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/ClassMethodInfo.java
@@ -713,7 +713,7 @@ final class ClassMethodInfo {
         int high = getEntryPointCount() - 1;
         while (low <= high) {
             int mid = (low + high) >>> 1;
-            int midVal = entryPoints[mid];
+            int midVal = getEntryPointTarget(mid);
             if (midVal < target) {
                 low = mid + 1;
             } else if (midVal > target) {

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/LineNumberTable.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/classfile/LineNumberTable.java
@@ -93,7 +93,7 @@ final class LineNumberTable {
         codeAttr.position(codeAttr.position() + codeLen);
 
         // Skip exception_table
-        short exTableLen = codeAttr.getShort();
+        int exTableLen = codeAttr.getShort() & 0xffff;
         codeAttr.position(codeAttr.position() + exTableLen * 8);
 
         int attrCnt = codeAttr.getShort() & 0xffff;


### PR DESCRIPTION
* It avoids endless loops that lead to memory leaks.