### PR TITLE
Include test / snippet name in stderr & stdout output

### DIFF
--- a/integration-tests/src/it/java/org/qbicc/tests/integration/SimpleAppTest.java
+++ b/integration-tests/src/it/java/org/qbicc/tests/integration/SimpleAppTest.java
@@ -46,7 +46,7 @@ public class SimpleAppTest {
 
         StringBuilder stdOut = new StringBuilder();
         StringBuilder stdErr = new StringBuilder();
-        NativeExecutable.run(outputExecutable, stdOut, stdErr, LOGGER);
+        NativeExecutable.run(appName, outputExecutable, stdOut, stdErr, LOGGER);
 
         assertTrue(stdErr.toString().isBlank(), "Native image execution should produce no error. " + stdErr);
         assertEquals("hello world", stdOut.toString().trim());
@@ -75,7 +75,7 @@ public class SimpleAppTest {
 
         StringBuilder stdOut = new StringBuilder();
         StringBuilder stdErr = new StringBuilder();
-        NativeExecutable.run(outputExecutable, stdOut, stdErr, LOGGER);
+        NativeExecutable.run(appName, outputExecutable, stdOut, stdErr, LOGGER);
 
         assertTrue(stdErr.toString().isBlank(), "Native image execution should produce no error. " + stdErr);
         assertEquals("1 1", stdOut.toString().trim());

--- a/integration-tests/src/it/java/org/qbicc/tests/integration/SnippetsTest.java
+++ b/integration-tests/src/it/java/org/qbicc/tests/integration/SnippetsTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import org.qbicc.context.DiagnosticContext;
+import org.qbicc.machine.tool.ToolExecutionFailureException;
 import org.qbicc.tests.integration.utils.Javac;
 import org.qbicc.tests.integration.utils.NativeExecutable;
 import org.qbicc.tests.integration.utils.Qbicc;
@@ -49,7 +50,12 @@ public class SnippetsTest {
 
         StringBuilder stdOut = new StringBuilder();
         StringBuilder stdErr = new StringBuilder();
-        NativeExecutable.run(outputExecutable, stdOut, stdErr, LOGGER);
+        try {
+            NativeExecutable.run(snippetName, outputExecutable, stdOut, stdErr, LOGGER);
+        } catch(ToolExecutionFailureException e) {
+            // ensure snippet name gets included in the output message
+            throw new ToolExecutionFailureException("Failed building: `"+ snippetName +"`", e);
+        }
 
         assertTrue(stdErr.toString().isBlank(), "Native image execution should produce no error. " + stdErr);
 

--- a/integration-tests/src/it/java/org/qbicc/tests/integration/utils/NativeExecutable.java
+++ b/integration-tests/src/it/java/org/qbicc/tests/integration/utils/NativeExecutable.java
@@ -8,16 +8,16 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 public class NativeExecutable {
-    public static void run(Path outputExecutable, StringBuilder stdOut, StringBuilder stdErr, Logger logger) throws IOException {
+    public static void run(String name, Path outputExecutable, StringBuilder stdOut, StringBuilder stdErr, Logger logger) throws IOException {
         OutputDestination stdOutDest = OutputDestination.of(stdOut);
         OutputDestination stdErrDest = OutputDestination.of(stdErr);
         ProcessBuilder processBuilder = new ProcessBuilder(outputExecutable.toString());
         OutputDestination process = OutputDestination.of(processBuilder, stdErrDest, stdOutDest);
         InputSource.empty().transferTo(process);
 
-        logger.infof("Process standard output:%n%s", stdOut);
+        logger.infof("Process(" + name + ") standard output:%n%s", stdOut);
         if (!stdErr.toString().isBlank()) {
-            logger.warnf("Process standard error:%n%s", stdErr);
+            logger.warnf("Process(" + name + ") standard error:%n%s", stdErr);
         }
     }
 


### PR DESCRIPTION
Output looks like:
```
2021-06-09 10:42:13.756 INFO  [o.q.t.i.u.NativeExecutable] (run) Process(Arrays) standard output:
```

Found this to be useful when trying to diagnose which Snippet test failed.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>