### PR TITLE
fix NPE when running without specifying any optional arguments

### DIFF
--- a/main/src/main/java/cc/quarkus/qcc/main/Main.java
+++ b/main/src/main/java/cc/quarkus/qcc/main/Main.java
@@ -440,7 +440,7 @@ public class Main implements Callable<DiagnosticContext> {
         private GraphGenArgs graphGenArgs;
 
         @CommandLine.ArgGroup(exclusive = false, heading = "Options for controlling optimizations%n")
-        private OptArgs optArgs;
+        private OptArgs optArgs = new OptArgs();
 
         private GraphGenConfig graphGenConfig = new GraphGenConfig();
 


### PR DESCRIPTION
Fixes: 
```
Daves-MacBook-Pro:tests dgrove$ qcc.sh Cast
NOTE: Picked up JDK_JAVA_OPTIONS: -Xss8m
[jbang] [WARN] Detected missing or out-of-date dependencies in cache.
[jbang] Resolving dependencies...
[jbang]     Resolving cc.quarkus:qcc-main:1.0.0-SNAPSHOT...Done
[jbang] Dependencies resolved
[jbang] [WARN] Detected missing or out-of-date dependencies in cache.
[jbang] Resolving dependencies...
[jbang]     Resolving cc.quarkus:qcc-main:1.0.0-SNAPSHOT...Done
[jbang] Dependencies resolved
NOTE: Picked up JDK_JAVA_OPTIONS: -Xss8m
Exception in thread "main" java.lang.NullPointerException: Cannot read field "optMemoryTracking" because "optionsProcessor.optArgs" is null
	at cc.quarkus.qcc.main.Main.main(Main.java:373)
```
