### PR TITLE
Allow access to the root block from a BBB

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -123,6 +123,15 @@ public interface BasicBlockBuilder extends Locatable {
      */
     void finish();
 
+    /**
+     * Get the first (entry) block of the subprogram.  If the first block has not yet been terminated, an exception
+     * is thrown.
+     *
+     * @return the first (entry) block (not {@code null})
+     * @throws IllegalStateException if the first block has not yet been terminated
+     */
+    BasicBlock getFirstBlock() throws IllegalStateException;
+
     // values
 
     ParameterValue parameter(ValueType type, String label, int index);

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -88,6 +88,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         getDelegate().finish();
     }
 
+    public BasicBlock getFirstBlock() throws IllegalStateException {
+        return getDelegate().getFirstBlock();
+    }
+
     public BasicBlockBuilder getDelegate() {
         return delegate;
     }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -118,6 +118,15 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         }
     }
 
+    @Override
+    public BasicBlock getFirstBlock() throws IllegalStateException {
+        BlockLabel firstBlock = this.firstBlock;
+        if (firstBlock != null && firstBlock.hasTarget()) {
+            return BlockLabel.getTargetOf(firstBlock);
+        }
+        throw new IllegalStateException("First block not yet terminated");
+    }
+
     private void mark(BasicBlock block, BasicBlock from) {
         if (block.setReachableFrom(from)) {
             Terminator terminator = block.getTerminator();


### PR DESCRIPTION
This allows delegating BBBs to do a full-method analysis by intercepting `finish()`.