### PR TITLE
Couple of fixes

### DIFF
--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -708,12 +708,14 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
             attr(param, "label", "call");
             attr(param, "fixedsize", "shape");
             nl(param);
-            addEdge(param, node, callTarget, EdgeType.VALUE_DEPENDENCY, "fn");
         }
         dependencyList.add(name);
         if (node.hasDependency()) processDependency(param, node.getDependency());
         for (Value arg : node.getArguments()) {
             addEdge(param, node, arg, EdgeType.VALUE_DEPENDENCY);
+        }
+        if (!(callTarget instanceof SymbolLiteral)) {
+            addEdge(param, node, callTarget, EdgeType.VALUE_DEPENDENCY, "fn");
         }
         return name;
     }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -37,7 +37,6 @@ public final class VMHelpers {
         return isAssignableTo(instance, typeId, dimensions);
     }
 
-    @NoSideEffects
     public static void arrayStoreCheck(Object value, type_id toTypeId, int toDimensions) {
         if (value == null || isAssignableTo(value, toTypeId, toDimensions)) {
             return;
@@ -45,14 +44,12 @@ public final class VMHelpers {
         raiseArrayStoreException();
     }
 
-    @NoSideEffects
     public static void checkcast_class (Object value, Class<?> cls) {
         type_id toTypeId = ObjectModel.get_type_id_from_class(cls);
         int toDim = ObjectModel.get_dimensions_from_class(cls);
         checkcast_typeId(value, toTypeId, toDim);
     }
 
-    @NoSideEffects
     public static void checkcast_typeId(Object value, type_id toTypeId, int toDimensions) {
         if (value == null || isAssignableTo(value, toTypeId, toDimensions)) {
             return;


### PR DESCRIPTION
1. Incorrect NoSideEffects annotation on some methods that can throw
exception
2. Process value dependency after processing order dependency when
visiting the FunctionCall node in DotNodeVisitor

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>