### PR TITLE
Make the bound thread field be a reference

### DIFF
--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -76,7 +76,7 @@ final class CompilationContextImpl implements CompilationContext {
         this.outputDir = outputDir;
         this.resolverFactories = resolverFactories;
         bootstrapClassContext = new ClassContextImpl(this, null);
-        qbiccBoundThread = getLiteralFactory().literalOfSymbol("_qbicc_bound_thread", getTypeSystem().getVoidType().getPointer().getPointer());
+        qbiccBoundThread = getLiteralFactory().literalOfSymbol("_qbicc_bound_thread", getTypeSystem().getVoidType().getPointer().asCollected().getPointer());
     }
 
     public <T> T getAttachment(final AttachmentKey<T> key) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -479,7 +479,7 @@ public final class CoreIntrinsics {
             //java.lang.Thread.nextThreadID
             Value thread = builder.new_(thrDesc);
             // immediately set the thread to be the current thread
-            builder.store(builder.pointerHandle(ctxt.getCurrentThreadLocalSymbolLiteral()), builder.valueConvert(thread, voidPtr), MemoryAtomicityMode.NONE);
+            builder.store(builder.pointerHandle(ctxt.getCurrentThreadLocalSymbolLiteral()), thread, MemoryAtomicityMode.NONE);
             // now start initializing
             DefinedTypeDefinition jlt = classContext.findDefinedType("java/lang/Thread");
             LoadedTypeDefinition jltVal = jlt.load();

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VM.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VM.java
@@ -18,7 +18,7 @@ public final class VM {
     @ThreadScoped
     @export
     @SuppressWarnings("unused")
-    static void_ptr _qbicc_bound_thread;
+    static Thread _qbicc_bound_thread;
 
     // Temporary manual implementation
     @SuppressWarnings("ManualArrayCopy")


### PR DESCRIPTION
References are now largely equivalent to collected (address space 1) pointers.  Putting a reference into an address space 0 pointer is therefore inappropriate and possibly incorrect.  This simple change ensures that the value of the global variable is a pointer in the correct address space.