### PR TITLE
Compile clinit methods before anything else

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
@@ -14,22 +14,21 @@ public interface ExecutableElement extends MemberElement {
 
     MethodBody getPreviousMethodBody();
 
-    MethodBody getMethodBody();
-
     /**
-     * Get the executable body, or create it if it has not yet been created.  Note that this method
-     * should only be called from the top level of compilation and not reentered unless it is guaranteed that
-     * the method body has already been created.
+     * Get the executable body.  If no body was created, or the method has none, an exception is thrown.
      *
-     * @return the method body (must not be {@code null})
+     * @return the executable body (not {@code null})
+     * @throws IllegalStateException if this executable has no body
      */
-    MethodBody getOrCreateMethodBody();
+    MethodBody getMethodBody() throws IllegalStateException;
 
     /**
-     * Attempt to initiate the creation of the method body if it has not yet been initiated.  Unlike
-     * {@link #getOrCreateMethodBody()}, this method is safe to call from a reentrant context.
+     * Attempt to initiate the creation of the method body if it has not yet been initiated.
+     * This method is safe to call from a reentrant context.
+     *
+     * @return {@code true} if the element has a method body; {@code false} otherwise
      */
-    void tryCreateMethodBody();
+    boolean tryCreateMethodBody();
 
     void replaceMethodBody(MethodBody replacement);
 

--- a/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
@@ -16,7 +16,20 @@ public interface ExecutableElement extends MemberElement {
 
     MethodBody getMethodBody();
 
+    /**
+     * Get the executable body, or create it if it has not yet been created.  Note that this method
+     * should only be called from the top level of compilation and not reentered unless it is guaranteed that
+     * the method body has already been created.
+     *
+     * @return the method body (must not be {@code null})
+     */
     MethodBody getOrCreateMethodBody();
+
+    /**
+     * Attempt to initiate the creation of the method body if it has not yet been initiated.  Unlike
+     * {@link #getOrCreateMethodBody()}, this method is safe to call from a reentrant context.
+     */
+    void tryCreateMethodBody();
 
     void replaceMethodBody(MethodBody replacement);
 

--- a/compiler/src/main/java/org/qbicc/type/definition/element/InitializerElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/InitializerElement.java
@@ -38,34 +38,14 @@ public final class InitializerElement extends BasicElement implements Executable
     }
 
     public MethodBody getMethodBody() {
-        return methodBody;
-    }
-
-    public MethodBody getOrCreateMethodBody() {
         MethodBody methodBody = this.methodBody;
         if (methodBody == null) {
-            MethodBodyFactory factory = this.methodBodyFactory;
-            if (factory != null) {
-                synchronized (this) {
-                    methodBody = this.methodBody;
-                    if (methodBody == null) {
-                        if (inProgress) {
-                            throw new IllegalStateException("Recursive method body creation");
-                        }
-                        inProgress = true;
-                        try {
-                            this.methodBody = previousMethodBody = methodBody = factory.createMethodBody(methodBodyFactoryIndex, this);
-                        } finally {
-                            inProgress = false;
-                        }
-                    }
-                }
-            }
+            throw new IllegalStateException("No method body is present on this element");
         }
         return methodBody;
     }
 
-    public void tryCreateMethodBody() {
+    public boolean tryCreateMethodBody() {
         MethodBody methodBody = this.methodBody;
         if (methodBody == null) {
             MethodBodyFactory factory = this.methodBodyFactory;
@@ -74,7 +54,7 @@ public final class InitializerElement extends BasicElement implements Executable
                     methodBody = this.methodBody;
                     if (methodBody == null) {
                         if (inProgress) {
-                            return;
+                            return true;
                         }
                         inProgress = true;
                         try {
@@ -84,8 +64,11 @@ public final class InitializerElement extends BasicElement implements Executable
                         }
                     }
                 }
+            } else {
+                return false;
             }
         }
+        return true;
     }
 
     public void replaceMethodBody(final MethodBody replacement) {

--- a/compiler/src/main/java/org/qbicc/type/definition/element/InvokableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/InvokableElement.java
@@ -84,34 +84,14 @@ public abstract class InvokableElement extends AnnotatedElement implements Execu
     }
 
     public MethodBody getMethodBody() {
-        return methodBody;
-    }
-
-    public MethodBody getOrCreateMethodBody() {
         MethodBody methodBody = this.methodBody;
         if (methodBody == null) {
-            MethodBodyFactory factory = this.methodBodyFactory;
-            if (factory != null) {
-                synchronized (this) {
-                    methodBody = this.methodBody;
-                    if (methodBody == null) {
-                        if (inProgress) {
-                            throw new IllegalStateException("Recursive method body creation");
-                        }
-                        inProgress = true;
-                        try {
-                            this.methodBody = previousMethodBody = methodBody = factory.createMethodBody(methodBodyFactoryIndex, this);
-                        } finally {
-                            inProgress = false;
-                        }
-                    }
-                }
-            }
+            throw new IllegalStateException("No method body is present on this element");
         }
         return methodBody;
     }
 
