### PR TITLE
More <clinit> groundwork

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
@@ -38,7 +38,21 @@ public interface LoadedTypeDefinition extends DefinedTypeDefinition {
 
     LoadedTypeDefinition getInterface(int index) throws IndexOutOfBoundsException;
 
+    /**
+     * Walk the locally declared interfaces
+     * 
+     * @return an array of LoadedTypeDefinition declared by this class.
+     */
     LoadedTypeDefinition[] getInterfaces();
+
+    /**
+     * Walk the set of interfaces implemented by this class and its superclasses.
+     *
+     * Note, interfaces may occur more than once in this walk.
+     *
+     * @param function the Consumer of the interfaces
+     */
+    void forEachInterfaceFullImplementedSet(Consumer<LoadedTypeDefinition> function);
 
     default boolean isSubtypeOf(LoadedTypeDefinition other) {
         return getType().isSubtypeOf(other.getType());

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -2,6 +2,7 @@ package org.qbicc.type.definition;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.qbicc.type.InterfaceObjectType;
 import org.qbicc.type.ObjectType;
@@ -111,6 +112,17 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
 
     public LoadedTypeDefinition[] getInterfaces() {
         return interfaces.clone();
+    }
+
+    public void forEachInterfaceFullImplementedSet(Consumer<LoadedTypeDefinition> function) {
+        for (LoadedTypeDefinition i : interfaces) {
+            function.accept(i);
+        }
+        // Walk up the heirarchy and visit each inteface from the the superclass
+        LoadedTypeDefinition superClass = getSuperClass();
+        if (superClass != null) {
+            superClass.forEachInterfaceFullImplementedSet(function);
+        }
     }
 
     public MethodElement[] getInstanceMethods() { return instanceMethods; }

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -43,6 +43,7 @@ import org.qbicc.plugin.gc.nogc.NoGcSetupHook;
 import org.qbicc.plugin.gc.nogc.NoGcTypeSystemConfigurator;
 import org.qbicc.plugin.instanceofcheckcast.InstanceOfCheckCastBasicBlockBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayBuilder;
+import org.qbicc.plugin.instanceofcheckcast.SupersDisplayEmitter;
 import org.qbicc.plugin.intrinsics.IntrinsicBasicBlockBuilder;
 import org.qbicc.plugin.intrinsics.core.CoreIntrinsics;
 import org.qbicc.plugin.layout.Layout;
@@ -358,6 +359,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, LowerVerificationBasicBlockBuilder::new);
                                 builder.addElementVisitor(Phase.LOWER, new DotGenerator(Phase.LOWER, graphGenConfig));
 
+                                builder.addPreHook(Phase.GENERATE, new SupersDisplayEmitter());
                                 builder.addPreHook(Phase.GENERATE, new DispatchTableEmitter());
                                 builder.addPreHook(Phase.GENERATE, new LLVMGenerator(isPie ? 2 : 0, isPie ? 2 : 0));
 

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -41,6 +41,7 @@ import org.qbicc.plugin.gc.nogc.NoGcBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcMultiNewArrayBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcSetupHook;
 import org.qbicc.plugin.gc.nogc.NoGcTypeSystemConfigurator;
+import org.qbicc.plugin.instanceofcheckcast.ClassInitializerRegister;
 import org.qbicc.plugin.instanceofcheckcast.InstanceOfCheckCastBasicBlockBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayEmitter;
@@ -329,6 +330,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 }
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addElementVisitor(Phase.ANALYZE, new DotGenerator(Phase.ANALYZE, graphGenConfig));
+                                builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
                                 builder.addPostHook(Phase.ANALYZE, new DispatchTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new HeapSerializer());

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/ClassInitializerRegister.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/ClassInitializerRegister.java
@@ -1,0 +1,54 @@
+package org.qbicc.plugin.instanceofcheckcast;
+
+import java.util.function.Consumer;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.plugin.reachability.RTAInfo;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.InitializerElement;
+
+/**
+ * Register all reachable class's class initalizer methods as entrypoints
+ * so they survive to be lowered into functions.
+ * This is required as we lose info after ReachabilityBlockBuilder required
+ * to otherwise keep them alive.
+ * 
+ * Eventually, this will need to skip an class initializer that was run as
+ * part of the build process.
+ */
+public class ClassInitializerRegister implements Consumer<CompilationContext>  {
+
+    @Override
+    public void accept(CompilationContext ctxt) {
+        RTAInfo rtaInfo = RTAInfo.get(ctxt);
+		
+        ClassContext classContext = ctxt.getBootstrapClassContext();
+        DefinedTypeDefinition jloDef = classContext.findDefinedType("java/lang/Object");
+        LoadedTypeDefinition jlo = jloDef.load();
+
+        // Code below uses #hasMethodBody() to filter out the empty
+        // class initializers and to avoid processing internal arrays
+
+        // Register Object's <clinit> if it exists
+        InitializerElement object_clinit = jlo.getInitializer();
+        if (object_clinit != null && object_clinit.hasMethodBody()) {
+            ctxt.registerEntryPoint(object_clinit);
+        }
+        // Visit all live subclasses and register their <clinit>
+		rtaInfo.visitLiveSubclassesPreOrder(jlo, sc -> {
+            InitializerElement initializer = sc.getInitializer();
+            if (initializer != null && initializer.hasMethodBody()) {
+                ctxt.registerEntryPoint(initializer);
+            }
+        });
+        // Visit all live interfaces and register their <clinit>
+        rtaInfo.visitLiveInterfaces(sc -> {
+            InitializerElement initializer = sc.getInitializer();
+            if (initializer != null && initializer.hasMethodBody()) {
+                ctxt.registerEntryPoint(initializer);
+            }
+        });
+    }
+}

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/ClassInitializerRegister.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/ClassInitializerRegister.java
@@ -37,7 +37,7 @@ public class ClassInitializerRegister implements Consumer<CompilationContext>  {
             ctxt.registerEntryPoint(object_clinit);
         }
         // Visit all live subclasses and register their <clinit>
