### PR TITLE
Avoid duplicate processing of node in LLVMNodeVisitor

### DIFF
--- a/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/cc/quarkus/qcc/plugin/llvm/LLVMNodeVisitor.java
@@ -902,13 +902,16 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Void, Void, Ge
             return value.accept(this, null);
         }
 
-        LLValue oldBuilderDebugLocation = builder.setDebugLocation(dbg(value));
         LLBasicBlock oldBuilderBlock = builder.moveToBlock(map(schedule.getBlockForNode(value)));
 
-        mapped = value.accept(this, null);
-        mappedValues.put(value, mapped);
+        mapped = mappedValues.get(value);
+        if (mapped == null) {
+            LLValue oldBuilderDebugLocation = builder.setDebugLocation(dbg(value));
+            mapped = value.accept(this, null);
+            mappedValues.put(value, mapped);
+            builder.setDebugLocation(oldBuilderDebugLocation);
+        }
 
-        builder.setDebugLocation(oldBuilderDebugLocation);
         builder.moveToBlock(oldBuilderBlock);
         return mapped;
     }


### PR DESCRIPTION
When mapping a node in LLVMNodeVisitor#map(), it is possible that the
node gets mapped during the process of changing the basic block, if the
node belongs to the target basic block.
Therefore, after changing the basic block, there should be a check to
see if node has already been mapped so as to avoid duplicate processing of the
node.
This issue is manifested as duplicate instructions in the LLVM IR.
Eg the code java/lang/StringBuilder.ll has following duplicate
instructions:

```
 63 Ba:
 64   %LE = getelementptr %T.java.lang.StringBuilder, %T.java.lang.StringBuilder* %L6, i32 0, i32 4
 65   %LF = load i32, i32* %LE, align 4, !dbg !94
 66   %L15 = call i64 (i64, i64, i32, i32) @exact.java.lang.StringLatin1.newString.ref.1.class.java-lang-String.3.ref.1.prim_array.s8.s32.s32(i64 %thr0, i64 %L14, i32 0, i32 %LF), !dbg !93
 67   %L16 = call i64 (i64, i64, i32, i32) @exact.java.lang.StringLatin1.newString.ref.1.class.java-lang-String.3.ref.1.prim_array.s8.s32.s32(i64 %thr0, i64 %L14, i32 0, i32 %LF), !dbg !91
 68   br label %B9, !dbg !92
 69 Bb:
 70   %L10 = getelementptr %T.java.lang.StringBuilder, %T.java.lang.StringBuilder* %L6, i32 0, i32 3
 71   %L11 = load i64, i64* %L10, align 8, !dbg !98
 72   %L13 = getelementptr %T.java.lang.StringBuilder, %T.java.lang.StringBuilder* %L6, i32 0, i32 3
 73   %L14 = load i64, i64* %L13, align 8, !dbg !96
 74   br i1 %L0, label %Bc, label %Ba, !dbg !97
```

Line 67 is same as 66, and lines 72-73 are same as 70-71.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>