### PR TITLE
reduce clang warnings on MacOS

### DIFF
--- a/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/AbstractClangInvoker.java
+++ b/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/AbstractClangInvoker.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.qbicc.machine.arch.Platform;
 import org.qbicc.machine.tool.CompilationFailureException;
 import org.qbicc.machine.tool.MessagingToolInvoker;
 import org.qbicc.machine.tool.ToolMessageHandler;
@@ -92,7 +93,6 @@ abstract class AbstractClangInvoker implements MessagingToolInvoker {
         OutputDestination errorHandler = OutputDestination.of(AbstractClangInvoker::collectError, this, StandardCharsets.UTF_8);
         List<String> cmd = new ArrayList<>();
         cmd.add(getTool().getExecutablePath().toString());
-        cmd.add("-pthread");
         addArguments(cmd);
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(cmd);

--- a/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangCCompilerInvokerImpl.java
+++ b/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangCCompilerInvokerImpl.java
@@ -82,7 +82,11 @@ final class ClangCCompilerInvokerImpl extends AbstractClangInvoker implements Cl
         Platform platform = getTool().getPlatform();
         cmd.add("-target");
         cmd.add(platform.getCpu().toString() + "-" + platform.getOs().toString() + "-" + platform.getAbi().toString());
-        Collections.addAll(cmd, "-std=gnu11", "-f" + "input-charset=UTF-8", "-pipe");
+        if (sourceLanguage == SourceLanguage.C) {
+            Collections.addAll(cmd, "-std=gnu11", "-f" + "input-charset=UTF-8");
+            cmd.add("-pthread");
+        }
+        cmd.add("-pipe");
         for (Path includePath : includePaths) {
             cmd.add("-I" + includePath.toString());
         }

--- a/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangLinkerInvokerImpl.java
+++ b/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangLinkerInvokerImpl.java
@@ -78,6 +78,7 @@ final class ClangLinkerInvokerImpl extends AbstractClangInvoker implements Clang
         } else {
             cmd.add("-no-pie");
         }
+        cmd.add("-pthread");
 
         for (Path libraryPath : libraryPaths) {
             cmd.add("-L" + libraryPath.toString());


### PR DESCRIPTION
1. push -pthread option down to the compiler/linker invokers
2. only give -std, -pthread, -input-charset when source language is C