-		rtaInfo.visitLiveSubclassesPreOrder(jlo, sc -> {
+        rtaInfo.visitLiveSubclassesPreOrder(jlo, sc -> {
             InitializerElement initializer = sc.getInitializer();
             if (initializer != null && initializer.hasMethodBody()) {
                 ctxt.registerEntryPoint(initializer);

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
@@ -84,5 +84,6 @@ public class SupersDisplayBuilder implements Consumer<CompilationContext> {
         tables.writeTypeIdToClasses();
 
         tables.defineTypeIdStructAndGlobalArray(jlo);
+        tables.defineClinitStatesGlobal(jlo);
     }
 }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayBuilder.java
@@ -83,7 +83,6 @@ public class SupersDisplayBuilder implements Consumer<CompilationContext> {
 
         tables.writeTypeIdToClasses();
 
-        // emit the typeid[] into Object's file
-        tables.emitTypeIdTable(jlo);
+        tables.defineTypeIdStructAndGlobalArray(jlo);
     }
 }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayEmitter.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayEmitter.java
@@ -1,0 +1,23 @@
+package org.qbicc.plugin.instanceofcheckcast;
+
+import java.util.function.Consumer;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+
+public class SupersDisplayEmitter implements Consumer<CompilationContext>  {
+
+	@Override
+    public void accept(CompilationContext ctxt) {
+        SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
+
+		ClassContext classContext = ctxt.getBootstrapClassContext();
+        DefinedTypeDefinition jloDef = classContext.findDefinedType("java/lang/Object");
+        LoadedTypeDefinition jlo = jloDef.load();
+
+		// emit the typeid[] into Object's file
+		tables.emitTypeIdTable(jlo);
+    }
+}

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayEmitter.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayEmitter.java
@@ -20,8 +20,7 @@ public class SupersDisplayEmitter implements Consumer<CompilationContext>  {
         // emit the typeid[] into Object's file
         tables.emitTypeIdTable(jlo);
 
-        // TODO: enable this when the final mising <clinit>s are tracked down
         // emit the initialization data
-        // tables.emitClinitStateTable(jlo);
+        tables.emitClinitStateTable(jlo);
     }
 }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayEmitter.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayEmitter.java
@@ -9,15 +9,19 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 
 public class SupersDisplayEmitter implements Consumer<CompilationContext>  {
 
-	@Override
+    @Override
     public void accept(CompilationContext ctxt) {
         SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
 
-		ClassContext classContext = ctxt.getBootstrapClassContext();
+        ClassContext classContext = ctxt.getBootstrapClassContext();
         DefinedTypeDefinition jloDef = classContext.findDefinedType("java/lang/Object");
         LoadedTypeDefinition jlo = jloDef.load();
 
-		// emit the typeid[] into Object's file
-		tables.emitTypeIdTable(jlo);
+        // emit the typeid[] into Object's file
+        tables.emitTypeIdTable(jlo);
+
+        // TODO: enable this when the final mising <clinit>s are tracked down
+        // emit the initialization data
+        // tables.emitClinitStateTable(jlo);
     }
 }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -20,8 +20,10 @@ import org.qbicc.plugin.reachability.RTAInfo;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.FunctionType;
+import org.qbicc.type.IntegerType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.UnsignedIntegerType;
+import org.qbicc.type.ValueType;
 import org.qbicc.type.CompoundType.Member;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -367,6 +369,30 @@ public class SupersDisplayTables {
         return List.of(literals);
     }
 
+    /**
+     * Flags:
+     * 1 - has clinit method
+     * 2 - declares default methods
+     * 4 - has default methods
+     */
+    Literal calculateTypeIdFlags(final UnsignedIntegerType type, LoadedTypeDefinition ltd) {
+        int flags = 0;
+        InitializerElement initializer = ltd.getInitializer();
+        if (initializer != null && initializer.hasMethodBody()) {
+            flags |= 1;
+        }
+        if (ltd.declaresDefaultMethods()) {
+            flags |= 2;
+        }
+        if (ltd.hasDefaultMethods()) {
+            flags |= 4;
+        }
+        
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        supersLog.debug("[[Flags] ID["+ ltd.getTypeId() + "] Flags = " + Integer.toBinaryString(flags) + ltd.getInternalName() + "]");
+        return lf.literalOf(type, flags);
+    }
+
     void defineTypeIdStructAndGlobalArray(LoadedTypeDefinition jlo) {
         TypeSystem ts = ctxt.getTypeSystem();
         UnsignedIntegerType u8 = ts.getUnsignedInteger8Type();
@@ -469,7 +495,7 @@ public class SupersDisplayTables {
                     members.get(1), lf.literalOf((UnsignedIntegerType)members.get(1).getType(), idRange.maximumSubtypeId),
                     members.get(2), lf.literalOf((UnsignedIntegerType)members.get(2).getType(), superTypeId),
                     members.get(3), lf.literalOf(interfaceBitsType, convertByteArrayToValuesList(lf, getImplementedInterfaceBits(vtd))),
-                    members.get(4), lf.literalOf((UnsignedIntegerType)members.get(4).getType(), 0)  /* TODO: calculate flags */
+                    members.get(4), calculateTypeIdFlags((UnsignedIntegerType)members.get(4).getType(), vtd)
                 )
             );
         }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -13,16 +13,20 @@ import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.object.Function;
 import org.qbicc.object.Section;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayTables.IdAndRange.Factory;
 import org.qbicc.plugin.reachability.RTAInfo;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.CompoundType;
+import org.qbicc.type.FunctionType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.UnsignedIntegerType;
+import org.qbicc.type.CompoundType.Member;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.generic.BaseTypeSignature;
 import io.smallrye.common.constraint.Assert;
@@ -48,6 +52,8 @@ public class SupersDisplayTables {
     static final String GLOBAL_TYPEID_ARRAY = "qbicc_typeid_array";
     private GlobalVariableElement typeIdArrayGlobal;
     private CompoundType typeIdStructType;
+
+    static final String GLOBAL_CLINIT_STATES_ARRAY = "qbicc_clinit_states";
 
     /** 
      * This class embodies the typeid for a class and the
@@ -509,6 +515,93 @@ public class SupersDisplayTables {
         Assert.assertTrue(idAndRange.typeid_index == (typeids.size() + 10));
         supersLog.debug("get_highest_typeid == " + (typeids.size() + 10));
         return typeids.size() + 10; // invalid zero + 8 prims + void
+    }
+
+    public void emitClinitStateTable(LoadedTypeDefinition jlo) {
+        // Structure will be laid out as two inline arrays:
+        // i8[] initStatus
+        // Function[] clinit_function_ptrs
+
+        TypeSystem ts = ctxt.getTypeSystem();
+        final int numElements = get_number_of_typeids();
+
+       // Sleazy way to get the function type for an Initializer
+       FunctionType clinit_function_type = null;
+       for (LoadedTypeDefinition ltd : typeids.keySet()) {
+            InitializerElement ie = ltd.getInitializer();
+            if (ie != null) {
+                clinit_function_type = ctxt.getFunctionTypeForElement(ie);
+                break;
+            }
+        }
+
+        ArrayType init_state_t = ts.getArrayType(ts.getUnsignedInteger8Type(), numElements);
+        ArrayType class_initializers_t = ts.getArrayType(clinit_function_type.getPointer(), numElements);
+        CompoundType clinit_state_t =  CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc_clinit_state")
+            .setOverallAlignment(ts.getPointerAlignment())
+            .addNextMember("init_state", init_state_t)
+            .addNextMember("class_initializers", class_initializers_t)
+            .build();
+
+        Section section = ctxt.getImplicitSection(jlo);
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        List<Literal> init_state_literals = new ArrayList<>();
+        List<Literal> class_initializers_literals = new ArrayList<>();
+        Literal uninitialized = lf.literalOf(0);
+        Literal initialized = lf.literalOf(1);
+        Literal nullInitializer = lf.zeroInitializerLiteralOfType(clinit_state_t.getMember("class_initializers").getType());
+         // poison
+        init_state_literals.add(uninitialized);
+        class_initializers_literals.add(nullInitializer);
+        // primitives
+        for (int i = 1; i < 10; i++) {
+            init_state_literals.add(initialized);
+            class_initializers_literals.add(nullInitializer);
+        }
+        // real types
+        typeids.entrySet().stream()
+            .sorted((a, b) -> a.getValue().typeid - b.getValue().typeid)
+            .forEach(es -> {            
+                LoadedTypeDefinition ltd = es.getKey();
+                Literal init_state = initialized;
+                Literal initializer = nullInitializer;
+                if (!isAlreadyInitialized(ltd)) {
+                    init_state = uninitialized;
+                    InitializerElement ie = ltd.getInitializer();
+                    if (ie != null && ie.hasMethodBody()) {
+                        FunctionType funType = ctxt.getFunctionTypeForElement(ie);
+                        Function impl = ctxt.getExactFunction(ie);
+                        if (!ie.getEnclosingType().load().equals(jlo)) {
+                            section.declareFunction(ie, impl.getName(), funType);
+                        }
+                        initializer = impl.getLiteral();
+                    }
+                }
+                init_state_literals.add(init_state);
+                class_initializers_literals.add(initializer);
+            }
+        );
+        Assert.assertTrue(init_state_literals.size() == numElements);
+  
+        ArrayType init_states = (ArrayType)clinit_state_t.getMember("init_state").getType();
+        ArrayType class_initializers = (ArrayType)clinit_state_t.getMember("class_initializers").getType();
+
+        Literal clinit_states = lf.literalOf(clinit_state_t, 
+            Map.of(
+                clinit_state_t.getMember(0), lf.literalOf(init_states, init_state_literals),
+                clinit_state_t.getMember(1), lf.literalOf(class_initializers, class_initializers_literals)
+            )
+        );
+        
+        /* Write the data into Object's section */
+        section.addData(null, GLOBAL_CLINIT_STATES_ARRAY, clinit_states);
+    }
+
+    // TODO: implement this for real
+    boolean isAlreadyInitialized(LoadedTypeDefinition ltd) {
+        return false;
     }
 }
 

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -411,7 +411,7 @@ public class SupersDisplayTables {
         List<CompoundType.Member> members = typeIdStruct.getMembers();
         
         Section section = ctxt.getImplicitSection(jlo);
-        Literal[] typeIdTable = new Literal[typeids.size() + 10]; // invalid zero + 8 prims + void
+        Literal[] typeIdTable = new Literal[get_number_of_typeids()];
         LiteralFactory literalFactory = ctxt.getLiteralFactory();
         
         /* Set up the implementedInterface[] for primitives */
@@ -496,6 +496,12 @@ public class SupersDisplayTables {
     public CompoundType getGlobalTypeIdStructType() {
         Assert.assertNotNull(typeIdStructType);
         return typeIdStructType;
+    }
+
+    public int get_number_of_typeids() {
+        Assert.assertTrue(idAndRange.typeid_index == (typeids.size() + 10));
+        supersLog.debug("get_highest_typeid == " + (typeids.size() + 10));
+        return typeids.size() + 10; // invalid zero + 8 prims + void
     }
 }
 

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -651,7 +651,7 @@ public final class CoreIntrinsics {
             ValueHandle initializers = builder.memberOf(builder.globalVariable(clinitStates), clinitStates_t.getMember("class_initializers"));
             Value typeIdInit = builder.load(builder.elementOf(initializers, typeId), MemoryAtomicityMode.UNORDERED);
 
-            return builder.callFunction(typeIdInit, List.of(builder.currentThread()));
+            return builder.callFunction(typeIdInit, List.of(builder.currentThread()), 0 /* flags */);
         };
         intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "call_class_initializer", typeIdVoidDesc, callClassInitializer);
 

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -527,6 +527,7 @@ public final class CoreIntrinsics {
         MethodDescriptor typeIdTypeIdBooleanDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of(typeIdDesc, typeIdDesc));
         MethodDescriptor clsTypeId = MethodDescriptor.synthesize(classContext, typeIdDesc, List.of(clsDesc));
         MethodDescriptor clsInt = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of(clsDesc));
