### PR TITLE
Nullability overhaul

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/AbstractBooleanCompare.java
+++ b/compiler/src/main/java/org/qbicc/graph/AbstractBooleanCompare.java
@@ -6,7 +6,7 @@ import org.qbicc.type.definition.element.ExecutableElement;
 /**
  *
  */
-public abstract class AbstractBooleanCompare extends AbstractBinaryValue {
+public abstract class AbstractBooleanCompare extends AbstractBinaryValue implements BooleanValue {
     private final BooleanType booleanType;
 
     AbstractBooleanCompare(final Node callSite, final ExecutableElement element, final int line, final int bci, final Value left, final Value right, final BooleanType booleanType) {
@@ -14,7 +14,18 @@ public abstract class AbstractBooleanCompare extends AbstractBinaryValue {
         this.booleanType = booleanType;
     }
 
+    @Override
     public BooleanType getType() {
         return booleanType;
+    }
+
+    @Override
+    public Value getValueIfTrue(Value input) {
+        return input;
+    }
+
+    @Override
+    public Value getValueIfFalse(Value input) {
+        return input;
     }
 }

--- a/compiler/src/main/java/org/qbicc/graph/AbstractTerminator.java
+++ b/compiler/src/main/java/org/qbicc/graph/AbstractTerminator.java
@@ -3,6 +3,7 @@ package org.qbicc.graph;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 abstract class AbstractTerminator extends AbstractNode implements Terminator {
@@ -14,7 +15,9 @@ abstract class AbstractTerminator extends AbstractNode implements Terminator {
 
     @Override
     public Value getOutboundValue(PhiValue phi) {
-        return outboundValues.get(phi);
+        Value value = outboundValues.get(phi);
+        LiteralFactory lf = getElement().getEnclosingType().getContext().getLiteralFactory();
+        return value != null ? value : lf.undefinedLiteralOfType(phi.getType());
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlock.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlock.java
@@ -67,13 +67,11 @@ public final class BasicBlock {
     }
 
     public boolean setReachableFrom(BasicBlock from) {
-        if (from != null) {
+        if (from != null && ! incoming.contains(from)) {
             if (incoming.isEmpty()) {
                 incoming = Set.of(from);
             } else if (incoming.size() == 1) {
-                if (! incoming.contains(from)) {
-                    incoming = Set.of(from, incoming.iterator().next());
-                }
+                incoming = Set.of(from, incoming.iterator().next());
             } else if (incoming.size() == 2) {
                 Set<BasicBlock> old = this.incoming;
                 incoming = new LinkedHashSet<>();

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -158,7 +158,7 @@ public interface BasicBlockBuilder extends Locatable {
 
     // phi
 
-    PhiValue phi(ValueType type, BlockLabel owner);
+    PhiValue phi(ValueType type, BlockLabel owner, PhiValue.Flag... flags);
 
     // ternary
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -214,6 +214,8 @@ public interface BasicBlockBuilder extends Locatable {
 
     // unary
 
+    Value notNull(Value v);
+
     Value negate(Value v); // neg is only needed for FP; ints should use 0-n
 
     Value byteSwap(Value v);

--- a/compiler/src/main/java/org/qbicc/graph/BooleanValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/BooleanValue.java
@@ -1,0 +1,27 @@
+package org.qbicc.graph;
+
+import org.qbicc.type.BooleanType;
+
+/**
+ * A value with a boolean type.  All nodes which implement this interface will have boolean type; however, some nodes
+ * may have boolean type without implementing this interface (for example, a method call which returns a boolean value).
+ */
+public interface BooleanValue extends Value {
+    BooleanType getType();
+
+    /**
+     * Get the actual value of the given input if this value evaluates to {@code true}.
+     *
+     * @param input the input value (must not be {@code null})
+     * @return the value if {@code true} (not {@code null})
+     */
+    Value getValueIfTrue(Value input);
+
+    /**
+     * Get the actual value of the given input if this value evaluates to {@code false}.
+     *
+     * @param input the input value (must not be {@code null})
+     * @return the value if {@code false} (not {@code null})
+     */
+    Value getValueIfFalse(Value input);
+}

--- a/compiler/src/main/java/org/qbicc/graph/CastValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/CastValue.java
@@ -17,4 +17,10 @@ public interface CastValue extends Value {
     default Value getValueDependency(int index) throws IndexOutOfBoundsException {
         return index == 0 ? getInput() : Util.throwIndexOutOfBounds(index);
     }
+
+    @Override
+    default boolean isNullable() {
+        // no cast can introduce or discard nullability
+        return getInput().isNullable();
+    }
 }

--- a/compiler/src/main/java/org/qbicc/graph/CheckCast.java
+++ b/compiler/src/main/java/org/qbicc/graph/CheckCast.java
@@ -97,7 +97,7 @@ public final class CheckCast extends AbstractValue implements CastValue, Ordered
     }
 
     int calcHashCode() {
-        return Objects.hash(CheckCast.class, input, toType, toDimensions, kind, type);
+        return Objects.hash(CheckCast.class, dependency, input, toType, toDimensions, kind, type);
     }
 
     public boolean equals(final Object other) {

--- a/compiler/src/main/java/org/qbicc/graph/ClassOf.java
+++ b/compiler/src/main/java/org/qbicc/graph/ClassOf.java
@@ -34,6 +34,11 @@ public final class ClassOf extends AbstractValue implements UnaryValue {
         return Objects.hash(ClassOf.class, input);
     }
 
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
     public boolean equals(final Object other) {
         return other instanceof ClassOf && equals((ClassOf) other);
     }

--- a/compiler/src/main/java/org/qbicc/graph/CurrentThreadRead.java
+++ b/compiler/src/main/java/org/qbicc/graph/CurrentThreadRead.java
@@ -43,6 +43,11 @@ public final class CurrentThreadRead extends AbstractValue implements OrderedNod
     }
 
     @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
     public <T, R> R accept(ValueVisitor<T, R> visitor, T param) {
         return visitor.visit(param, this);
     }

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -263,8 +263,8 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().insertMember(compound, member, value);
     }
 
-    public PhiValue phi(final ValueType type, final BlockLabel owner) {
-        return getDelegate().phi(type, owner);
+    public PhiValue phi(final ValueType type, final BlockLabel owner, PhiValue.Flag... flags) {
+        return getDelegate().phi(type, owner, flags);
     }
 
     public Value select(final Value condition, final Value trueValue, final Value falseValue) {

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -515,6 +515,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().cmpL(v1, v2);
     }
 
+    public Value notNull(final Value v) {
+        return getDelegate().notNull(v);
+    }
+
     public Value negate(final Value v) {
         return getDelegate().negate(v);
     }

--- a/compiler/src/main/java/org/qbicc/graph/If.java
+++ b/compiler/src/main/java/org/qbicc/graph/If.java
@@ -23,6 +23,20 @@ public final class If extends AbstractTerminator implements Terminator {
         this.falseBranchLabel = falseBranchLabel;
     }
 
+    @Override
+    public Value getOutboundValue(PhiValue phi) {
+        Value outboundValue = super.getOutboundValue(phi);
+        if (condition instanceof BooleanValue) {
+            BooleanValue booleanValue = (BooleanValue) condition;
+            if (phi.getPinnedBlock().equals(getTrueBranch())) {
+                return booleanValue.getValueIfTrue(outboundValue);
+            } else if (phi.getPinnedBlock().equals(getFalseBranch())) {
+                return booleanValue.getValueIfFalse(outboundValue);
+            }
+        }
+        return outboundValue;
+    }
+
     public BasicBlock getTerminatedBlock() {
         return terminatedBlock;
     }

--- a/compiler/src/main/java/org/qbicc/graph/InstanceOf.java
+++ b/compiler/src/main/java/org/qbicc/graph/InstanceOf.java
@@ -9,15 +9,17 @@ import org.qbicc.type.definition.element.ExecutableElement;
 /**
  * A node that represents a check of the upper bound of the value against the given type.
  */
-public final class InstanceOf extends AbstractValue implements InstanceOperation {
+public final class InstanceOf extends AbstractValue implements InstanceOperation, OrderedNode {
+    private final Node dependency;
     private final Value input;
     private final ObjectType checkType;
     private final int checkDimensions;
     private final BooleanType booleanType;
 
-    InstanceOf(final Node callSite, final ExecutableElement element, final int line, final int bci, final Value input,
+    InstanceOf(final Node callSite, final ExecutableElement element, final int line, final int bci, Node dependency, final Value input,
                final ObjectType checkType, final int checkDimensions, final BooleanType booleanType) {
         super(callSite, element, line, bci);
+        this.dependency = dependency;
         this.input = input;
         this.checkType = checkType;
         this.checkDimensions = checkDimensions;
@@ -33,7 +35,7 @@ public final class InstanceOf extends AbstractValue implements InstanceOperation
      }
 
     int calcHashCode() {
-        return Objects.hash(input, checkType, checkDimensions);
+        return Objects.hash(dependency, input, checkType, checkDimensions);
     }
 
     public boolean equals(final Object other) {
@@ -41,7 +43,7 @@ public final class InstanceOf extends AbstractValue implements InstanceOperation
     }
 
     public boolean equals(final InstanceOf other) {
-        return this == other || other != null && input.equals(other.input) && checkType.equals(other.checkType) && checkDimensions == other.checkDimensions;
+        return this == other || other != null && dependency.equals(other.dependency) && input.equals(other.input) && checkType.equals(other.checkType) && checkDimensions == other.checkDimensions;
     }
 
     public int getValueDependencyCount() {
@@ -62,5 +64,10 @@ public final class InstanceOf extends AbstractValue implements InstanceOperation
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    @Override
+    public Node getDependency() {
+        return dependency;
     }
 }

--- a/compiler/src/main/java/org/qbicc/graph/InstanceOf.java
+++ b/compiler/src/main/java/org/qbicc/graph/InstanceOf.java
@@ -4,12 +4,13 @@ import java.util.Objects;
 
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.ObjectType;
+import org.qbicc.type.ReferenceType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
  * A node that represents a check of the upper bound of the value against the given type.
  */
-public final class InstanceOf extends AbstractValue implements InstanceOperation, OrderedNode {
+public final class InstanceOf extends AbstractValue implements InstanceOperation, OrderedNode, BooleanValue {
     private final Node dependency;
     private final Value input;
     private final ObjectType checkType;
@@ -60,6 +61,19 @@ public final class InstanceOf extends AbstractValue implements InstanceOperation
 
     public BooleanType getType() {
         return booleanType;
+    }
+
+    @Override
+    public Value getValueIfTrue(Value input) {
+        return input.equals(this.input) ?
+            new NotNull(getCallSite(), getElement(), getSourceLine(), getBytecodeIndex(),
+                new BitCast(getCallSite(), getElement(), getSourceLine(), getBytecodeIndex(), input, ((ReferenceType)input.getType()).narrow(checkType)))
+            : input;
+    }
+
+    @Override
+    public Value getValueIfFalse(Value input) {
+        return input;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/IsEq.java
+++ b/compiler/src/main/java/org/qbicc/graph/IsEq.java
@@ -1,5 +1,6 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.literal.Literal;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -9,6 +10,17 @@ import org.qbicc.type.definition.element.ExecutableElement;
 public final class IsEq extends AbstractBooleanCompare implements CommutativeBinaryValue {
     IsEq(final Node callSite, final ExecutableElement element, final int line, final int bci, final Value v1, final Value v2, final BooleanType booleanType) {
         super(callSite, element, line, bci, v1, v2, booleanType);
+    }
+
+    @Override
+    public Value getValueIfTrue(Value input) {
+        if (input.equals(getLeftInput()) && getRightInput() instanceof Literal) {
+            return getRightInput();
+        } else if (input.equals(getRightInput()) && getLeftInput() instanceof Literal) {
+            return getLeftInput();
+        } else {
+            return input;
+        }
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/IsNe.java
+++ b/compiler/src/main/java/org/qbicc/graph/IsNe.java
@@ -1,6 +1,8 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.literal.ZeroInitializerLiteral;
 import org.qbicc.type.BooleanType;
+import org.qbicc.type.ReferenceType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
@@ -9,6 +11,18 @@ import org.qbicc.type.definition.element.ExecutableElement;
 public final class IsNe extends AbstractBooleanCompare implements CommutativeBinaryValue {
     IsNe(final Node callSite, final ExecutableElement element, final int line, final int bci, final Value v1, final Value v2, final BooleanType booleanType) {
         super(callSite, element, line, bci, v1, v2, booleanType);
+    }
+
+    @Override
+    public Value getValueIfTrue(Value input) {
+        if (input.getType() instanceof ReferenceType) {
+            if (input.equals(getLeftInput()) && getRightInput() instanceof ZeroInitializerLiteral ||
+                input.equals(getRightInput()) && getLeftInput() instanceof ZeroInitializerLiteral) {
+                // todo: maybe require a BBB input instead
+                return new NotNull(input.getCallSite(), input.getElement(), input.getSourceLine(), input.getBytecodeIndex(), input);
+            }
+        }
+        return input;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/MultiNewArray.java
+++ b/compiler/src/main/java/org/qbicc/graph/MultiNewArray.java
@@ -54,6 +54,10 @@ public final class MultiNewArray extends AbstractValue implements OrderedNode {
         return visitor.visit(param, this);
     }
 
+    public boolean isNullable() {
+        return false;
+    }
+
     int calcHashCode() {
         return System.identityHashCode(this);
     }

--- a/compiler/src/main/java/org/qbicc/graph/New.java
+++ b/compiler/src/main/java/org/qbicc/graph/New.java
@@ -47,4 +47,9 @@ public final class New extends AbstractValue implements OrderedNode {
     public boolean isDefNe(Value other) {
         return other instanceof NullLiteral;
     }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
 }

--- a/compiler/src/main/java/org/qbicc/graph/NewArray.java
+++ b/compiler/src/main/java/org/qbicc/graph/NewArray.java
@@ -59,4 +59,9 @@ public final class NewArray extends AbstractValue implements OrderedNode {
     public boolean equals(final Object other) {
         return this == other;
     }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
 }

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -736,6 +736,10 @@ public interface Node {
                 return param.getBlockBuilder().newArray(node.getArrayType(), param.copyValue(node.getSize()));
             }
 
+            public Value visit(final Copier param, final NotNull node) {
+                return param.getBlockBuilder().notNull(param.copyValue(node.getInput()));
+            }
+
             public Value visit(final Copier param, final NullLiteral node) {
                 return node;
             }

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -756,9 +756,12 @@ public interface Node {
                 return node;
             }
 
+            static final PhiValue.Flag[] NO_FLAGS = new PhiValue.Flag[0];
+            static final PhiValue.Flag[] NOT_NULL_FLAGS = new PhiValue.Flag[] { PhiValue.Flag.NOT_NULL };
+
             public Value visit(final Copier param, final PhiValue node) {
                 param.enqueue(node);
-                return param.getBlockBuilder().phi(node.getType(), param.copyBlock(node.getPinnedBlock()));
+                return param.getBlockBuilder().phi(node.getType(), param.copyBlock(node.getPinnedBlock()), node.possibleValuesAreNullable() ? NO_FLAGS : NOT_NULL_FLAGS);
             }
 
             public Value visit(Copier param, ReferenceTo node) {

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -637,6 +637,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final InstanceOf node) {
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().instanceOf(param.copyValue(node.getInstance()), node.getCheckType(), node.getCheckDimensions());
             }
 

--- a/compiler/src/main/java/org/qbicc/graph/NotNull.java
+++ b/compiler/src/main/java/org/qbicc/graph/NotNull.java
@@ -1,0 +1,22 @@
+package org.qbicc.graph;
+
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * A value that asserts non-nullity.
+ */
+public final class NotNull extends AbstractUnaryValue {
+    NotNull(Node callSite, ExecutableElement element, int line, int bci, Value input) {
+        super(callSite, element, line, bci, input);
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public <T, R> R accept(ValueVisitor<T, R> visitor, T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/ParameterValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/ParameterValue.java
@@ -14,12 +14,14 @@ public final class ParameterValue extends AbstractValue implements Unschedulable
     private final ValueType type;
     private final String label;
     private final int index;
+    private final boolean nullable;
 
     ParameterValue(final Node callSite, final ExecutableElement element, final ValueType type, String label, final int index) {
         super(callSite, element, 0, -1);
         this.type = type;
         this.label = label;
         this.index = index;
+        nullable = label.equals("p");
     }
 
     public ValueType getType() {
@@ -32,6 +34,11 @@ public final class ParameterValue extends AbstractValue implements Unschedulable
 
     public String getLabel() {
         return label;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return nullable;
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -301,6 +301,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return new CmpL(callSite, element, line, bci, v1, v2, typeSystem.getSignedInteger32Type());
     }
 
+    public Value notNull(Value v) {
+        return v.isNullable() ? new NotNull(callSite, element, line, bci, v) : v;
+    }
+
     public Value negate(final Value v) {
         return new Neg(callSite, element, line, bci, v);
     }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -532,7 +532,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         ValueType idType = typeIdType.getUpperBound();
         if (idType instanceof ReferenceType) {
             CompilationContext ctxt = classContext.getCompilationContext();
-            ctxt.warning(getLocation(), "TODO: class type ID argument is given as a reference type which is not allowed");
+//            ctxt.warning(getLocation(), "TODO: class type ID argument is given as a reference type which is not allowed");
             // decode the expected type
             PhysicalObjectType upperBound = ((ReferenceType) idType).getUpperBound();
             LiteralFactory lf = classContext.getLiteralFactory();

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -350,7 +350,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
     }
 
     public Value instanceOf(final Value input, final ObjectType expectedType, final int expectedDimensions) {
-        return new InstanceOf(callSite, element, line, bci, input, expectedType, expectedDimensions, typeSystem.getBooleanType());
+        return asDependency(new InstanceOf(callSite, element, line, bci, requireDependency(), input, expectedType, expectedDimensions, typeSystem.getBooleanType()));
     }
 
     public Value instanceOf(final Value input, final TypeDescriptor desc) {

--- a/compiler/src/main/java/org/qbicc/graph/StackAllocation.java
+++ b/compiler/src/main/java/org/qbicc/graph/StackAllocation.java
@@ -55,6 +55,11 @@ public final class StackAllocation extends AbstractValue implements OrderedNode 
     }
 
     @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
     public Node getDependency() {
         return dependency;
     }

--- a/compiler/src/main/java/org/qbicc/graph/Value.java
+++ b/compiler/src/main/java/org/qbicc/graph/Value.java
@@ -45,4 +45,13 @@ public interface Value extends Node {
         // only floats can be NaN
         return ! (getType() instanceof FloatType);
     }
+
+    /**
+     * Determine whether this value may be {@code null}.
+     *
+     * @return {@code true} if the value may be {@code null}, or {@code false} if it can never be {@code null}
+     */
+    default boolean isNullable() {
+        return true;
+    }
 }

--- a/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
@@ -268,6 +268,10 @@ public interface ValueVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, NotNull node) {
+        return visitUnknown(param, node);
+    }
+
     default R visit(T param, NullLiteral node) {
         return visitUnknown(param, node);
     }
@@ -592,6 +596,10 @@ public interface ValueVisitor<T, R> {
         }
 
         default R visit(T param, NewArray node) {
+            return getDelegateValueVisitor().visit(param, node);
+        }
+
+        default R visit(T param, NotNull node) {
             return getDelegateValueVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/VirtualMethodElementHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/VirtualMethodElementHandle.java
@@ -10,6 +10,9 @@ public final class VirtualMethodElementHandle extends InstanceMethodElementHandl
 
     VirtualMethodElementHandle(ExecutableElement element, int line, int bci, MethodElement methodElement, Value instance) {
         super(element, line, bci, methodElement, instance);
+        if (methodElement.isStatic() || methodElement.getEnclosingType().isInterface()) {
+            throw new IllegalArgumentException("Wrong argument kind for virtual method handle");
+        }
     }
 
     int calcHashCode() {

--- a/compiler/src/main/java/org/qbicc/graph/literal/BitCastLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/BitCastLiteral.java
@@ -41,6 +41,11 @@ public class BitCastLiteral extends Literal {
 
     public int hashCode() { return value.hashCode() * 19 + toType.hashCode(); }
 
+    @Override
+    public boolean isNullable() {
+        return value.isNullable();
+    }
+
     public String toString() {
         return "bitcast ("+value+" to "+toType+")";
     }

--- a/compiler/src/main/java/org/qbicc/graph/literal/ByteArrayLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ByteArrayLiteral.java
@@ -48,6 +48,11 @@ public final class ByteArrayLiteral extends Literal {
         return hashCode;
     }
 
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
     public String toString() {
         return toString(new StringBuilder()).toString();
     }

--- a/compiler/src/main/java/org/qbicc/graph/literal/Literal.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/Literal.java
@@ -40,6 +40,11 @@ public abstract class Literal implements Unschedulable, Value {
         return ! isZero();
     }
 
+    @Override
+    public boolean isNullable() {
+        return Value.super.isNullable();
+    }
+
     public final boolean equals(final Object obj) {
         return obj instanceof Literal && equals((Literal) obj);
     }

--- a/compiler/src/main/java/org/qbicc/graph/literal/NullLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/NullLiteral.java
@@ -1,5 +1,6 @@
 package org.qbicc.graph.literal;
 
+import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueVisitor;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.NullableType;
@@ -44,6 +45,16 @@ public final class NullLiteral extends WordLiteral {
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    @Override
+    public boolean isDefNe(Value other) {
+        return ! other.isNullable();
+    }
+
+    @Override
+    public boolean isDefEq(Value other) {
+        return other instanceof NullLiteral;
     }
 
     public int hashCode() {

--- a/compiler/src/main/java/org/qbicc/graph/literal/ObjectLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ObjectLiteral.java
@@ -41,6 +41,10 @@ public final class ObjectLiteral extends WordLiteral {
         return false;
     }
 
+    public boolean isNullable() {
+        return false;
+    }
+
     public boolean equals(final Literal other) {
         return other instanceof ObjectLiteral && equals((ObjectLiteral) other);
     }

--- a/compiler/src/main/java/org/qbicc/graph/literal/StringLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/StringLiteral.java
@@ -53,6 +53,11 @@ public final class StringLiteral extends WordLiteral {
         return this == other || other != null && type.equals(other.type) && value.equals(other.value);
     }
 
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
     public int hashCode() {
         return value.hashCode();
     }

--- a/compiler/src/main/java/org/qbicc/graph/literal/ValueConvertLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ValueConvertLiteral.java
@@ -36,6 +36,11 @@ public class ValueConvertLiteral extends Literal {
 
     public int hashCode() { return value.hashCode() * 19 + toType.hashCode(); }
 
+    @Override
+    public boolean isNullable() {
+        return value.isNullable();
+    }
+
     public String toString() {
         return "convert ("+value+" to "+toType+")";
     }

--- a/compiler/src/main/java/org/qbicc/graph/schedule/Schedule.java
+++ b/compiler/src/main/java/org/qbicc/graph/schedule/Schedule.java
@@ -3,6 +3,7 @@ package org.qbicc.graph.schedule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +70,7 @@ public interface Schedule {
         }
 
         // now, use the dominator depths to calculate the simplest possible schedule.
-        Map<Node, BlockInfo> scheduledNodes = new HashMap<>();
+        Map<Node, BlockInfo> scheduledNodes = new LinkedHashMap<>();
         scheduleEarly(root, blockInfos, scheduledNodes, entryBlock);
         Map<Node, BasicBlock> finalMapping = new HashMap<>(scheduledNodes.size());
         Map<BasicBlock, List<Node>> blockToNodesMap = new HashMap<>(allBlocks.length);

--- a/compiler/src/main/java/org/qbicc/object/ProgramModule.java
+++ b/compiler/src/main/java/org/qbicc/object/ProgramModule.java
@@ -1,12 +1,15 @@
 package org.qbicc.object;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.smallrye.common.constraint.Assert;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.definition.DefinedTypeDefinition;
-import io.smallrye.common.constraint.Assert;
 
 /**
  *
@@ -36,6 +39,8 @@ public final class ProgramModule {
     }
 
     public Iterable<Section> sections() {
-        return sections.values();
+        Section[] array = this.sections.values().toArray(Section[]::new);
+        Arrays.sort(array, Comparator.comparing(ProgramObject::getName));
+        return List.of(array);
     }
 }

--- a/compiler/src/main/java/org/qbicc/object/Section.java
+++ b/compiler/src/main/java/org/qbicc/object/Section.java
@@ -1,6 +1,8 @@
 package org.qbicc.object;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -162,6 +164,8 @@ public final class Section extends ProgramObject {
     }
 
     public Iterable<ProgramObject> contents() {
-        return List.of(definedObjects.values().toArray(ProgramObject[]::new));
+        ProgramObject[] array = definedObjects.values().toArray(ProgramObject[]::new);
+        Arrays.sort(array, Comparator.comparing(ProgramObject::getName));
+        return List.of(array);
     }
 }

--- a/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
@@ -4,10 +4,21 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.qbicc.context.ClassContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.BlockLabel;
+import org.qbicc.graph.ParameterValue;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.type.FunctionType;
+import org.qbicc.type.ReferenceType;
 import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.type.definition.classfile.BootstrapMethod;
@@ -17,9 +28,13 @@ import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
+import org.qbicc.type.definition.element.ParameterElement;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
+import org.qbicc.type.descriptor.MethodDescriptor;
 import org.qbicc.type.generic.ClassSignature;
 import io.smallrye.common.constraint.Assert;
+import org.qbicc.type.generic.MethodSignature;
 
 /**
  *
@@ -192,9 +207,135 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
             fields.add(fieldResolvers[i].resolveField(fieldIndexes[i], this));
         }
         cnt = getMethodCount();
-        MethodElement[] methods = cnt == 0 ? MethodElement.NO_METHODS : new MethodElement[cnt];
-        for (int i = 0; i < cnt; i ++) {
-            methods[i] = methodResolvers[i].resolveMethod(methodIndexes[i], this);
+        MethodElement[] methods;
+        if (isInterface()) {
+            methods = cnt == 0 ? MethodElement.NO_METHODS : new MethodElement[cnt];
+            for (int i = 0; i < cnt; i ++) {
+                methods[i] = methodResolvers[i].resolveMethod(methodIndexes[i], this);
+            }
+        } else {
+            List<MethodElement> methodsList = new ArrayList<>(cnt + (cnt >> 1)); // 1.5x size
+            for (int i = 0; i < cnt; i ++) {
+                methodsList.add(methodResolvers[i].resolveMethod(methodIndexes[i], this));
+            }
+            // now add methods for any maximally-specific interface methods that are not implemented by this class
+            // - but, if the method is default, let's copy it in, body and all
+            HashMap<String, HashSet<MethodDescriptor>> visited = new HashMap<>();
+            // populate the set of methods that we already have implementations for
+            for (MethodElement method : methodsList) {
+                addMethodToVisitedSet(method, visited);
+            }
+            addMethodsToVisitedSet(superType, visited);
+            // now the visited set contains all methods we do not need to implement
+            // next we find the set of methods that we're missing
+            for (int depth = 0;; depth ++) {
+                // at each depth stage, create a new to-add set
+                HashMap<String, HashMap<MethodDescriptor, List<MethodElement>>> toAdd = new HashMap<>();
+                if (findInterfaceImplementations(interfaces, visited, toAdd, depth) == 0) {
+                    break;
+                }
+                // we may have found methods to add
+                for (Map.Entry<String, HashMap<MethodDescriptor, List<MethodElement>>> entry : toAdd.entrySet()) {
+                    String name = entry.getKey();
+                    HashMap<MethodDescriptor, List<MethodElement>> subMap = entry.getValue();
+                    nextMethod: for (Map.Entry<MethodDescriptor, List<MethodElement>> entry2 : subMap.entrySet()) {
+                        MethodDescriptor descriptor = entry2.getKey();
+                        List<MethodElement> elementList = entry2.getValue();
+                        MethodElement defaultMethod = null;
+                        MethodElement oneOfTheMethods = null;
+                        for (MethodElement element : elementList) {
+                            if (oneOfTheMethods == null) {
+                                oneOfTheMethods = element;
+                            }
+                            if (! element.isAbstract()) {
+                                // found a default method
+                                if (defaultMethod == null) {
+                                    defaultMethod = element;
+                                } else {
+                                    // conflict method! Synthesize a method that throws ICCE
+                                    MethodElement.Builder builder = MethodElement.builder();
+                                    builder.setName(name);
+                                    builder.setDescriptor(descriptor);
+                                    builder.setEnclosingType(this);
+                                    // inheritable interface methods are public
+                                    builder.setModifiers(ClassFile.ACC_PUBLIC);
+                                    builder.setInvisibleAnnotations(List.of());
+                                    builder.setVisibleAnnotations(List.of());
+                                    builder.setSignature(MethodSignature.synthesize(context, descriptor));
+                                    // synthesize parameter objects
+                                    builder.setParameters(copyParametersFrom(element));
+                                    builder.setMethodBodyFactory((index, e) -> {
+                                        LoadedTypeDefinition ltd = e.getEnclosingType().load();
+                                        BasicBlockBuilder bbb = context.newBasicBlockBuilder(e);
+                                        ReferenceType thisType = ltd.getType().getReference();
+                                        ParameterValue thisValue = bbb.parameter(thisType, "this", 0);
+                                        FunctionType type = e.getType();
+                                        int pcnt = type.getParameterCount();
+                                        List<ParameterValue> paramValues = new ArrayList<>(pcnt);
+                                        for (int i = 0; i < pcnt; i ++) {
+                                            paramValues.add(bbb.parameter(type.getParameterType(i), "p", i));
+                                        }
+                                        // build the entry block
+                                        BlockLabel entryLabel = new BlockLabel();
+                                        bbb.begin(entryLabel);
+                                        ClassContext bc = context.getCompilationContext().getBootstrapClassContext();
+                                        LoadedTypeDefinition vmHelpers = bc.findDefinedType("org/qbicc/runtime/main/VMHelpers").load();
+                                        MethodElement icce = vmHelpers.resolveMethodElementExact("raiseIncompatibleClassChangeError", MethodDescriptor.synthesize(bc, BaseTypeDescriptor.V, List.of()));
+                                        BasicBlock entryBlock = bbb.callNoReturn(bbb.staticMethod(icce), List.of());
+                                        Schedule schedule = Schedule.forMethod(entryBlock);
+                                        return MethodBody.of(entryBlock, schedule, thisValue, paramValues);
+                                    }, 0);
+                                    methodsList.add(builder.build());
+                                    continue nextMethod;
+                                }
+                            }
+                        }
+                        assert oneOfTheMethods != null;
+                        // non-conflict method
+                        MethodElement.Builder builder = MethodElement.builder();
+                        builder.setName(name);
+                        builder.setDescriptor(descriptor);
+                        builder.setEnclosingType(this);
+                        builder.setInvisibleAnnotations(List.of());
+                        builder.setVisibleAnnotations(List.of());
+                        builder.setSignature(MethodSignature.synthesize(context, descriptor));
+                        builder.setParameters(copyParametersFrom(oneOfTheMethods));
+                        if (defaultMethod == null) {
+                            // add an abstract method
+                            // inheritable interface methods are public
+                            builder.setModifiers(ClassFile.ACC_PUBLIC | ClassFile.ACC_ABSTRACT);
+                        } else {
+                            // add the default method
+                            // inheritable interface methods are public
+                            builder.setModifiers(ClassFile.ACC_PUBLIC | ClassFile.I_ACC_HIDDEN);
+                            // synthesize a tail-calling exact delegation to the default method
+                            MethodElement finalDefaultMethod = defaultMethod;
+                            builder.setMethodBodyFactory((index, e) -> {
+                                LoadedTypeDefinition ltd = e.getEnclosingType().load();
+                                BasicBlockBuilder bbb = context.newBasicBlockBuilder(e);
+                                ReferenceType thisType = ltd.getType().getReference();
+                                ParameterValue thisValue = bbb.parameter(thisType, "this", 0);
+                                FunctionType type = e.getType();
+                                int pcnt = type.getParameterCount();
+                                List<ParameterValue> paramValues = new ArrayList<>(pcnt);
+                                for (int i = 0; i < pcnt; i ++) {
+                                    paramValues.add(bbb.parameter(type.getParameterType(i), "p", i));
+                                }
+                                // build the entry block
+                                BlockLabel entryLabel = new BlockLabel();
+                                bbb.begin(entryLabel);
+                                // just cast the list because it's fine; todo: maybe this method should accept List<? extends Value>
+                                //noinspection unchecked,rawtypes
+                                BasicBlock entryBlock = bbb.tailCall(bbb.exactMethodOf(thisValue, finalDefaultMethod), (List<Value>) (List) paramValues);
+                                Schedule schedule = Schedule.forMethod(entryBlock);
+                                return MethodBody.of(entryBlock, schedule, thisValue, paramValues);
+                            }, 0);
+                        }
+                        methodsList.add(builder.build());
+                    }
+                }
+            }
+            methods = methodsList.toArray(MethodElement[]::new);
         }
         cnt = getConstructorCount();
         ConstructorElement[] ctors = cnt == 0 ? ConstructorElement.NO_CONSTRUCTORS : new ConstructorElement[cnt];
@@ -252,6 +393,88 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
             this.loaded = validated;
             return validated.load();
         }
+    }
+
+    private List<ParameterElement> copyParametersFrom(final MethodElement element) {
+        List<ParameterElement> parameters = new ArrayList<>(element.getParameters().size());
+        for (ParameterElement original : element.getParameters()) {
+            ParameterElement.Builder paramBuilder = ParameterElement.builder(original);
+            paramBuilder.setEnclosingType(this);
+            paramBuilder.setSourceFileName(null);
+            parameters.add(paramBuilder.build());
+        }
+        return parameters;
+    }
+
+    private void addMethodsToVisitedSet(final LoadedTypeDefinition ltd, final HashMap<String, HashSet<MethodDescriptor>> visited) {
+        if (ltd == null) {
+            return;
+        }
+        int cnt = ltd.getMethodCount();
+        for (int i = 0; i < cnt; i ++) {
+            addMethodToVisitedSet(ltd.getMethod(i), visited);
+        }
+        addMethodsToVisitedSet(ltd.getSuperClass(), visited);
+    }
+
+    /**
+     * Add one method to the visited set.
+     * @param method the method to add
+     * @param visited the visited set
+     * @return {@code true} if the method is not static or private and was not previously in the set, or {@code false} if no new method was added
+     */
+    private boolean addMethodToVisitedSet(final MethodElement method, final HashMap<String, HashSet<MethodDescriptor>> visited) {
+        if (method.isStatic() || method.isPrivate()) {
+            return false;
+        } else {
+            return visited.computeIfAbsent(method.getName(), DefinedTypeDefinitionImpl::newSet).add(method.getDescriptor());
+        }
+    }
+
+    private int findInterfaceImplementations(LoadedTypeDefinition[] interfaces, HashMap<String, HashSet<MethodDescriptor>> visited, HashMap<String, HashMap<MethodDescriptor, List<MethodElement>>> toAdd, int depth) {
+        int processed = 0;
+        for (int i = 0; i < interfaces.length; i ++) {
+            processed += findInterfaceImplementations(interfaces[i], visited, toAdd, depth);
+        }
+        return processed;
+    }
+
+    private int findInterfaceImplementations(LoadedTypeDefinition currentInterface, HashMap<String, HashSet<MethodDescriptor>> visited, HashMap<String, HashMap<MethodDescriptor, List<MethodElement>>> toAdd, int depth) {
+        if (depth > 0) {
+            return findInterfaceImplementations(currentInterface.getInterfaces(), visited, toAdd, depth - 1);
+        } else {
+            int cnt = currentInterface.getMethodCount();
+            for (int i = 0; i < cnt; i ++) {
+                MethodElement method = currentInterface.getMethod(i);
+                if (addMethodToVisitedSet(method, visited)) {
+                    // we didn't have this one before
+                    toAdd.computeIfAbsent(method.getName(), DefinedTypeDefinitionImpl::newMap).computeIfAbsent(method.getDescriptor(), DefinedTypeDefinitionImpl::newList).add(method);
+                } else {
+                    // check to see whether we need to add this one to our level
+                    HashMap<MethodDescriptor, List<MethodElement>> map1 = toAdd.get(method.getName());
+                    if (map1 != null) {
+                        List<MethodElement> list = map1.get(method.getDescriptor());
+                        if (list != null) {
+                            // we have another impl option for this
+                            list.add(method);
+                        }
+                    }
+                }
+            }
+            return 1;
+        }
+    }
+
+    private static <E> HashSet<E> newSet(final Object ignored) {
+        return new HashSet<>(4);
+    }
+
+    private static <K, V> HashMap<K, V> newMap(final Object ignored) {
+        return new HashMap<>(4);
+    }
+
+    private static <E> ArrayList<E> newList(final Object ignored) {
+        return new ArrayList<>(3);
     }
 
     private NestedClassElement[] resolveEnclosedClasses(final EnclosedClassResolver[] resolvers, final int[] indexes, final int inIdx, final int outIdx) {

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -157,14 +157,22 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
 
     public void injectField(final FieldElement field) {
         Assert.checkNotNullParam("field", field);
-        if ((field.getModifiers() & ClassFile.I_ACC_HIDDEN) == 0) {
-            throw new IllegalArgumentException("Injected fields must be hidden");
+        if ((field.getModifiers() & ClassFile.I_ACC_NO_RESOLVE) == 0) {
+            throw new IllegalArgumentException("Injected fields must be unresolvable");
         }
         fields.add(field);
     }
 
+    public int getMethodCount() {
+        return methods.length;
+    }
+
     public MethodElement getMethod(final int index) {
         return methods[index];
+    }
+
+    public int getConstructorCount() {
+        return ctors.length;
     }
 
     public ConstructorElement getConstructor(final int index) {

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFile.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFile.java
@@ -87,6 +87,9 @@ public interface ClassFile extends FieldResolver,
      */
     int I_ACC_PINNED = 1 << 16;
     int I_ACC_DEPRECATED = 1 << 17;
+    /**
+     * On methods, hide from stack traces.
+     */
     int I_ACC_HIDDEN = 1 << 18;
     /**
      * For static fields that are thread-local.
@@ -98,6 +101,14 @@ public interface ClassFile extends FieldResolver,
      * For methods which have no side-effects.
      */
     int I_ACC_NO_SIDE_EFFECTS = 1 << 22;
+    /**
+     * For members and types which should not appear to reflection.
+     */
+    int I_ACC_NO_REFLECT = 1 << 23;
+    /**
+     * For members which should never be symbolically resolvable.
+     */
+    int I_ACC_NO_RESOLVE = 1 << 24;
 
     int OP_NOP = 0x00;
     int OP_ACONST_NULL = 0x01;

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFileImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFileImpl.java
@@ -16,7 +16,6 @@ import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.schedule.Schedule;
-import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.annotation.Annotation;
@@ -1205,7 +1204,7 @@ final class ClassFileImpl extends AbstractBufferBacked implements ClassFile, Enc
             int j = 0;
             if (nonStatic) {
                 // instance method or constructor
-                thisValue = gf.parameter(enclosing.load().getType().getReference().asNullable(), "this", 0);
+                thisValue = gf.parameter(enclosing.load().getType().getReference(), "this", 0);
                 currentVarTypes[j] = thisValue.getType();
                 methodParser.setLocal1(j++, thisValue);
             } else {
@@ -1401,22 +1400,18 @@ final class ClassFileImpl extends AbstractBufferBacked implements ClassFile, Enc
             return ts.getSignedInteger64Type();
         } else if (viTag == 5) { // null
             // todo: bottom object type?
-            return ctxt.findDefinedType("java/lang/Object").load().getClassType().getReference().asNullable();
+            return ctxt.findDefinedType("java/lang/Object").load().getClassType().getReference();
         } else if (viTag == 6) { // uninitialized this
-            return element.getEnclosingType().load().getType().getReference().asNullable();
+            return element.getEnclosingType().load().getType().getReference();
         } else if (viTag == 7) { // object
             int cpIdx = sm.getShort() & 0xffff;
-            return nullable(getTypeConstant(cpIdx, TypeParameterContext.of(element)));
+            return getTypeConstant(cpIdx, TypeParameterContext.of(element));
         } else if (viTag == 8) { // uninitialized object
             int newIdx = sm.getShort() & 0xffff;
             int cpIdx = byteCode.getShort(newIdx + 1) & 0xffff;
-            return nullable(getTypeConstant(cpIdx, TypeParameterContext.of(element)));
+            return getTypeConstant(cpIdx, TypeParameterContext.of(element));
         } else {
             throw new IllegalStateException("Invalid variable info tag " + viTag);
         }
-    }
-
-    ValueType nullable(ValueType v) {
-        return v instanceof ReferenceType ? ((ReferenceType) v).asNullable() : v;
     }
 }

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -140,7 +140,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
         ExceptionHandlerImpl(final int index, final BasicBlockBuilder.ExceptionHandler delegate) {
             this.index = index;
             this.delegate = delegate;
-            this.phi = gf.phi(throwable.load().getType().getReference().asNullable(), new BlockLabel());
+            this.phi = gf.phi(throwable.load().getType().getReference().asNullable(), new BlockLabel(), PhiValue.Flag.NOT_NULL);
         }
 
         private void clearExceptionField() {

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -140,7 +140,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
         ExceptionHandlerImpl(final int index, final BasicBlockBuilder.ExceptionHandler delegate) {
             this.index = index;
             this.delegate = delegate;
-            this.phi = gf.phi(throwable.load().getType().getReference().asNullable(), new BlockLabel(), PhiValue.Flag.NOT_NULL);
+            this.phi = gf.phi(throwable.load().getType().getReference(), new BlockLabel(), PhiValue.Flag.NOT_NULL);
         }
 
         private void clearExceptionField() {
@@ -461,7 +461,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_NOP:
                         break;
                     case OP_ACONST_NULL:
-                        push1(lf.zeroInitializerLiteralOfType(jlo.load().getClassType().getReference().asNullable()));
+                        push1(lf.zeroInitializerLiteralOfType(jlo.load().getClassType().getReference()));
                         break;
                     case OP_ICONST_M1:
                     case OP_ICONST_0:

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -1342,7 +1342,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                         FieldElement.Builder callSiteBuilder = FieldElement.builder();
                         callSiteBuilder.setDescriptor(callSiteDesc);
                         callSiteBuilder.setName("callSite_" + gf.getCurrentElement().getIndex() + "_" + src);
-                        callSiteBuilder.setModifiers(ACC_STATIC | ACC_FINAL | I_ACC_HIDDEN);
+                        callSiteBuilder.setModifiers(ACC_STATIC | ACC_FINAL | I_ACC_NO_RESOLVE | I_ACC_NO_REFLECT);
                         callSiteBuilder.setSignature(TypeSignature.synthesize(ctxt, callSiteDesc));
                         callSiteBuilder.setEnclosingType(enclosingType);
                         FieldElement callSiteHolder = callSiteBuilder.build();

--- a/compiler/src/main/java/org/qbicc/type/definition/element/AnnotatedElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/AnnotatedElement.java
@@ -39,6 +39,12 @@ public abstract class AnnotatedElement extends BasicElement {
 
         Builder() {}
 
+        Builder(final AnnotatedElement original) {
+            super(original);
+            visibleAnnotations = original.visibleAnnotations;
+            invisibleAnnotations = original.invisibleAnnotations;
+        }
+
         public void setVisibleAnnotations(List<Annotation> annotations) {
             visibleAnnotations = Assert.checkNotNullParam("annotations", annotations);
         }

--- a/compiler/src/main/java/org/qbicc/type/definition/element/BasicElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/BasicElement.java
@@ -73,6 +73,13 @@ public abstract class BasicElement implements Element {
 
         Builder() {}
 
+        Builder(final BasicElement original) {
+            enclosingType = original.enclosingType;
+            sourceFileName = original.sourceFileName;
+            modifiers = original.modifiers;
+            index = original.index;
+        }
+
         public void setSourceFileName(final String sourceFileName) {
             this.sourceFileName = sourceFileName;
         }

--- a/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
@@ -10,6 +10,19 @@ import org.qbicc.type.generic.MethodSignature;
  *
  */
 public interface ExecutableElement extends MemberElement {
+    /**
+     * Determine whether this element has a body factory.  An element with a body factory will
+     * produce a body when {@link #tryCreateMethodBody()} is called.
+     *
+     * @return {@code true} if there is a body factory, {@code false} otherwise
+     */
+    boolean hasMethodBodyFactory();
+
+    /**
+     * Determine whether a body was produced for this element.
+     *
+     * @return {@code true} if a body was produced, {@code false} otherwise
+     */
     boolean hasMethodBody();
 
     MethodBody getPreviousMethodBody();

--- a/compiler/src/main/java/org/qbicc/type/definition/element/InitializerElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/InitializerElement.java
@@ -29,8 +29,12 @@ public final class InitializerElement extends BasicElement implements Executable
         this.maximumLineNumber = builder.maximumLineNumber;
     }
 
-    public boolean hasMethodBody() {
+    public boolean hasMethodBodyFactory() {
         return methodBodyFactory != null;
+    }
+
+    public boolean hasMethodBody() {
+        return methodBody != null;
     }
 
     public MethodBody getPreviousMethodBody() {

--- a/compiler/src/main/java/org/qbicc/type/definition/element/InvokableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/InvokableElement.java
@@ -63,8 +63,12 @@ public abstract class InvokableElement extends AnnotatedElement implements Execu
         this.type = builder.type;
     }
 
-    public boolean hasMethodBody() {
+    public boolean hasMethodBodyFactory() {
         return methodBodyFactory != null;
+    }
+
+    public boolean hasMethodBody() {
+        return methodBody != null;
     }
 
     public MethodBodyFactory getMethodBodyFactory() {

--- a/compiler/src/main/java/org/qbicc/type/definition/element/MethodElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/MethodElement.java
@@ -73,6 +73,16 @@ public final class MethodElement extends InvokableElement implements NamedElemen
         return new Builder();
     }
 
+    public boolean overrides(final MethodElement other) {
+        // todo: account for access control cases
+        return ! isStatic()
+            && ! other.isStatic()
+            && ! other.isFinal()
+            && getDescriptor().equals(other.getDescriptor())
+            && getName().equals(other.getName())
+            && getEnclosingType().load().getType().isSubtypeOf(other.getEnclosingType().load().getType());
+    }
+
     public static final class Builder extends InvokableElement.Builder implements NamedElement.Builder {
         String name;
 

--- a/compiler/src/main/java/org/qbicc/type/definition/element/ParameterElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/ParameterElement.java
@@ -22,6 +22,10 @@ public final class ParameterElement extends VariableElement {
         return new Builder();
     }
 
+    public static Builder builder(ParameterElement original) {
+        return new Builder(original);
+    }
+
     ValueType resolveTypeDescriptor(final ClassContext classContext, TypeParameterContext paramCtxt) {
         return classContext.resolveTypeFromMethodDescriptor(
                         getTypeDescriptor(),
@@ -32,6 +36,12 @@ public final class ParameterElement extends VariableElement {
     }
 
     public static final class Builder extends VariableElement.Builder {
+        Builder() {}
+
+        Builder(ParameterElement original) {
+            super(original);
+        }
+
         public ParameterElement build() {
             return new ParameterElement(this);
         }

--- a/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
@@ -67,12 +67,6 @@ public abstract class VariableElement extends AnnotatedElement implements NamedE
         ValueType type = this.type;
         if (type == null) {
             type = resolveTypeDescriptor(classContext, typeParameterContext);
-            if (type instanceof ReferenceType) {
-                // all fields are considered nullable for now
-                // todo: add a flag for non-nullable fields
-                // todo: initial heap final fields are non-nullable
-                type = ((ReferenceType) type).asNullable();
-            }
             this.type = type;
         }
         return type;

--- a/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
@@ -106,6 +106,17 @@ public abstract class VariableElement extends AnnotatedElement implements NamedE
 
         Builder() {}
 
+        Builder(final VariableElement original) {
+            super(original);
+            name = original.name;
+            typeDescriptor = original.typeDescriptor;
+            typeSignature = original.typeSignature;
+            visibleTypeAnnotations = original.visibleTypeAnnotations;
+            invisibleTypeAnnotations = original.invisibleTypeAnnotations;
+            typeParameterContext = original.typeParameterContext;
+            type = original.type;
+        }
+
         public void setName(final String name) {
             this.name = name;
         }

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -637,7 +637,7 @@ final class CompilationContextImpl implements CompilationContext {
                 }
                 try {
                     consumer.accept(element);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     log.error("An exception was thrown from a queue processing task", e);
                     error(element, "Exception while processing queue task for element: %s", e);
                 }

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -366,7 +366,7 @@ final class CompilationContextImpl implements CompilationContext {
                     ClassTypeDescriptor desc = ClassTypeDescriptor.synthesize(classContext, "java/lang/Throwable");
                     builder.setDescriptor(desc);
                     builder.setSignature(TypeSignature.synthesize(classContext, desc));
-                    builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.I_ACC_HIDDEN);
+                    builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
                     builder.setEnclosingType(jlt);
                     fieldElement = builder.build();
                     jlt.load().injectField(fieldElement);

--- a/driver/src/main/java/org/qbicc/driver/Driver.java
+++ b/driver/src/main/java/org/qbicc/driver/Driver.java
@@ -359,7 +359,7 @@ public class Driver implements Closeable {
         MDC.put("phase", "ADD");
         compilationContext.processQueue(element -> {
             MDC.put("phase", "ADD");
-            if (element.hasMethodBody()) {
+            if (element.hasMethodBodyFactory()) {
                 // cause method and field references to be resolved
                 try {
                     element.tryCreateMethodBody();

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -292,7 +292,6 @@ public class Main implements Callable<DiagnosticContext> {
                                 if (nogc) {
                                     builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NoGcMultiNewArrayBasicBlockBuilder::new);
                                 }
-                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, LocalThrowHandlingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ClassLoadingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NativeBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, MemberResolvingBasicBlockBuilder::new);
@@ -309,6 +308,7 @@ public class Main implements Callable<DiagnosticContext> {
                                     builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, LocalMemoryTrackingBasicBlockBuilder::new);
                                 }
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, RuntimeChecksBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, LocalThrowHandlingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.OPTIMIZE, SimpleOptBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addElementVisitor(Phase.ADD, new DotGenerator(Phase.ADD, graphGenConfig));

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -341,6 +341,9 @@ public class Main implements Callable<DiagnosticContext> {
                                 if (optGotos) {
                                     builder.addCopyFactory(Phase.LOWER, GotoRemovingVisitor::new);
                                 }
+                                if (optPhis) {
+                                    builder.addCopyFactory(Phase.LOWER, PhiOptimizerVisitor::new);
+                                }
 
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ThrowLoweringBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -304,6 +304,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ThrowValueBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, MethodCallFixupBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, SynchronizedMethodBasicBlockBuilder::createIfNeeded);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
                                 if (optMemoryTracking) {
                                     builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, LocalMemoryTrackingBasicBlockBuilder::new);
                                 }

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
@@ -306,7 +306,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
     }
 
     private void nullCheck(Value value) {
-        if (value.getType() instanceof ArrayType || value.getType() instanceof ReferenceType && ! ((ReferenceType) value.getType()).isNullable()) {
+        if (value.getType() instanceof ArrayType || value.getType() instanceof ReferenceType && ! value.isNullable()) {
             return;
         }
 

--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DevirtualizingBasicBlockBuilder.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DevirtualizingBasicBlockBuilder.java
@@ -56,10 +56,10 @@ public class DevirtualizingBasicBlockBuilder extends DelegatingBasicBlockBuilder
             return null;
         }
         LoadedTypeDefinition definition = classType.getDefinition().load();
-        int idx = definition.findMethodIndex(target.getName(), target.getDescriptor());
-        if (idx != -1) {
+        MethodElement virtual = definition.resolveMethodElementVirtual(target.getName(), target.getDescriptor());
+        if (virtual != null) {
             log.debugf("Deinterfacing call to %s::%s", target.getEnclosingType().getDescriptor().getClassName(), target.getName());
-            return definition.getMethod(idx);
+            return virtual;
         }
         return null;
     }

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -80,6 +80,7 @@ import org.qbicc.graph.NoSuchMethodErrorNode;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.NodeVisitor;
 import org.qbicc.graph.NonCommutativeBinaryValue;
+import org.qbicc.graph.NotNull;
 import org.qbicc.graph.Or;
 import org.qbicc.graph.ParameterValue;
 import org.qbicc.graph.PhiValue;
@@ -1059,6 +1060,10 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
         processDependency(param, node.getDependency());
         addEdge(param, node, node.getSize(), EdgeType.VALUE_DEPENDENCY, "size");
         return name;
+    }
+
+    public String visit(final Appendable param, final NotNull node) {
+        return node(param, "not-null", node);
     }
 
     public String visit(final Appendable param, final NullLiteral node) {

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -11,6 +11,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.smallrye.common.constraint.Assert;
 import org.qbicc.graph.Action;
 import org.qbicc.graph.Add;
 import org.qbicc.graph.AddressOf;
@@ -932,6 +933,8 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
         attr(param, "label", "instanceof " + node.getCheckType().toString());
         attr(param, "fixedsize", "shape");
         nl(param);
+        dependencyList.add(name);
+        processDependency(param, node.getDependency());
         addEdge(param, node, node.getInstance(), EdgeType.VALUE_DEPENDENCY, "value");
         return name;
     }

--- a/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
+++ b/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
@@ -83,9 +83,9 @@ public class NoGcBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             size = extend(size, ctxt.getTypeSystem().getSignedInteger64Type());
         }
         Value realSize = add(baseSize, multiply(lf.literalOf(arrayType.getElementType().getSize()), size));
-        Value rawMem = call(staticMethod(noGc.getAllocateMethod()), List.of(realSize, align));
+        Value ptrVal = notNull(call(staticMethod(noGc.getAllocateMethod()), List.of(realSize, align)));
 
-        Value ptrVal = notNull(call(staticMethod(noGc.getZeroMethod()), List.of(rawMem, realSize)));
+        call(staticMethod(noGc.getZeroMethod()), List.of(ptrVal, realSize));
         Value arrayPtr = valueConvert(ptrVal, arrayType.getReference());
         ValueHandle arrayHandle = referenceHandle(arrayPtr);
 

--- a/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
+++ b/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
@@ -46,7 +46,7 @@ public class NoGcBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             ptrVal = stackAllocate(compoundType, lf.literalOf(1), align);
         } else {
             long size = compoundType.getSize();
-            ptrVal = call(staticMethod(noGc.getAllocateMethod()), List.of(lf.literalOf(size), align));
+            ptrVal = notNull(call(staticMethod(noGc.getAllocateMethod()), List.of(lf.literalOf(size), align)));
         }
         Value oop = valueConvert(ptrVal, type.getReference());
         ValueHandle oopHandle = referenceHandle(oop);
@@ -85,7 +85,7 @@ public class NoGcBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         Value realSize = add(baseSize, multiply(lf.literalOf(arrayType.getElementType().getSize()), size));
         Value rawMem = call(staticMethod(noGc.getAllocateMethod()), List.of(realSize, align));
 
-        Value ptrVal = call(staticMethod(noGc.getZeroMethod()), List.of(rawMem, realSize));
+        Value ptrVal = notNull(call(staticMethod(noGc.getZeroMethod()), List.of(rawMem, realSize)));
         Value arrayPtr = valueConvert(ptrVal, arrayType.getReference());
         ValueHandle arrayHandle = referenceHandle(arrayPtr);
 
@@ -117,7 +117,7 @@ public class NoGcBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             if (type.isSubtypeOf(noGc.getStackObjectType())) {
                 ptrVal = stackAllocate(compoundType, lf.literalOf(1), align);
             } else {
-                ptrVal = call(staticMethod(noGc.getAllocateMethod()), List.of(size, align));
+                ptrVal = notNull(call(staticMethod(noGc.getAllocateMethod()), List.of(size, align)));
             }
             // TODO: replace with field-by-field copy once we have a redundant assignment elimination optimization
             // TODO: if/when we put a thinlock, default hashcode, or GC state bits in the object header we need to properly initialize them.

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/InstanceOfCheckCastBasicBlockBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/InstanceOfCheckCastBasicBlockBuilder.java
@@ -198,7 +198,7 @@ public class InstanceOfCheckCastBasicBlockBuilder extends DelegatingBasicBlockBu
 
         ctxt.warning(getLocation(), "Lowering classOf to incomplete VMHelper stub");
         List<Value> args = List.of(typeId);
-        return getFirstBuilder().call(getFirstBuilder().staticMethod(methodElement), args);
+        return notNull(getFirstBuilder().call(getFirstBuilder().staticMethod(methodElement), args));
     }
 
     // Used when we know the exact type we are testing for at compile time (checkcast and instanceof bytecodes)

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -633,7 +633,7 @@ public class SupersDisplayTables {
                     init_state = uninitialized;
                     if (info.isInitializedType(ltd)) {
                         InitializerElement ie = ltd.getInitializer();
-                        if (ie != null && ie.hasMethodBody()) {
+                        if (ie != null && ie.hasMethodBody() && ctxt.wasEnqueued(ie)) {
                             FunctionType funType = ctxt.getFunctionTypeForElement(ie);
                             Function impl = ctxt.getExactFunction(ie);
                             if (!ie.getEnclosingType().load().equals(jlo)) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -724,6 +724,12 @@ public final class CoreIntrinsics {
             ctxt.getLiteralFactory().constantLiteralOfType(ctxt.getTypeSystem().getPoisonType());
 
         intrinsics.registerIntrinsic(cNativeDesc, "constant", MethodDescriptor.synthesize(classContext, nObjDesc, List.of()), constant);
+
+        StaticIntrinsic bitCast = (builder, target, arguments) ->
+            builder.bitCast(arguments.get(0), (WordType) target.getType().getReturnType());
+
+        intrinsics.registerIntrinsic(cNativeDesc, "ptrToRef", MethodDescriptor.synthesize(classContext, objDesc, List.of(ptrDesc)), bitCast);
+        intrinsics.registerIntrinsic(cNativeDesc, "refToPtr", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(objDesc)), bitCast);
     }
 
     static void registerOrgQbiccObjectModelIntrinsics(final CompilationContext ctxt) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -225,7 +225,7 @@ public final class CoreIntrinsics {
         // Null and no-operation intrinsics
 
         StaticIntrinsic returnNull = (builder, target, arguments) ->
-            classContext.getLiteralFactory().zeroInitializerLiteralOfType(jls.getClassType().getReference().asNullable());
+            classContext.getLiteralFactory().zeroInitializerLiteralOfType(jls.getClassType().getReference());
         intrinsics.registerIntrinsic(systemDesc, "getSecurityManager",
             MethodDescriptor.synthesize(classContext,
                 ClassTypeDescriptor.synthesize(classContext,"java/lang/SecurityManager"), List.of()),

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
@@ -162,7 +162,7 @@ public final class Layout {
 
         // now the reference array class
 
-        LoadedTypeDefinition refArrayType = defineArrayType(classContext, baseType, jlo.getClassType().getReference().asNullable(), "[L").load();
+        LoadedTypeDefinition refArrayType = defineArrayType(classContext, baseType, jlo.getClassType().getReference(), "[L").load();
         refArrayDimensionsField = refArrayType.getField(0);
         refArrayElementTypeIdField = refArrayType.getField(1);
         refArrayContentField = refArrayType.getField(2);

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
@@ -86,7 +86,7 @@ public final class Layout {
         // inject a field to hold the object typeId
         // TODO: This should be a 16 bit unsigned field.  It is being generated as an i32 currently.
         FieldElement.Builder builder = FieldElement.builder();
-        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL | ClassFile.I_ACC_HIDDEN);
+        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         builder.setName("typeId");
         builder.setEnclosingType(jloDef);
         builder.setDescriptor(typeTypeDescriptor);
@@ -99,7 +99,7 @@ public final class Layout {
         // now inject a field of ClassObjectType into Class to hold the corresponding run time type
         // TODO: This should be a 16 bit unsigned field.  It is being generated as an i32 currently.
         builder = FieldElement.builder();
-        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL | ClassFile.I_ACC_HIDDEN);
+        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         builder.setName("id");
         builder.setEnclosingType(jlcDef);
         builder.setDescriptor(typeTypeDescriptor);
@@ -112,7 +112,7 @@ public final class Layout {
         // now inject a field of int into Class to hold the corresponding run time dimensionality
         // TODO: This could be a 8 bit unsigned field.  It is being generated as an i32 currently.
         builder = FieldElement.builder();
-        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL | ClassFile.I_ACC_HIDDEN);
+        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         builder.setName("dimension");
         builder.setEnclosingType(jlcDef);
         builder.setDescriptor(BaseTypeDescriptor.I);
@@ -138,7 +138,7 @@ public final class Layout {
         typeBuilder.addInterfaceName("java/io/Serializable");
         typeBuilder.setSimpleName("base_array_type");
         typeBuilder.setContext(classContext);
-        typeBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PUBLIC | ClassFile.I_ACC_HIDDEN);
+        typeBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PUBLIC | ClassFile.I_ACC_NO_REFLECT);
         typeBuilder.setName("base_array_type");
         typeBuilder.addField(Layout::makeLengthField, 0);
         typeBuilder.setInitializer(EMPTY_INIT, 0);
@@ -179,7 +179,7 @@ public final class Layout {
         typeBuilder.setSuperClassName(superClass.getInternalName());
         typeBuilder.setSimpleName(simpleName);
         typeBuilder.setContext(classContext);
-        typeBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PUBLIC | ClassFile.I_ACC_HIDDEN);
+        typeBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PUBLIC | ClassFile.I_ACC_NO_REFLECT);
         typeBuilder.setName(internalName);
         // add fields in this order, which is relied upon up above
         int idx = 0;
@@ -203,7 +203,7 @@ public final class Layout {
         fieldBuilder.setIndex(index);
         fieldBuilder.setName("dims");
         fieldBuilder.setType(enclosing.getContext().getTypeSystem().getSignedInteger32Type());
-        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_HIDDEN);
+        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         return fieldBuilder.build();
     }
 
@@ -215,7 +215,7 @@ public final class Layout {
         fieldBuilder.setIndex(index);
         fieldBuilder.setName("length");
         fieldBuilder.setType(enclosing.getContext().getTypeSystem().getSignedInteger32Type());
-        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_HIDDEN);
+        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         return fieldBuilder.build();
     }
 
@@ -228,7 +228,7 @@ public final class Layout {
         fieldBuilder.setIndex(index);
         fieldBuilder.setName("elementType");
         fieldBuilder.setType(jlo.load().getClassType().getReference().getTypeType());
-        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_HIDDEN);
+        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         return fieldBuilder.build();
     }
 
@@ -240,7 +240,7 @@ public final class Layout {
         fieldBuilder.setIndex(index);
         fieldBuilder.setName("content");
         fieldBuilder.setType(enclosing.getContext().getTypeSystem().getArrayType(realMemberType, 0));
-        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_HIDDEN);
+        fieldBuilder.setModifiers(ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         return fieldBuilder.build();
     }
 

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -846,7 +846,8 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail().attribute(FunctionAttributes.noreturn);
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        return builder.unreachable();
+        builder.unreachable();
+        return call;
     }
 
     @Override

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -776,6 +776,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
     }
 
     public LLValue visit(final Void param, final CheckCast node) {
+        map(node.getDependency());
         return map(node.getInput());
     }
 

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -56,6 +56,7 @@ import org.qbicc.graph.CheckCast;
 import org.qbicc.graph.Neg;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.NotNull;
 import org.qbicc.graph.Or;
 import org.qbicc.graph.ParameterValue;
 import org.qbicc.graph.PhiValue;
@@ -547,6 +548,10 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         LLValue inputType = map(javaInputType);
         LLValue llvmInput = map(node.getInput());
         return builder.fneg(inputType, llvmInput).asLocal();
+    }
+
+    public LLValue visit(Void param, NotNull node) {
+        return map(node.getInput());
     }
 
     public LLValue visit(final Void param, final Shr node) {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/ThrowExceptionHelper.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/ThrowExceptionHelper.java
@@ -28,7 +28,7 @@ public class ThrowExceptionHelper {
         ClassTypeDescriptor desc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/unwind/Unwind$struct__Unwind_Exception");
         builder.setDescriptor(desc);
         builder.setSignature(TypeSignature.synthesize(classContext, desc));
-        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.I_ACC_HIDDEN);
+        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.I_ACC_NO_RESOLVE | ClassFile.I_ACC_NO_REFLECT);
         DefinedTypeDefinition jltDefined = classContext.findDefinedType("java/lang/Thread");
         builder.setEnclosingType(jltDefined);
         FieldElement field = builder.build();

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
@@ -108,9 +108,9 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     public Value isEq(final Value v1, final Value v2) {
-        if (isAlwaysNull(v1) && isAlwaysNull(v2) || v1.isDefEq(v2)) {
+        if (v1.isDefEq(v2)) {
             return ctxt.getLiteralFactory().literalOf(true);
-        } else if (isNeverNull(v1) && isAlwaysNull(v2) || isAlwaysNull(v1) && isNeverNull(v2) || v1.isDefNe(v2)) {
+        } else if (!v1.isNullable() && isAlwaysNull(v2) || isAlwaysNull(v1) && !v2.isNullable() || v1.isDefNe(v2)) {
             return ctxt.getLiteralFactory().literalOf(false);
         }
 
@@ -140,9 +140,9 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     public Value isNe(final Value v1, final Value v2) {
-        if (isAlwaysNull(v1) && isAlwaysNull(v2) || v1.isDefEq(v2)) {
+        if (v1.isDefEq(v2)) {
             return ctxt.getLiteralFactory().literalOf(false);
-        } else if (isNeverNull(v1) && isAlwaysNull(v2) || isAlwaysNull(v1) && isNeverNull(v2) || v1.isDefNe(v2)) {
+        } else if (!v1.isNullable() && isAlwaysNull(v2) || isAlwaysNull(v1) && !v2.isNullable() || v1.isDefNe(v2)) {
             return ctxt.getLiteralFactory().literalOf(true);
         }
 
@@ -347,10 +347,6 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             }
         }
         return super.valueConvert(input, toType);
-    }
-
-    private boolean isNeverNull(final Value v1) {
-        return !v1.isNullable();
     }
 
     public Value arrayLength(final ValueHandle arrayHandle) {

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
@@ -350,11 +350,7 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     private boolean isNeverNull(final Value v1) {
-        ValueType type = v1.getType();
-        if (isAlwaysNull(v1)) {
-            return false;
-        }
-        return ! (type instanceof ReferenceType) || ! ((ReferenceType) type).isNullable();
+        return !v1.isNullable();
     }
 
     public Value arrayLength(final ValueHandle arrayHandle) {

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapSerializer.java
@@ -143,9 +143,8 @@ public class HeapSerializer implements Consumer<CompilationContext> {
         bb.begin(merge);
         NoGc noGc = NoGc.get(ctxt);
         LoadedTypeDefinition jlo = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Object").load();
-        Value ptrValue =  bb.call(bb.staticMethod(noGc.getAllocateMethod()), List.of(sizeInBytes, ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getPointerAlignment())));
-        ptrValue = bb.call(bb.staticMethod(noGc.getZeroMethod()), List.of(ptrValue, sizeInBytes));
-        Value oop = bb.valueConvert(ptrValue, jlo.getType().getReference());
+        Value oop =  bb.call(bb.staticMethod(noGc.getAllocateMethod()), List.of(sizeInBytes, ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getPointerAlignment())));
+        bb.call(bb.staticMethod(noGc.getZeroMethod()), List.of(oop, sizeInBytes));
         bb.store(bb.instanceFieldOf(bb.referenceHandle(oop), layout.getObjectTypeIdField()), original.getParameterValue(0), MemoryAtomicityMode.UNORDERED);
         bb.return_(oop);
         bb.finish();

--- a/plugins/thread-local/src/main/java/org/qbicc/plugin/threadlocal/ThreadLocalTypeBuilder.java
+++ b/plugins/thread-local/src/main/java/org/qbicc/plugin/threadlocal/ThreadLocalTypeBuilder.java
@@ -55,7 +55,7 @@ public class ThreadLocalTypeBuilder implements DefinedTypeDefinition.Builder.Del
                             // remove unwanted modifiers
                             modifiers &= ~(ClassFile.I_ACC_THREAD_LOCAL | ClassFile.ACC_STATIC);
                             // add these modifiers
-                            modifiers |= ClassFile.I_ACC_HIDDEN;
+                            modifiers |= ClassFile.I_ACC_NO_RESOLVE | ClassFile.I_ACC_NO_REFLECT;
                             injectedFieldBuilder.setModifiers(modifiers);
                             injectedFieldBuilder.setName(resolved.getName());
                             injectedFieldBuilder.setSourceFileName(resolved.getSourceFileName());

--- a/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/LocalThrowHandlingBasicBlockBuilder.java
+++ b/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/LocalThrowHandlingBasicBlockBuilder.java
@@ -37,7 +37,7 @@ public class LocalThrowHandlingBasicBlockBuilder extends DelegatingBasicBlockBui
         BlockLabel npe = new BlockLabel();
         BasicBlock from = if_(isEq(value, lf.zeroInitializerLiteralOfType(value.getType())), npe, exceptionHandler.getHandler());
         // dispatch to the exception handler
-        exceptionHandler.enterHandler(from, value);
+        exceptionHandler.enterHandler(from, notNull(value));
         // throw an NPE to the handler instead
         begin(npe);
         ClassContext classContext = ctxt.getBootstrapClassContext();

--- a/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/LocalThrowHandlingBasicBlockBuilder.java
+++ b/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/LocalThrowHandlingBasicBlockBuilder.java
@@ -35,18 +35,19 @@ public class LocalThrowHandlingBasicBlockBuilder extends DelegatingBasicBlockBui
         LiteralFactory lf = ctxt.getLiteralFactory();
         // null check
         BlockLabel npe = new BlockLabel();
-        BasicBlock from = if_(isEq(value, lf.zeroInitializerLiteralOfType(value.getType())), npe, exceptionHandler.getHandler());
+        BasicBlockBuilder fb = getFirstBuilder();
+        BasicBlock from = fb.if_(fb.isEq(value, lf.zeroInitializerLiteralOfType(value.getType())), npe, exceptionHandler.getHandler());
         // dispatch to the exception handler
-        exceptionHandler.enterHandler(from, notNull(value));
+        exceptionHandler.enterHandler(from, fb.notNull(value));
         // throw an NPE to the handler instead
-        begin(npe);
+        fb.begin(npe);
         ClassContext classContext = ctxt.getBootstrapClassContext();
         LoadedTypeDefinition npeType = classContext.findDefinedType("java/lang/NullPointerException").load();
-        Value ex = new_(npeType.getClassType());
+        Value ex = fb.new_(npeType.getClassType());
         // pre-resolver
-        ValueHandle ctor = constructorOf(ex, npeType.getDescriptor(), MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of()));
-        call(ctor, List.of());
-        BasicBlock from2 = goto_(exceptionHandler.getHandler());
+        ValueHandle ctor = fb.constructorOf(ex, npeType.getDescriptor(), MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of()));
+        fb.call(ctor, List.of());
+        BasicBlock from2 = fb.goto_(exceptionHandler.getHandler());
         exceptionHandler.enterHandler(from2, ex);
         return from;
     }

--- a/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
+++ b/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
@@ -36,7 +36,7 @@ public class SynchronizedMethodBasicBlockBuilder extends DelegatingBasicBlockBui
         if (element.isStatic()) {
             monitor = classOf(ctxt.getLiteralFactory().literalOfType(enclosing.load().getType()));
         } else {
-            monitor = parameter(enclosing.load().getType().getReference().asNullable(), "this", 0);
+            monitor = parameter(enclosing.load().getType().getReference(), "this", 0);
         }
         throwable = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Throwable").load().getClassType().getReference();
     }

--- a/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
+++ b/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
@@ -36,7 +36,7 @@ public class SynchronizedMethodBasicBlockBuilder extends DelegatingBasicBlockBui
         if (element.isStatic()) {
             monitor = classOf(ctxt.getLiteralFactory().literalOfType(enclosing.load().getType()));
         } else {
-            monitor = parameter(enclosing.load().getType().getReference(), "this", 0);
+            monitor = notNull(parameter(enclosing.load().getType().getReference(), "this", 0));
         }
         throwable = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Throwable").load().getClassType().getReference();
     }

--- a/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
+++ b/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
@@ -63,7 +63,7 @@ public class SynchronizedMethodBasicBlockBuilder extends DelegatingBasicBlockBui
 
         ExceptionHandlerImpl(final ExceptionHandler delegate) {
             this.delegate = delegate;
-            phi = phi(throwable, new BlockLabel());
+            phi = phi(throwable, new BlockLabel(), PhiValue.Flag.NOT_NULL);
         }
 
         public BlockLabel getHandler() {

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
@@ -154,16 +154,14 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
             // it may be something we can't really cast.
             return ctxt.getLiteralFactory().undefinedLiteralOfType(castType);
         } else if (castType instanceof ReferenceType) {
-            if (value.getType() instanceof ReferenceType && value.isNullable()) {
-                castType = ((ReferenceType) castType);
-            }
-            ObjectType toType = ((ReferenceType) castType).getUpperBound();
+            ReferenceType referenceType = (ReferenceType) castType;
+            ObjectType toType = referenceType.getUpperBound();
             int toDimensions = 0;
             if (toType instanceof ReferenceArrayObjectType) {
                 toDimensions = ((ReferenceArrayObjectType) toType).getDimensionCount();
                 toType = ((ReferenceArrayObjectType) toType).getLeafElementType();
             }
-            return checkcast(value, cc.getLiteralFactory().literalOfType(toType), cc.getLiteralFactory().literalOf(toDimensions), CheckCast.CastType.Cast, (ReferenceType) castType);
+            return checkcast(value, cc.getLiteralFactory().literalOfType(toType), cc.getLiteralFactory().literalOf(toDimensions), CheckCast.CastType.Cast, referenceType);
         } else if (castType instanceof WordType) {
             // A checkcast in the bytecodes, but it is actually a WordType coming from some native magic...just bitcast it.
             WordType toType = (WordType) castType;

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
@@ -155,7 +155,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
             return ctxt.getLiteralFactory().undefinedLiteralOfType(castType);
         } else if (castType instanceof ReferenceType) {
             if (value.getType() instanceof ReferenceType && value.isNullable()) {
-                castType = ((ReferenceType)castType).asNullable();
+                castType = ((ReferenceType) castType);
             }
             ObjectType toType = ((ReferenceType) castType).getUpperBound();
             int toDimensions = 0;

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
@@ -154,7 +154,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
             // it may be something we can't really cast.
             return ctxt.getLiteralFactory().undefinedLiteralOfType(castType);
         } else if (castType instanceof ReferenceType) {
-            if (value.getType() instanceof ReferenceType && ((ReferenceType) value.getType()).isNullable()) {
+            if (value.getType() instanceof ReferenceType && value.isNullable()) {
                 castType = ((ReferenceType)castType).asNullable();
             }
             ObjectType toType = ((ReferenceType) castType).getUpperBound();

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -405,6 +405,26 @@ public final class CNative {
         return new String(bytes, StandardCharsets.US_ASCII);
     }
 
+    // conversions
+
+    /**
+     * <b>Warning:</b> this is a potentially dangerous operation and should only be performed by internal components.
+     * Directly convert a pointer to a reference.
+     *
+     * @param ptr the pointer (may be {@code null})
+     * @return the reference (may be {@code null})
+     */
+    public static native Object ptrToRef(ptr<?> ptr);
+
+    /**
+     * <b>Warning:</b> this is a potentially dangerous operation and should only be performed by internal components.
+     * Directly convert a reference to a pointer.
+     *
+     * @param ref the reference (may be {@code null})
+     * @return the pointer (may be {@code null})
+     */
+    public static native <P extends ptr<?>> P refToPtr(Object ref);
+
     // built-in
 
     /**

--- a/runtime/gc/nogc/src/main/java/org/qbicc/runtime/gc/nogc/NoGcHelpers.java
+++ b/runtime/gc/nogc/src/main/java/org/qbicc/runtime/gc/nogc/NoGcHelpers.java
@@ -14,7 +14,7 @@ import org.qbicc.runtime.Build;
 public final class NoGcHelpers {
     private NoGcHelpers() {}
 
-    public static ptr<?> allocate(long size, int align) {
+    public static Object allocate(long size, int align) {
         if (false && Build.Target.isPosix()) {
             void_ptr ptr = auto();
             c_int res = posix_memalign(addr_of(ptr), word((long)align), word(size));
@@ -34,13 +34,13 @@ public final class NoGcHelpers {
                 ptrdiff_t word = word(((~ misAlign) & mask) + 1);
                 ptr = ptr.plus(word);
             }
-            return ptr;
+            return ptrToRef(ptr);
         }
     }
 
-    public static void_ptr clear(void_ptr ptr, long size) { return memset(ptr, word(0), word(size)); }
+    public static void clear(Object ptr, long size) { memset(refToPtr(ptr), word(0), word(size)); }
 
-    public static void copy(void_ptr to, const_void_ptr from, long size) {
-        memcpy(to, from, word(size));
+    public static void copy(Object to, Object from, long size) {
+        memcpy(refToPtr(to), refToPtr(from), word(size));
     }
 }


### PR DESCRIPTION
This is a draft PR to overhaul nullability checks.  At present, all method calls are assumed to never return `null`, which is obviously incorrect.  This PR fixes that problem.

* Make nullability a property of `Value`
* Introduce a `NotNull` node that asserts the non-nullability of a `Value`
* Introduce a `BooleanValue` interface which can be used to transform outbound values based on the truth of the boolean expression (for example, if `foo != null` then uses of `foo` will see `NotNull(foo)`)
* Make `CheckCast` and `InstanceOf` implement `OrderedNode` to prevent scheduling issues
* Many misc. fixes around nullability assumptions
