### PR TITLE
Fix forEachInterfaceFullImplementedSet() to actually walk superinterfaces

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -124,6 +124,9 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
             Collections.addAll(worklist, cur.getInterfaces());
             cur = cur.getSuperClass();
         }
+        if (this.isInterface()) {
+            worklist.add(this);
+        }
         // worklist contains all directly implemented interfaces in the super class chain
         HashSet<LoadedTypeDefinition> visited = new HashSet<>();
         while (!worklist.isEmpty()) {

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -1,6 +1,9 @@
 package org.qbicc.type.definition;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -115,13 +118,22 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
     }
 
     public void forEachInterfaceFullImplementedSet(Consumer<LoadedTypeDefinition> function) {
-        for (LoadedTypeDefinition i : interfaces) {
-            function.accept(i);
+        ArrayDeque<LoadedTypeDefinition> worklist = new ArrayDeque<>();
+        LoadedTypeDefinition cur = this;
+        while (cur != null) {
+            Collections.addAll(worklist, cur.getInterfaces());
+            cur = cur.getSuperClass();
         }
-        // Walk up the heirarchy and visit each inteface from the the superclass
-        LoadedTypeDefinition superClass = getSuperClass();
-        if (superClass != null) {
-            superClass.forEachInterfaceFullImplementedSet(function);
+        // worklist contains all directly implemented interfaces in the super class chain
+        HashSet<LoadedTypeDefinition> visited = new HashSet<>();
+        while (!worklist.isEmpty()) {
+            LoadedTypeDefinition ltd = worklist.pop();
+            if (!visited.contains(ltd)) {
+                visited.add(ltd);
+                function.accept(ltd);
+                // Now add the interface's superinterface hierarchy to the worklist
+                Collections.addAll(worklist, ltd.getInterfaces());
+            }
         }
     }
 

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -131,8 +131,7 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
         HashSet<LoadedTypeDefinition> visited = new HashSet<>();
         while (!worklist.isEmpty()) {
             LoadedTypeDefinition ltd = worklist.pop();
-            if (!visited.contains(ltd)) {
-                visited.add(ltd);
+            if (visited.add(ltd)) {
                 function.accept(ltd);
                 // Now add the interface's superinterface hierarchy to the worklist
                 Collections.addAll(worklist, ltd.getInterfaces());
@@ -226,4 +225,3 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
         return hasDefaultMethods;
     }
 }
-

--- a/integration-tests/src/it/java/org/qbicc/tests/integration/SnippetsTest.java
+++ b/integration-tests/src/it/java/org/qbicc/tests/integration/SnippetsTest.java
@@ -60,7 +60,8 @@ public class SnippetsTest {
         assertTrue(stdErr.toString().isBlank(), "Native image execution should produce no error. " + stdErr);
 
         assertTrue(outputPattern.matcher(stdOut.toString()).matches(),
-            "Standard output should have matched the pattern: " +
-                outputPattern.pattern());
+            "Standard output should have matched the pattern:\n[" +
+                outputPattern.pattern() +
+                "] but output was:\n["+ stdOut.toString() + "]");
     }
 }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -324,25 +324,13 @@ public class SupersDisplayTables {
 
     byte[] getImplementedInterfaceBits(LoadedTypeDefinition cls) {
         byte[] setBits = new byte[getNumberOfBytesInInterfaceBitsArray()];
-        ArrayDeque<LoadedTypeDefinition> worklist = new ArrayDeque<>();
-        if (cls.isInterface()) {
-            worklist.add(cls);
-        } else {
-            LoadedTypeDefinition cur = cls;
-            while (cur != null) {
-                worklist.addAll(List.of(cur.getInterfaces()));
-                cur = cur.getSuperClass();
-            }
-        }
-        while (!worklist.isEmpty()) {
-            LoadedTypeDefinition i = worklist.pop();
-            worklist.addAll(List.of(i.getInterfaces()));
+        cls.forEachInterfaceFullImplementedSet(i -> {
             IdAndRange idRange = typeids.get(i);
             if (idRange != null) {
                 int index = idRange.implementedInterfaceByteIndex();
                 setBits[index] |= idRange.implementedInterfaceBitMask();
             }
-        }
+        });
 
         return setBits;
     }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -375,7 +375,7 @@ public class SupersDisplayTables {
         }
         
         LiteralFactory lf = ctxt.getLiteralFactory();
-        supersLog.debug("[[Flags] ID["+ ltd.getTypeId() + "] Flags = " + Integer.toBinaryString(flags) + ltd.getInternalName() + "]");
+        supersLog.debug("[[Flags] ID["+ ltd.getTypeId() + "] Flags = " + Integer.toBinaryString(flags) + " : " + ltd.getInternalName() + "]");
         return lf.literalOf(type, flags);
     }
 


### PR DESCRIPTION
Dave correctly pointed out that the original implementation only
walked the directly implemented interfaces of the target class
and its superclasses.

It was missing the walk of the interfaces super-interfaces.

I've now corrected the implementation and tightend it to only visit
each interface once.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>