+        MethodDescriptor IntDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of());
 
         StaticValueIntrinsic typeOf = (builder, owner, name, descriptor, arguments) ->
             builder.typeIdOf(builder.referenceHandle(arguments.get(0)));
@@ -622,6 +623,9 @@ public final class CoreIntrinsics {
         StaticValueIntrinsic getTypeIdFromClass = (builder, owner, name, descriptor, arguments) ->
             builder.load(builder.instanceFieldOf(builder.referenceHandle(arguments.get(0)), layout.getClassTypeIdField()), MemoryAtomicityMode.UNORDERED);
         intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_type_id_from_class", clsTypeId, getTypeIdFromClass);
+
+        StaticValueIntrinsic getNumberOfTypeIds = (builder, owner, name, descriptor, arguments) -> lf.literalOf(tables.get_number_of_typeids());
+        intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_number_of_typeids", IntDesc, getNumberOfTypeIds);
     }
 
     static void registerOrgQbiccRuntimeValuesIntrinsics(final CompilationContext ctxt) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -31,6 +31,7 @@ import org.qbicc.plugin.intrinsics.Intrinsics;
 import org.qbicc.plugin.intrinsics.StaticIntrinsic;
 import org.qbicc.plugin.intrinsics.StaticValueIntrinsic;
 import org.qbicc.plugin.layout.Layout;
