### PR TITLE
Tools output is not displayed

### DIFF
--- a/integration-tests/src/it/java/org/qbicc/tests/integration/SimpleAppTest.java
+++ b/integration-tests/src/it/java/org/qbicc/tests/integration/SimpleAppTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import org.qbicc.context.Diagnostic;
 import org.qbicc.context.DiagnosticContext;
 import org.qbicc.tests.integration.utils.TestConstants;
 import org.qbicc.tests.integration.utils.Javac;

--- a/integration-tests/src/it/java/org/qbicc/tests/integration/utils/QbiccDiagnosticLogger.java
+++ b/integration-tests/src/it/java/org/qbicc/tests/integration/utils/QbiccDiagnosticLogger.java
@@ -19,6 +19,7 @@ public class QbiccDiagnosticLogger implements Consumer<Iterable<Diagnostic>> {
             switch (diagnostic.getLevel()) {
                 case ERROR:
                     logger.error(message);
+                    break;
                 case WARNING:
                     logger.warn(message);
                     break;


### PR DESCRIPTION
Closes #534

This PR tunes the regex that matches tools output so that it covers even cases where the line does not match the pattern `filename:row:col errorlevel message` but instead is something like `executable: message`. 

It also moves the propagation of the message outside, so a line that does not match the pattern at all is still printed as an error.