### PR TITLE
Format large arrays with one item per line and append item index

### DIFF
--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/ArrayImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/ArrayImpl.java
@@ -5,7 +5,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import org.qbicc.machine.llvm.Array;
+import org.qbicc.machine.llvm.IdentifiedType;
 import org.qbicc.machine.llvm.LLValue;
+import org.qbicc.machine.llvm.StructType;
 
 final class ArrayImpl extends AbstractValue implements Array {
     final AbstractValue elementType;
@@ -23,17 +25,30 @@ final class ArrayImpl extends AbstractValue implements Array {
     public Appendable appendTo(final Appendable target) throws IOException {
         target.append('[');
         Iterator<AbstractValue> iterator = values.iterator();
+        boolean multiLineOutput = false;
+        if (values.size() > 20) {
+            // complex types are easier to read if output across multiple lines
+            multiLineOutput = true;
+            target.append('\n');
+        }
         if (iterator.hasNext()) {
+            int index = 0;
             target.append(' ');
             elementType.appendTo(target);
             target.append(' ');
             iterator.next().appendTo(target);
             while (iterator.hasNext()) {
                 target.append(',');
+                if (multiLineOutput) {
+                    target.append(" ; " + index++ + " \n");
+                }
                 target.append(' ');
                 elementType.appendTo(target);
                 target.append(' ');
                 iterator.next().appendTo(target);
+            }
+            if (index > 0 && multiLineOutput) {
+                target.append(" ; " + index++ + " \n");
             }
         }
         target.append(' ');


### PR DESCRIPTION
Output looks like:
```
@qbicc_typeid_array = global [189 x %T.struct.typeIds] [
 %T.struct.typeIds zeroinitializer, ; 0
 %T.struct.typeIds { i32 1, i32 1, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 1
 %T.struct.typeIds { i32 2, i32 2, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 2
 %T.struct.typeIds { i32 3, i32 3, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 3
 %T.struct.typeIds { i32 4, i32 4, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 4
 %T.struct.typeIds { i32 5, i32 5, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 5
 %T.struct.typeIds { i32 6, i32 6, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 6
 %T.struct.typeIds { i32 7, i32 7, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 7
 %T.struct.typeIds { i32 8, i32 8, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 8
 %T.struct.typeIds { i32 9, i32 9, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 9
 %T.struct.typeIds { i32 10, i32 188, i32 0, [4 x i8] zeroinitializer, i32 0 }, ; 10
 %T.struct.typeIds { i32 11, i32 11, i32 30, [4 x i8] [ i8 0, i8 0, i8 48, i8 0 ], i32 4 }, ; 11
 %T.struct.typeIds { i32 12, i32 12, i32 30, [4 x i8] [ i8 0, i8 0, i8 48, i8 0 ], i32 4 }, ; 12

```

Signed-off-by: Dan Heidinga <heidinga@redhat.com>