### PR TITLE
Use schedule in copier

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/CheckCast.java
+++ b/compiler/src/main/java/org/qbicc/graph/CheckCast.java
@@ -1,5 +1,6 @@
 package org.qbicc.graph;
 
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import org.qbicc.type.ReferenceType;
@@ -10,7 +11,8 @@ import org.qbicc.type.definition.element.ExecutableElement;
  * This node is used to implement two distinct kinds of dynamic checks:
  * arraystorechecks and checkcasts.
  */
-public final class CheckCast extends AbstractValue implements CastValue {
+public final class CheckCast extends AbstractValue implements CastValue, OrderedNode {
+    private final Node dependency;
     /**
      * The input value, which must be of type ReferenceType
      */
@@ -41,14 +43,20 @@ public final class CheckCast extends AbstractValue implements CastValue {
         }
     }
 
-    CheckCast(final Node callSite, final ExecutableElement element, final int line, final int bci, final Value input, final Value toType,
+    CheckCast(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final Value input, final Value toType,
               final Value toDimensions, CastType kind, ReferenceType type) {
         super(callSite, element, line, bci);
+        this.dependency = dependency;
         this.input = input;
         this.toType = toType;
         this.toDimensions = toDimensions;
         this.type = type;
         this.kind = kind;
+    }
+
+    @Override
+    public Node getDependency() throws NoSuchElementException {
+        return dependency;
     }
 
     public Value getInput() {
@@ -98,6 +106,7 @@ public final class CheckCast extends AbstractValue implements CastValue {
 
     public boolean equals(final CheckCast other) {
         return this == other || other != null
+            && dependency.equals(other.dependency)
             && input.equals(other.input)
             && toType.equals(other.toType)
             && toDimensions.equals(other.toDimensions)

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -480,6 +480,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final CheckCast node) {
+                param.copyNode(node.getDependency());
                 return param.getBlockBuilder().checkcast(param.copyValue(node.getInput()), param.copyValue(node.getToType()),
                     param.copyValue(node.getToDimensions()), node.getKind(), node.getType());
             }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -363,7 +363,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
                 throw new BlockEarlyTermination(unreachable());
             }
         }
-        return new CheckCast(callSite, element, line, bci, value, toType, toDimensions, kind, outputType);
+        return asDependency(new CheckCast(callSite, element, line, bci, requireDependency(), value, toType, toDimensions, kind, outputType));
     }
 
     public Value checkcast(final Value value, final TypeDescriptor desc) {

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -856,6 +856,8 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
         attr(param, "label", node.getKind() + "→" + node.getType().toString());
         attr(param, "fixedsize", "shape");
         nl(param);
+        dependencyList.add(name);
+        processDependency(param, node.getDependency());
         addEdge(param, node, node.getInput(), EdgeType.VALUE_DEPENDENCY);
         addEdge(param, node, node.getToType(), EdgeType.VALUE_DEPENDENCY);
         addEdge(param, node, node.getToDimensions(), EdgeType.VALUE_DEPENDENCY);


### PR DESCRIPTION
Using Schedule when copying nodes ensures that the nodes are processed before their dependencies.

Fixes #517 