+import org.qbicc.type.CompoundType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
@@ -86,6 +87,7 @@ public final class CoreIntrinsics {
         MethodDescriptor classToBool = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of(jlcDesc));
         MethodDescriptor emptyToVoid = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of());
         MethodDescriptor emptyToString = MethodDescriptor.synthesize(classContext, jlsDesc, List.of());
+        MethodDescriptor emptyToBool = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of());
         MethodDescriptor stringToClass = MethodDescriptor.synthesize(classContext, jlcDesc, List.of(jlsDesc));
         MethodDescriptor objToObj = MethodDescriptor.synthesize(classContext, jloDesc, List.of(jloDesc));
 
@@ -93,6 +95,9 @@ public final class CoreIntrinsics {
 
         // todo: this probably belongs in the class libraries rather than here
         StaticValueIntrinsic desiredAssertionStatus0 = (builder, owner, name, descriptor, arguments) ->
+            classContext.getLiteralFactory().literalOf(false);
+
+        InstanceValueIntrinsic desiredAssertionStatus =  (builder, kind, instance, owner, name, descriptor, arguments) -> 
             classContext.getLiteralFactory().literalOf(false);
 
         InstanceValueIntrinsic cast =  (builder, kind, instance, owner, name, descriptor, arguments) -> {
@@ -147,6 +152,7 @@ public final class CoreIntrinsics {
 
         intrinsics.registerIntrinsic(jlcDesc, "cast", objToObj, cast);
         intrinsics.registerIntrinsic(jlcDesc, "desiredAssertionStatus0", classToBool, desiredAssertionStatus0);
+        intrinsics.registerIntrinsic(jlcDesc, "desiredAssertionStatus", emptyToBool, desiredAssertionStatus);
         intrinsics.registerIntrinsic(jlcDesc, "registerNatives", emptyToVoid, registerNatives);
         intrinsics.registerIntrinsic(jlcDesc, "initClassName", emptyToString, initClassName);
         intrinsics.registerIntrinsic(jlcDesc, "getPrimitiveClass", stringToClass, getPrimitiveClass);
@@ -525,6 +531,7 @@ public final class CoreIntrinsics {
         MethodDescriptor typeIdTypeIdDesc = MethodDescriptor.synthesize(classContext, typeIdDesc, List.of(typeIdDesc));
         MethodDescriptor typeIdBooleanDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of(typeIdDesc));
         MethodDescriptor typeIdTypeIdBooleanDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of(typeIdDesc, typeIdDesc));
+        MethodDescriptor typeIdVoidDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of(typeIdDesc));
         MethodDescriptor clsTypeId = MethodDescriptor.synthesize(classContext, typeIdDesc, List.of(clsDesc));
         MethodDescriptor clsInt = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of(clsDesc));
         MethodDescriptor IntDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of());
