### PR TITLE
Add Locatable interface

### DIFF
--- a/compiler/src/main/java/cc/quarkus/qcc/context/Locatable.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/context/Locatable.java
@@ -1,0 +1,15 @@
+package cc.quarkus.qcc.context;
+
+/**
+ * A context or element which can yield a location for diagnostic reporting.
+ */
+public interface Locatable {
+    /**
+     * Get the location to use for diagnostic reporting.
+     *
+     * @return the location (must not be {@code null})
+     */
+    Location getLocation();
+
+    Locatable EMPTY = () -> Location.NO_LOC;
+}

--- a/compiler/src/main/java/cc/quarkus/qcc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/graph/BasicBlockBuilder.java
@@ -2,6 +2,7 @@ package cc.quarkus.qcc.graph;
 
 import java.util.List;
 
+import cc.quarkus.qcc.context.Locatable;
 import cc.quarkus.qcc.context.Location;
 import cc.quarkus.qcc.graph.literal.BlockLiteral;
 import cc.quarkus.qcc.type.ArrayObjectType;
@@ -27,7 +28,7 @@ import cc.quarkus.qcc.type.descriptor.TypeDescriptor;
 /**
  * A program graph builder, which builds each basic block in succession and wires them together.
  */
-public interface BasicBlockBuilder {
+public interface BasicBlockBuilder extends Locatable {
     // context
 
     /**

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinition.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/DefinedTypeDefinition.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.ObjIntConsumer;
 
+import cc.quarkus.qcc.context.Locatable;
+import cc.quarkus.qcc.context.Location;
 import cc.quarkus.qcc.type.annotation.Annotation;
 import cc.quarkus.qcc.type.annotation.type.TypeAnnotationList;
 import cc.quarkus.qcc.type.definition.classfile.BootstrapMethod;
@@ -24,11 +26,17 @@ public interface DefinedTypeDefinition extends FieldResolver,
                                                MethodResolver,
                                                ConstructorResolver,
                                                InitializerResolver,
-                                               TypeParameterContext {
+                                               TypeParameterContext,
+                                               Locatable {
 
     ValidatedTypeDefinition validate() throws VerifyFailedException;
 
     ClassContext getContext();
+
+    @Override
+    default Location getLocation() {
+        return Location.builder().setClassInternalName(getInternalName()).build();
+    }
 
     String getInternalName();
 
@@ -58,7 +66,7 @@ public interface DefinedTypeDefinition extends FieldResolver,
                 return enclosing;
             }
         }
-        return EMPTY;
+        return TypeParameterContext.EMPTY;
     }
 
     int getModifiers();

--- a/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/Element.java
+++ b/compiler/src/main/java/cc/quarkus/qcc/type/definition/element/Element.java
@@ -1,11 +1,13 @@
 package cc.quarkus.qcc.type.definition.element;
 
+import cc.quarkus.qcc.context.Locatable;
+import cc.quarkus.qcc.context.Location;
 import cc.quarkus.qcc.type.definition.DefinedTypeDefinition;
 
 /**
  *
  */
-public interface Element {
+public interface Element extends Locatable {
     String getSourceFileName();
 
     int getModifiers();
@@ -19,6 +21,11 @@ public interface Element {
     <T, R> R accept(ElementVisitor<T, R> visitor, T param);
 
     DefinedTypeDefinition getEnclosingType();
+
+    @Override
+    default Location getLocation() {
+        return Location.builder().setElement(this).build();
+    }
 
     interface Builder {
         void setModifiers(int modifiers);


### PR DESCRIPTION
This will allow descriptor type resolvers (and other things) to improve their error reporting without having to speculatively construct a `Location`.  A follow-up PR will add a parameter of this type to various contextless methods which nevertheless can result in a compilation error or warning being reported.