### PR TITLE
Annotate sys/types.h mode_t as integer

### DIFF
--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysTypes.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysTypes.java
@@ -49,6 +49,7 @@ public final class SysTypes {
     public static final class gid_t extends word {
     }
 
+    @name("int") // integer type
     public static final class mode_t extends word {
     }
 


### PR DESCRIPTION
I'm running into an issue where compiling [UnixConstants.java](https://github.com/qbicc/qbicc-class-library/blob/main/java.base/src/main/java/sun/nio/fs/UnixConstants.java) results in this error for lines 57-72:
```
UnixConstants.java:57: error: Cannot extend a signed integer of type s32 into a wider unsigned integer of type u32: either sign-extend to s32 first or cast to u32 first
```
[sys/types.h](https://pubs.opengroup.org/onlinepubs/009696899/basedefs/sys/types.h.html) indicates that `mode_t` is an integer type.

Signed-off-by: Theresa Mammarella <tmammare@redhat.com>