### PR TITLE
Stack allocations must be ordered

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -400,7 +400,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
     }
 
     public Value stackAllocate(final ValueType type, final Value count, final Value align) {
-        return new StackAllocation(callSite, element, line, bci, type, count, align);
+        return asDependency(new StackAllocation(callSite, element, line, bci, requireDependency(), type, count, align));
     }
 
     public ParameterValue parameter(final ValueType type, String label, final int index) {

--- a/compiler/src/main/java/org/qbicc/graph/StackAllocation.java
+++ b/compiler/src/main/java/org/qbicc/graph/StackAllocation.java
@@ -7,13 +7,15 @@ import org.qbicc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public final class StackAllocation extends AbstractValue {
+public final class StackAllocation extends AbstractValue implements OrderedNode {
+    private final Node dependency;
     private final ValueType type;
     private final Value count;
     private final Value align;
 
-    StackAllocation(final Node callSite, final ExecutableElement element, final int line, final int bci, final ValueType type, final Value count, final Value align) {
+    StackAllocation(final Node callSite, final ExecutableElement element, final int line, final int bci, Node dependency, final ValueType type, final Value count, final Value align) {
         super(callSite, element, line, bci);
+        this.dependency = dependency;
         this.type = type;
         this.count = count;
         this.align = align;
@@ -50,5 +52,10 @@ public final class StackAllocation extends AbstractValue {
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 }


### PR DESCRIPTION
This prevents them from being improperly moved outside of their loops (see also 51685d8382971ea635234c26c4f0e465c6455461)