### PR TITLE
Fix in quoting escape sequnce of DOT attribute

### DIFF
--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -1083,7 +1083,7 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
             if (cp == '"') {
                 appendTo(output, '\\');
             } else if (cp == '\\') {
-                if((i+1) == orig.length() ||
+                if((i + 1) == orig.length() ||
                    "nlrGNTHE".indexOf(orig.codePointAt(i + 1)) == -1) {
                     appendTo(output, '\\');
                 }


### PR DESCRIPTION
Fixed `quote()` not to add an extra `\` when it is a part of a DOT escape sequence.