-    public void tryCreateMethodBody() {
+    public boolean tryCreateMethodBody() {
         MethodBody methodBody = this.methodBody;
         if (methodBody == null) {
             MethodBodyFactory factory = this.methodBodyFactory;
@@ -120,7 +100,7 @@ public abstract class InvokableElement extends AnnotatedElement implements Execu
                     methodBody = this.methodBody;
                     if (methodBody == null) {
                         if (inProgress) {
-                            return;
+                            return true;
                         }
                         inProgress = true;
                         try {
@@ -130,8 +110,11 @@ public abstract class InvokableElement extends AnnotatedElement implements Execu
                         }
                     }
                 }
+            } else {
+                return false;
             }
         }
+        return true;
     }
 
     public void replaceMethodBody(final MethodBody replacement) {

--- a/driver/src/main/java/org/qbicc/driver/Driver.java
+++ b/driver/src/main/java/org/qbicc/driver/Driver.java
@@ -362,7 +362,7 @@ public class Driver implements Closeable {
             if (element.hasMethodBody()) {
                 // cause method and field references to be resolved
                 try {
-                    element.getOrCreateMethodBody();
+                    element.tryCreateMethodBody();
                 } catch (Exception e) {
                     log.error("An exception was thrown while constructing a method body", e);
                     compilationContext.error(element, "Exception while constructing method body: %s", e);
@@ -432,7 +432,7 @@ public class Driver implements Closeable {
             if (element.hasMethodBody()) {
                 // rewrite the method body
                 ClassContext classContext = element.getEnclosingType().getContext();
-                MethodBody original = element.getOrCreateMethodBody();
+                MethodBody original = element.getMethodBody();
                 BasicBlock entryBlock = original.getEntryBlock();
                 BasicBlockBuilder builder = classContext.newBasicBlockBuilder(element);
                 BasicBlock copyBlock = Node.Copier.execute(entryBlock, builder, compilationContext, addToAnalyzeCopiers);

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -83,6 +83,7 @@ import org.qbicc.plugin.threadlocal.ThreadLocalTypeBuilder;
 import org.qbicc.plugin.trycatch.LocalThrowHandlingBasicBlockBuilder;
 import org.qbicc.plugin.trycatch.SynchronizedMethodBasicBlockBuilder;
 import org.qbicc.plugin.trycatch.ThrowValueBasicBlockBuilder;
+import org.qbicc.plugin.verification.ClassInitializingBasicBlockBuilder;
 import org.qbicc.plugin.verification.ClassLoadingBasicBlockBuilder;
 import org.qbicc.plugin.verification.LowerVerificationBasicBlockBuilder;
 import org.qbicc.plugin.verification.MemberResolvingBasicBlockBuilder;
@@ -298,7 +299,9 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NativeBindingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, PointerBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ThreadLocalBasicBlockBuilder::new);
-                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ConstantDefiningBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ClassInitializingBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ConstantDefiningBasicBlockBuilder::createIfNeeded);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ConstantBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ThrowValueBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, MethodCallFixupBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, SynchronizedMethodBasicBlockBuilder::createIfNeeded);
@@ -319,7 +322,6 @@ public class Main implements Callable<DiagnosticContext> {
                                     builder.addCopyFactory(Phase.ANALYZE, PhiOptimizerVisitor::new);
                                 }
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
-                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, ConstantBasicBlockBuilder::new);
                                 if (optMemoryTracking) {
                                     builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, LocalMemoryTrackingBasicBlockBuilder::new);
                                 }

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotGenerator.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotGenerator.java
@@ -65,9 +65,11 @@ public class DotGenerator implements ElementVisitor<CompilationContext, Void>, C
     public Void visitUnknown(final CompilationContext param, final BasicElement basicElement) {
         if (basicElement instanceof ExecutableElement) {
             ExecutableElement element = (ExecutableElement) basicElement;
-            MethodBody methodBody = element.getOrCreateMethodBody();
-            if (methodBody != null && filter != null && filter.accept(element, phase)) {
-                process(element, methodBody);
+            if (element.hasMethodBody()) {
+                MethodBody methodBody = element.getMethodBody();
+                if (filter != null && filter.accept(element, phase)) {
+                    process(element, methodBody);
+                }
             }
         }
         return null;

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -713,6 +713,11 @@ public final class CoreIntrinsics {
             ctxt.getLiteralFactory().literalOf(0);
 
         intrinsics.registerIntrinsic(cNativeDesc, "zero", MethodDescriptor.synthesize(classContext, nObjDesc, List.of()), zero);
+
+        StaticIntrinsic constant = (builder, target, arguments) ->
+            ctxt.getLiteralFactory().constantLiteralOfType(ctxt.getTypeSystem().getPoisonType());
+
+        intrinsics.registerIntrinsic(cNativeDesc, "constant", MethodDescriptor.synthesize(classContext, nObjDesc, List.of()), constant);
     }
 
     static void registerOrgQbiccObjectModelIntrinsics(final CompilationContext ctxt) {

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstantDefiningBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstantDefiningBasicBlockBuilder.java
@@ -37,13 +37,21 @@ import org.qbicc.type.descriptor.ClassTypeDescriptor;
 public class ConstantDefiningBasicBlockBuilder extends DelegatingBasicBlockBuilder implements ValueHandleVisitor<Void, Value> {
     private final CompilationContext ctxt;
 
-    public ConstantDefiningBasicBlockBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+    private ConstantDefiningBasicBlockBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
         super(delegate);
         ExecutableElement element = getCurrentElement();
         if (element instanceof InitializerElement) {
             NativeInfo.get(ctxt).registerInitializer((InitializerElement) element);
         }
         this.ctxt = ctxt;
+    }
+
+    public static BasicBlockBuilder createIfNeeded(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+        if (delegate.getCurrentElement() instanceof InitializerElement) {
+            return new ConstantDefiningBasicBlockBuilder(ctxt, delegate);
+        } else {
+            return delegate;
+        }
     }
 
     @Override

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstantDefiningBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstantDefiningBasicBlockBuilder.java
@@ -1,22 +1,18 @@
 package org.qbicc.plugin.native_;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.qbicc.context.CompilationContext;
 import org.qbicc.context.Location;
 import org.qbicc.driver.Driver;
 import org.qbicc.graph.BasicBlockBuilder;
-import org.qbicc.graph.BlockLabel;
 import org.qbicc.graph.CastValue;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.StaticField;
-import org.qbicc.graph.StaticMethodElementHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
-import org.qbicc.graph.ValueHandleVisitor;
 import org.qbicc.graph.literal.ConstantLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.machine.probe.CProbe;
@@ -27,14 +23,13 @@ import org.qbicc.type.annotation.StringAnnotationValue;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
-import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
  * This block builder replaces calls to the {@link CNative#constant()} method with a registration of the constant
  * field value.
  */
-public class ConstantDefiningBasicBlockBuilder extends DelegatingBasicBlockBuilder implements ValueHandleVisitor<Void, Value> {
+public class ConstantDefiningBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     private final CompilationContext ctxt;
 
     private ConstantDefiningBasicBlockBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
@@ -52,23 +47,6 @@ public class ConstantDefiningBasicBlockBuilder extends DelegatingBasicBlockBuild
         } else {
             return delegate;
         }
-    }
-
-    @Override
-    public Value load(ValueHandle handle, MemoryAtomicityMode mode) {
-        if (handle instanceof StaticField) {
-            FieldElement fieldElement = ((StaticField) handle).getVariableElement();
-            if (fieldElement.isReallyFinal()) {
-                // initialize the constant if any
-                InitializerElement initializerElement = fieldElement.getEnclosingType().load().getInitializer();
-                if (NativeInfo.get(ctxt).registerInitializer(initializerElement)) {
-                    if (initializerElement.hasMethodBody()) {
-                        initializerElement.getOrCreateMethodBody();
-                    }
-                }
-            }
-        }
-        return super.load(handle, mode);
     }
 
     @Override
@@ -91,41 +69,6 @@ public class ConstantDefiningBasicBlockBuilder extends DelegatingBasicBlockBuild
             return nop();
         }
         return super.store(handle, value, mode);
-    }
-
-    @Override
-    public Value call(ValueHandle target, List<Value> arguments) {
-        Value result = target.accept(this, null);
-        return result == null ? super.call(target, arguments) : result;
-    }
-
-    @Override
-    public Value callNoSideEffects(ValueHandle target, List<Value> arguments) {
-        Value result = target.accept(this, null);
-        return result == null ? super.callNoSideEffects(target, arguments) : result;
-    }
-
-    @Override
-    public Value invoke(ValueHandle target, List<Value> arguments, BlockLabel catchLabel, BlockLabel resumeLabel) {
-        Value result = target.accept(this, null);
-        if (result == null) {
-            return super.invoke(target, arguments, catchLabel, resumeLabel);
-        } else {
-            goto_(resumeLabel);
-            return result;
-        }
-    }
-
-    @Override
-    public Value visit(Void param, StaticMethodElementHandle node) {
-        MethodElement target = node.getExecutable();
-        if (target.getEnclosingType().internalPackageAndNameEquals(Native.NATIVE_PKG, Native.C_NATIVE)) {
-            if (target.getName().equals("constant")) {
-                // it's a constant but we don't yet know its type
-                return ctxt.getLiteralFactory().constantLiteralOfType(ctxt.getTypeSystem().getPoisonType());
-            }
-        }
-        return null;
     }
 
     private void processConstant(final FieldElement fieldElement) {

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBindingTypeBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBindingTypeBuilder.java
@@ -52,14 +52,14 @@ public class NativeBindingTypeBuilder implements DefinedTypeDefinition.Builder.D
                     if (nativeType != null) {
                         // found the native type; check for corresponding method
                         MethodElement nativeMethod = nativeType.load().resolveMethodElementExact(origMethod.getName(), origMethod.getDescriptor());
-                        if (nativeMethod != null && nativeMethod.hasMethodBody()) {
+                        if (nativeMethod != null && nativeMethod.tryCreateMethodBody()) {
                             // there's a match
                             if (isBinding) {
                                 // register reverse binding to remap calls
                                 NativeInfo.get(ctxt).registerNativeBinding(nativeMethod, origMethod);
                             } else {
                                 // plug in replacement method body, let calls flow naturally
-                                origMethod.replaceMethodBody(origMethod.getOrCreateMethodBody());
+                                origMethod.replaceMethodBody(nativeMethod.getMethodBody());
                             }
                         } else {
                             log.debugf("No match found for native method %s in bindings class %s", origMethod, nativeType.getInternalName());

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapSerializer.java
@@ -109,7 +109,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.allocateClass(int, bool, bool)
     private static void allocateClassImpl(CompilationContext ctxt, MethodElement meth, LoadedTypeDefinition[] classes) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
         Layout layout = Layout.get(ctxt);
 
         int numCases = classes.length;
@@ -156,7 +156,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.allocatePrimitiveArray(int, int, bool, bool)
     private static void allocatePrimitiveArrayImpl(CompilationContext ctxt, MethodElement meth) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
 
         PrimitiveArrayObjectType[] primArrays = new PrimitiveArrayObjectType[8];
         primArrays[0] = ctxt.getTypeSystem().getBooleanType().getPrimitiveArrayObjectType();
@@ -204,7 +204,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.allocateReferenceArray(int, int, bool, bool)
     private static void allocateReferenceArrayImpl(CompilationContext ctxt, MethodElement meth) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
         LoadedTypeDefinition jlo = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Object").load();
         Layout layout = Layout.get(ctxt);
 
@@ -223,7 +223,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.createString(byte[], byte, bool, bool)
     private static void createStringImpl(CompilationContext ctxt, MethodElement meth) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
 
         bb.begin(new BlockLabel());
         LoadedTypeDefinition jls = ctxt.getBootstrapClassContext().findDefinedType("java/lang/String").load();
@@ -239,7 +239,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.deserializeInstanceFields(int, Object, Deserializer)
     private static void deserializeInstanceFieldsImpl(CompilationContext ctxt, MethodElement meth, LoadedTypeDefinition[] classes) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
         LoadedTypeDefinition deser = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/deserialization/Deserializer").load();
 
         int numCases = classes.length;
@@ -311,7 +311,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.deserializePrimitiveArrayData(int, int, Object, Deserializer)
     private static void deserializePrimitiveArrayDataImpl(CompilationContext ctxt, MethodElement meth) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
         LiteralFactory lf = ctxt.getLiteralFactory();
 
         LoadedTypeDefinition deser = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/deserialization/Deserializer").load();
@@ -384,7 +384,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.deserializeHeap(Deserializer)
     private static void deserializeHeapImpl(CompilationContext ctxt, MethodElement meth, BuildtimeHeap heap) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
         LoadedTypeDefinition deserializerType = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/deserialization/Deserializer").load();
         MethodElement readObject = deserializerType.getMethod(deserializerType.findMethodIndex(e -> "readObject".equals(e.getName())));
 
@@ -403,7 +403,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.getNumberOfPickledObjects()
     private static void getNumberOfPickledObjectsImpl(CompilationContext ctxt, MethodElement meth, BuildtimeHeap heap) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
 
         bb.begin(new BlockLabel());
         bb.return_(ctxt.getLiteralFactory().literalOf(heap.getNumberOfObjects()));
@@ -415,7 +415,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
     // Implementation of RuntimeObjectDeserializer.getPickledHeap()
     private static void getPickledHeapImpl(CompilationContext ctxt, MethodElement meth, CompoundType heapCT) {
         BasicBlockBuilder bb = ctxt.getBootstrapClassContext().newBasicBlockBuilder(meth);
-        MethodBody original = meth.getOrCreateMethodBody();
+        MethodBody original = meth.getMethodBody();
 
         bb.begin(new BlockLabel());
         bb.return_(bb.bitCast(ctxt.getLiteralFactory().literalOfSymbol(heapSymbol, heapCT.getPointer()),

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/ClassInitializingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/ClassInitializingBasicBlockBuilder.java
@@ -1,0 +1,109 @@
+package org.qbicc.plugin.verification;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.type.ClassObjectType;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.ConstructorElement;
+import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.InitializerElement;
+import org.qbicc.type.definition.element.MethodElement;
+
+/**
+ *
+ */
+public class ClassInitializingBasicBlockBuilder extends DelegatingBasicBlockBuilder {
+
+    private final CompilationContext ctxt;
+
+    public ClassInitializingBasicBlockBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+        super(delegate);
+        this.ctxt = ctxt;
+    }
+
+    @Override
+    public ValueHandle instanceFieldOf(ValueHandle instance, FieldElement field) {
+        initialize(field.getEnclosingType());
+        return super.instanceFieldOf(instance, field);
+    }
+
+    @Override
+    public ValueHandle staticField(FieldElement field) {
+        initializeStaticMember(field.getEnclosingType());
+        return super.staticField(field);
+    }
+
+    @Override
+    public ValueHandle exactMethodOf(Value instance, MethodElement method) {
+        initialize(method.getEnclosingType());
+        return super.exactMethodOf(instance, method);
+    }
+
+    @Override
+    public ValueHandle virtualMethodOf(Value instance, MethodElement method) {
+        initialize(method.getEnclosingType());
+        return super.virtualMethodOf(instance, method);
+    }
+
+    @Override
+    public ValueHandle staticMethod(MethodElement method) {
+        initializeStaticMember(method.getEnclosingType());
+        return super.staticMethod(method);
+    }
+
+    @Override
+    public ValueHandle constructorOf(Value instance, ConstructorElement constructor) {
+        initialize(constructor.getEnclosingType());
+        return super.constructorOf(instance, constructor);
+    }
+
+    @Override
+    public Value new_(ClassObjectType type) {
+        initialize(type.getDefinition());
+        return super.new_(type);
+    }
+
+    private void initializeStaticMember(DefinedTypeDefinition definition) {
+        if (definition.isInterface()) {
+            initializeSingle(definition.load());
+        } else {
+            initialize(definition);
+        }
+    }
+
+    private void initialize(DefinedTypeDefinition definition) {
+        LoadedTypeDefinition ltd = definition.load();
+        if (ltd.hasSuperClass()) {
+            LoadedTypeDefinition superClass = ltd.getSuperClass();
+            if (superClass != null) {
+                initialize(superClass);
+            }
+        }
+        maybeInitializeInterfaces(ltd);
+        initializeSingle(ltd);
+    }
+
+    private void initializeSingle(final LoadedTypeDefinition ltd) {
+        InitializerElement initializer = ltd.getInitializer();
+        if (initializer != null) {
+            ctxt.enqueue(initializer);
+            initializer.tryCreateMethodBody();
+        }
+    }
+
+    private void maybeInitializeInterfaces(LoadedTypeDefinition ltd) {
+        int cnt = ltd.getInterfaceCount();
+        for (int i = 0; i < cnt; i ++) {
+            LoadedTypeDefinition interfaceLtd = ltd.getInterface(i);
+            if (interfaceLtd.declaresDefaultMethods()) {
+                initialize(interfaceLtd);
+            } else {
+                maybeInitializeInterfaces(interfaceLtd);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change fixes the constant ordering issue.  It's based on #531 so it's not as big as it looks... only the last two commits belong to this change.

This might provide a basis to simplify #530 by allowing clinits to be recursively compiled, and maybe re-enqueued as well.

Use this link to see just the two commits: a9e56d6...f305662