@@ -626,6 +633,25 @@ public final class CoreIntrinsics {
 
         StaticValueIntrinsic getNumberOfTypeIds = (builder, owner, name, descriptor, arguments) -> lf.literalOf(tables.get_number_of_typeids());
         intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_number_of_typeids", IntDesc, getNumberOfTypeIds);
+
+        StaticIntrinsic callClassInitializer = (builder, owner, name, descriptor, arguments) -> {
+            Value typeId = arguments.get(0);
+        
+            // CompoundType clinit_state_t =  CompoundType.builder(ts)
+            //     .setTag(CompoundType.Tag.STRUCT)
+            //     .setName("qbicc_clinit_state")
+            //     .setOverallAlignment(ts.getPointerAlignment())
+            //     .addNextMember("init_state", init_state_t)
+            //     .addNextMember("class_initializers", class_initializers_t)
+            //     .build();
+
+            GlobalVariableElement clinitStates = tables.getAndRegisterGlobalClinitStateStruct(builder.getCurrentElement());
+            CompoundType clinitStates_t = (CompoundType) clinitStates.getType();
+            ValueHandle initializers = builder.memberOf(builder.globalVariable(clinitStates), clinitStates_t.getMember("class_initializers"));
+            Value typeIdInit = builder.load(builder.elementOf(initializers, typeId), MemoryAtomicityMode.UNORDERED);
+            return builder.callFunction(typeIdInit, List.of(builder.currentThread()));
+        };
+        intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "call_class_initializer", typeIdVoidDesc, callClassInitializer);
     }
 
     static void registerOrgQbiccRuntimeValuesIntrinsics(final CompilationContext ctxt) {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
@@ -45,5 +45,8 @@ public class VMHelpersSetupHook implements Consumer<CompilationContext> {
         for (int i=0; i < deser.getMethodCount(); i++) {
             ctxt.registerEntryPoint(deser.getMethod(i));
         }
+
+        // class initialization
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("initialize_class"));
     }
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -98,4 +98,16 @@ public class ObjectModel {
      * This will be 1 higher than the highest typeid
      */
     public static native int get_number_of_typeids();
+
+    /**
+     * Call the class initializer for this class if it hasn't already been
+     * called.
+     * 
+     * This operation is racy as the locking is managed by the ClinitState
+     * object in VMHelpers#initialize_class and should only be called by
+     * that method.
+     * 
+     * @param typeId the class to initialize
+     */
+    public static native void call_class_initializer(CNative.type_id typeId);
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -92,4 +92,10 @@ public class ObjectModel {
      * Does a typeId implement the argument interface?
      */
     public static native boolean does_implement(CNative.type_id valueTypeId, CNative.type_id interfaceTypeId);
+
+    /**
+     * Get the number of typeIds in the system.
+     * This will be 1 higher than the highest typeid
+     */
+    public static native int get_number_of_typeids();
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -110,4 +110,35 @@ public class ObjectModel {
      * @param typeId the class to initialize
      */
     public static native void call_class_initializer(CNative.type_id typeId);
+
+    static final int Flag_typeid_has_clinit = 1;
+    static final int Flag_typeid_declares_default_methods = 2;
+    static final int Flag_typeid_has_default_methods = 4;
+
+    /**
+     * Get the `flags` field from the qbicc_typeid_array for the given
+     * typeid.
+     * 
+     * Flags are:
+     * 1 - has clinit method
+     * 2 - declares default methods
+     * 4 - has default methods
+     * See SupersDisplayTables.calculateTypeIdFlags() for definitive list.
+     * 
+     * @param typeID the class to read the flags for
+     * @return the flags value
+     */
+    public static native int get_typeid_flags(CNative.type_id typeId);
+
+    public static boolean has_class_initializer(CNative.type_id typeId) {
+        return (get_typeid_flags(typeId) & Flag_typeid_has_clinit) == Flag_typeid_has_clinit;
+    }
+
+    public static boolean declares_default_methods(CNative.type_id typeId) {
+        return (get_typeid_flags(typeId) & Flag_typeid_declares_default_methods) == Flag_typeid_declares_default_methods;
+    }
+
+    public static boolean has_default_methods(CNative.type_id typeId) {
+        return (get_typeid_flags(typeId) & Flag_typeid_has_default_methods) == Flag_typeid_has_default_methods;
+    }
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -175,10 +175,14 @@ public final class VMHelpers {
     }
 
     // TODO: mark this with a "NoInline" annotation
-    static void raiseIncompatibleClassChangeError() { throw new IncompatibleClassChangeError(); }
+    static void raiseIncompatibleClassChangeError() {
+        throw new IncompatibleClassChangeError(); 
+    }
 
     // TODO: mark this with a "NoInline" annotation
-    static void raiseNegativeArraySizeException() { throw new NegativeArraySizeException(); }
+    static void raiseNegativeArraySizeException() {
+        throw new NegativeArraySizeException(); 
+    }
 
     // TODO: mark this with a "NoInline" annotation
     static void raiseNullPointerException() {
@@ -186,5 +190,7 @@ public final class VMHelpers {
     }
 
     // TODO: mark this with a "NoInline" annotation
-    static void raiseUnsatisfiedLinkError() { throw new UnsatisfiedLinkError(); }
+    static void raiseUnsatisfiedLinkError() {
+        throw new UnsatisfiedLinkError(); 
+    }
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -193,4 +193,188 @@ public final class VMHelpers {
     static void raiseUnsatisfiedLinkError() {
         throw new UnsatisfiedLinkError(); 
     }
-}
+ 
+    // TODO: mark with "must be build time initialized" annotation
+    static class ClinitState {
+        static final byte STATE_UNINITIALIZED = 0;
+        static final byte STATE_INPROGRESS = 1;
+        static final byte STATE_INITIALIZED = 2;
+        static final byte STATE_FAILED = 3;
+
+        Thread initializerThread;
+        Throwable errorInInitializer;
+        // Must be one of:
+        // 0 - uninitialized
+        // 1 - in-progress
+        // 2 - initialized
+        // 3 - failed
+        byte initializedState;
+
+        ClinitState(Thread currentThread) {
+            initializerThread = currentThread;
+            initializedState = STATE_UNINITIALIZED;
+        }
+
+        boolean beingInitializedByMe(Thread currentThread) {
+            return currentThread == initializerThread;
+        }
+
+        boolean isInitialized() {
+            return initializedState == STATE_INITIALIZED;
+        }
+
+        boolean isInProgress() {
+            return initializedState == STATE_INPROGRESS;
+        }
+
+        boolean isFailed() {
+            return initializedState == STATE_FAILED;
+        }
+
+        void setInProgress() {
+            assert initializedState == STATE_UNINITIALIZED;
+            initializedState = STATE_INPROGRESS;
+        }
+
+        void setFailed(Throwable t) {
+            errorInInitializer = t;
+            initializedState = STATE_FAILED;
+        }
+
+        void setInitialized() {
+            initializedState = STATE_INITIALIZED;
+            initializerThread = null;
+        }
+
+        /**
+         * Is initialization in a final state?
+         * Both Failed and Initialized are final states
+         * 
+         * @return true if it is, false otherwise
+         */
+        boolean isInTerminalInitializedState() {
+            switch(initializedState) {
+                case STATE_FAILED:
+                case STATE_INITIALIZED:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        Throwable initializationAlreadyFailed(type_id typeid) {
+            // TODO: convert type_id to a class name
+            NoClassDefFoundError e = new NoClassDefFoundError("initialization failed: " + typeid.intValue());
+            e.initCause(errorInInitializer);
+            throw e;
+        }
+    }
+    
+    // This probably needs to be an Object[] or we need to force ClinitState to be
+    // initialized at build time or there will be recursive issues - initializing
+    // depends on the array, but it depends on a not-yet initialized class.
+    // Eventually, array and elements will be build time intialized with null
+    // elements for classes that are already initailized.  Makes for a cheaper
+    // check as elements can be nulled when initialized.
+    static ClinitState[] clinitStates;
+
+    static void initialize_class(Thread currentThread, type_id typeid) throws Throwable {
+        ClinitState state;
+        // ==== Code in this section would be better done at build time
+        if (clinitStates == null) {
+            int size = ObjectModel.get_number_of_typeids();
+            synchronized(ClinitState.class) {
+                if (clinitStates == null) {
+                    clinitStates = new ClinitState[size];
+                }
+            }
+        }
+        int typeid_value = typeid.intValue();
+        ClinitState arrayState = clinitStates[typeid_value];
+        if (arrayState == null) {
+            state = new ClinitState(currentThread);
+            synchronized(clinitStates) {
+                arrayState = clinitStates[typeid_value];
+                if (arrayState == null) {
+                    clinitStates[typeid_value] = state;
+                } else {
+                    state = arrayState;
+                }
+            }
+        } else {
+            state = arrayState;
+        }
+        // ==== end better at build time section
+        assert state != null;
+        synchronized(state) { // state is the "LC"
+            if (state.isInProgress()) {
+                if (!state.beingInitializedByMe(currentThread)) {
+                    while (!state.isInTerminalInitializedState()) {
+                        // `C` is being initialized by another thread, wait on it
+                        try {
+                            state.wait();
+                        } catch (InterruptedException e) {
+                            // Don't repeat, keep waiting
+                        }
+                    }
+                } else {
+                    assert !state.isInTerminalInitializedState();
+                    // curentThread is in the process of initializing,
+                    // complete normally as this is a recursive request
+                    return;
+                }
+            }
+            
+            // Not an else if as both the current initializing thread and waiting
+            // threads need to execute this section
+            if (state.isInitialized()) {
+                // Successfully initialized, complete normally
+                return;
+            } else if (state.isFailed()) {
+                // release and throw NoClassDefFoundError
+                throw state.initializationAlreadyFailed(typeid);
+            } else {
+                assert state.beingInitializedByMe(currentThread);
+                state.setInProgress();
+            }
+        }
+        // LC is released at this point, and in-progress by current thread
+        // Static field preparation happens at build time
+        if (ObjectModel.is_class(typeid)) {
+            try {
+                // TODO; initialize the super classes
+                // TODO: initialize the super interfaces - may be issues with ordering requirements depending on the data we preserve
+            } catch (Throwable t) {
+                synchronized(state) {
+                    state.setFailed(t);
+                    state.notifyAll();;
+                }
+                throw t;
+            }
+        }
+        // Assertions are never enabled for images, so no check required
+        Error clinitThrowable = null;
+        try {
+            // TODO: call C's <clinit>
+        } catch (Throwable t) {
+            if (t instanceof Error) {
+                clinitThrowable = (Error)t;
+            } else {
+                clinitThrowable = new ExceptionInInitializerError(t);
+            }
+        }
+        synchronized(state) {
+            if (clinitThrowable == null) {
+                // completed successfully
+                state.setInitialized();
+            } else {
+                state.setFailed(clinitThrowable);
+            }
+            state.notifyAll();
+        }
+        if (clinitThrowable != null) {
+            throw clinitThrowable;
+        }
+        return;
+    }
+} 


### PR DESCRIPTION
Related to #458

* Lower the class initialization status and function pointer to the `<clinit>` method into a new structure:
```
qbicc_clinit_state {
    u8[typeid] clinitState;  // 0 or 1
    void (i8 addrspace(1)*)*[typeid]// <clinit> function pointers
}
```

* Sketch out the class initialization protocol as defined in the JVMS

* Ensure the full set of <clinit> methods are enqueued

* Refactoring of emitting the `qbicc_typeid_array`

* Register `<clinit>` methods as entrypoints so they persist to code generation

* Emit the `qbicc_clinit_state` table