### PR TITLE
Class init: support initializing interfaces

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/TypeType.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeType.java
@@ -6,7 +6,7 @@ import java.util.Objects;
  * A type that represents the type of a value that is itself a type.  Values of this type are lowered to type identifiers
  * once the full set of reachable types is determined.
  */
-public final class TypeType extends org.qbicc.type.ValueType {
+public final class TypeType extends WordType {
     private final ValueType upperBound;
 
     TypeType(final TypeSystem typeSystem, final ValueType upperBound) {
@@ -44,5 +44,10 @@ public final class TypeType extends org.qbicc.type.ValueType {
 
     public StringBuilder toFriendlyString(final StringBuilder b) {
         return upperBound.toFriendlyString(b.append("typeof").append('.'));
+    }
+
+    @Override
+    public int getMinBits() {
+        return typeSystem.getTypeIdSize() * typeSystem.getByteBits();
     }
 }

--- a/plugins/conversion/src/main/java/org/qbicc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
+++ b/plugins/conversion/src/main/java/org/qbicc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
@@ -16,6 +16,7 @@ import org.qbicc.type.IntegerType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
+import org.qbicc.type.TypeType;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
@@ -230,6 +231,13 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
             }
         } else if (fromTypeRaw instanceof ReferenceType) {
             if (toTypeRaw instanceof PointerType) {
+                return super.valueConvert(from, toTypeRaw);
+            }
+        } else if (fromTypeRaw instanceof TypeType) {
+            if (toTypeRaw instanceof IntegerType) {
+                if (fromTypeRaw.getSize() > toTypeRaw.getSize()) {
+                    ctxt.error(getLocation(), "Invalid typeid conversion to narrower type %s", fromTypeRaw);
+                }
                 return super.valueConvert(from, toTypeRaw);
             }
         }

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -887,13 +887,13 @@ public final class CoreIntrinsics {
         intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_first_interface_typeid", emptyTotypeIdDesc, get_first_interface_typeid);
 
         // public static native int get_number_of_bytes_in_interface_bits_array();
-        StaticValueIntrinsic get_number_of_bytes_in_interface_bits_array = (builder, owner, name, descriptor, arguments) -> {
+        StaticIntrinsic get_number_of_bytes_in_interface_bits_array = (builder, target, arguments) -> {
             return lf.literalOf(tables.getNumberOfBytesInInterfaceBitsArray());
         };
         intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_number_of_bytes_in_interface_bits_array", IntDesc, get_number_of_bytes_in_interface_bits_array);
 
         // public static native byte get_byte_of_interface_bits(CNative.type_id typeId, int index);
-        StaticValueIntrinsic get_byte_of_interface_bits = (builder, owner, name, descriptor, arguments) -> {
+        StaticIntrinsic get_byte_of_interface_bits = (builder, target, arguments) -> {
             Value typeId = arguments.get(0);
             Value index = arguments.get(1);
             GlobalVariableElement typeIdGlobal = tables.getAndRegisterGlobalTypeIdArray(builder.getCurrentElement());

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -428,6 +428,12 @@ public final class CoreIntrinsics {
             ctxt.getLiteralFactory().literalOf(0);
         intrinsics.registerIntrinsic(objDesc, "hashCode", hashCodeDesc, hashCodeIntrinsic);
 
+        // TODO: replace this do nothing stub of notifyAll with real implementation
+        MethodDescriptor notifyAllDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of());
+        InstanceIntrinsic notifyAllIntrinsic = (builder, instance, target, arguments) -> 
+            ctxt.getLiteralFactory().zeroInitializerLiteralOfType(ctxt.getTypeSystem().getVoidType()); // Do nothing
+        intrinsics.registerIntrinsic(objDesc, "notifyAll", notifyAllDesc, notifyAllIntrinsic);
+
         InstanceIntrinsic clone = (builder, instance, target, arguments) -> {
             ValueType instanceType = instance.getType();
             if (instanceType instanceof ReferenceType) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -738,6 +738,7 @@ public final class CoreIntrinsics {
         MethodDescriptor clsInt = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of(clsDesc));
         MethodDescriptor IntDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of());
         MethodDescriptor emptyTotypeIdDesc = MethodDescriptor.synthesize(classContext, typeIdDesc, List.of());
+        MethodDescriptor typeIdIntToByteDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.B, List.of(typeIdDesc, BaseTypeDescriptor.I));
 
         StaticIntrinsic typeOf = (builder, target, arguments) ->
             builder.typeIdOf(builder.referenceHandle(arguments.get(0)));
@@ -884,6 +885,24 @@ public final class CoreIntrinsics {
             return lf.literalOf(tables.getFirstInterfaceTypeId());
         };
         intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_first_interface_typeid", emptyTotypeIdDesc, get_first_interface_typeid);
+
+        // public static native int get_number_of_bytes_in_interface_bits_array();
+        StaticValueIntrinsic get_number_of_bytes_in_interface_bits_array = (builder, owner, name, descriptor, arguments) -> {
+            return lf.literalOf(tables.getNumberOfBytesInInterfaceBitsArray());
+        };
+        intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_number_of_bytes_in_interface_bits_array", IntDesc, get_number_of_bytes_in_interface_bits_array);
+
+        // public static native byte get_byte_of_interface_bits(CNative.type_id typeId, int index);
+        StaticValueIntrinsic get_byte_of_interface_bits = (builder, owner, name, descriptor, arguments) -> {
+            Value typeId = arguments.get(0);
+            Value index = arguments.get(1);
+            GlobalVariableElement typeIdGlobal = tables.getAndRegisterGlobalTypeIdArray(builder.getCurrentElement());
+            ValueHandle typeIdStruct = builder.elementOf(builder.globalVariable(typeIdGlobal), typeId);
+            ValueHandle bits = builder.memberOf(typeIdStruct, tables.getGlobalTypeIdStructType().getMember("interfaceBits"));
+            Value dataByte = builder.load(builder.elementOf(bits, index), MemoryAtomicityMode.UNORDERED);
+            return dataByte;
+        };
+        intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_byte_of_interface_bits", typeIdIntToByteDesc, get_byte_of_interface_bits);
     }
 
     static void registerOrgQbiccRuntimeValuesIntrinsics(final CompilationContext ctxt) {

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -150,4 +150,8 @@ public class ObjectModel {
     public static native CNative.type_id get_superclass_typeid(CNative.type_id typeId);
 
     public static native CNative.type_id get_first_interface_typeid();
+
+    public static native int get_number_of_bytes_in_interface_bits_array();
+
+    public static native byte get_byte_of_interface_bits(CNative.type_id typeId, int index);
 }


### PR DESCRIPTION
Walk the `qcc_typeid_array[typeid].interfaceBits` to find all the interfaces that are implemented by the current class.  This finds the full set of interfaces that a class implements.  Only interfaces that `ObjectModel.declares_default_methods(type_id)` actually need to be initialized.  This initializes the right interfaces but the ordering doesn't match the spec yet.

TypeType is now a WordType so it can be created at runtime from an integer.

Added some helper methods to print numbers to allow tracing class initialization.  They should be removed when we have a better way to trace runtime actions (JFR?).

Stubbed out `Object.notifyAll()` so the initialization state machine can use it before locks are fully supported.