### PR TITLE
Heap serialization: configurable endianness

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -3,6 +3,7 @@ package org.qbicc.type;
 import java.lang.invoke.ConstantBootstraps;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,6 +24,7 @@ public final class TypeSystem {
     private final int referenceAlign;
     private final int typeIdSize;
     private final int typeIdAlign;
+    private final ByteOrder endianness;
     private final VariadicType variadicType = new VariadicType(this);
     private final PoisonType poisonType = new PoisonType(this);
     private final VoidType voidType = new VoidType(this);
@@ -56,6 +58,7 @@ public final class TypeSystem {
         booleanType = new BooleanType(this, builder.getBoolSize(), builder.getBoolAlignment());
         typeIdSize = builder.getTypeIdSize();
         typeIdAlign = builder.getTypeIdAlignment();
+        endianness = builder.getEndianness();
         int float32Size = builder.getFloat32Size();
         if (float32Size * byteBits < 32) {
             throw typeTooSmall("float32");
@@ -168,6 +171,10 @@ public final class TypeSystem {
      */
     public int getTypeIdAlignment() {
         return typeIdAlign;
+    }
+
+    public ByteOrder getEndianness() {
+        return endianness;
     }
 
     public CompoundType.Member getCompoundTypeMember(String name, ValueType type, int offset, int align) {
@@ -418,6 +425,7 @@ public final class TypeSystem {
             int typeIdAlignment = 4;
             int referenceSize = 4;
             int referenceAlignment = 4;
+            ByteOrder endianness = ByteOrder.nativeOrder();
 
             public int getByteBits() {
                 return byteBits;
@@ -617,6 +625,14 @@ public final class TypeSystem {
                 this.referenceAlignment = alignment;
             }
 
+            public ByteOrder getEndianness() {
+                return endianness;
+            }
+
+            public void setEndianness(ByteOrder endianness) {
+                this.endianness = endianness;
+            }
+
             public TypeSystem build() {
                 return new TypeSystem(this);
             }
@@ -714,6 +730,10 @@ public final class TypeSystem {
         int getReferenceAlignment();
 
         void setReferenceAlignment(int alignment);
+
+        ByteOrder getEndianness();
+
+        void setEndianness(ByteOrder endianness);
 
         TypeSystem build();
     }

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -1,6 +1,7 @@
 package org.qbicc.main;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -229,6 +230,8 @@ public class Main implements Callable<DiagnosticContext> {
                             // for now, type IDs == int32
                             tsBuilder.setTypeIdSize((int) probeResult.getTypeInfo(int32_t).getSize());
                             tsBuilder.setTypeIdAlignment((int) probeResult.getTypeInfo(int32_t).getAlign());
+                            // todo: endianness probe
+                            tsBuilder.setEndianness(ByteOrder.LITTLE_ENDIAN);
                             if (nogc) {
                                 new NoGcTypeSystemConfigurator().accept(tsBuilder);
                             }

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -230,8 +230,7 @@ public class Main implements Callable<DiagnosticContext> {
                             // for now, type IDs == int32
                             tsBuilder.setTypeIdSize((int) probeResult.getTypeInfo(int32_t).getSize());
                             tsBuilder.setTypeIdAlignment((int) probeResult.getTypeInfo(int32_t).getAlign());
-                            // todo: endianness probe
-                            tsBuilder.setEndianness(ByteOrder.LITTLE_ENDIAN);
+                            tsBuilder.setEndianness(probeResult.getByteOrder());
                             if (nogc) {
                                 new NoGcTypeSystemConfigurator().accept(tsBuilder);
                             }

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -5,7 +5,6 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -41,22 +40,13 @@ public class BuildtimeHeap {
     }
 
     public void serializeHeap() {
-        try {
-            for (InitializedField initField : heapRoots) {
-                ser.writeObject(initField.value, usedClasses);
-            }
-        } catch (IOException e) {
-            ctxt.error(e,"Error serializing build-time heap");
+        for (InitializedField initField : heapRoots) {
+            ser.writeObject(initField.value, usedClasses);
         }
     }
 
     public byte[] getHeapBytes() {
-        try {
-            return ser.getBytes();
-        } catch (IOException e) {
-            ctxt.error(e,"Error serializing build-time heap");
-            return new byte[0];
-        }
+        return ser.getBytes();
     }
 
     public List<InitializedField> getHeapRoots() {

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapOutputStream.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapOutputStream.java
@@ -1,0 +1,98 @@
+package org.qbicc.plugin.serialization;
+
+import org.qbicc.context.CompilationContext;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.IdentityHashMap;
+
+class HeapOutputStream {
+    private static final int CHUNK_SIZE = 16; // 128 * 1024;  TODO: Set very small to test growing logic...don't leave it like this for long!
+
+    private final ByteOrder endianness;
+    private final IdentityHashMap<Object, Integer> objects = new IdentityHashMap<>();
+    private int lastIndex = 0;
+    private byte[] buffer;
+    private ByteBuffer out;
+
+    HeapOutputStream(ByteOrder endianness) {
+        this.endianness = endianness;
+        buffer = new byte[CHUNK_SIZE];
+        out = ByteBuffer.wrap(buffer).order(endianness);
+    }
+
+    private void ensureCapacity(int desired) {
+        if (out.position() + desired >= out.limit()) {
+            byte[] newBuf = new byte[buffer.length + CHUNK_SIZE];
+            System.arraycopy(buffer, 0, newBuf, 0, out.position());
+            out = ByteBuffer.wrap(newBuf).position(out.position()).order(endianness);
+            buffer = newBuf;
+        }
+    }
+
+    int getBackref(Object obj) {
+        if (objects.containsKey(obj)) {
+            Integer prevIdx = objects.get(obj);
+            return lastIndex - prevIdx;
+        } else {
+            lastIndex += 1;
+            objects.put(obj, lastIndex);
+            return -1;
+        }
+    }
+
+    byte[] getBytes() {
+        byte[] ans = new byte[out.position()];
+        System.arraycopy(buffer, 0, ans, 0, out.position());
+        return ans;
+    }
+
+    int getNumberOfObjects() {
+        return lastIndex;
+    }
+
+    void putBoolean(boolean v) {
+        ensureCapacity(1);
+        out.put(v ? (byte)1 : (byte)0);
+    }
+
+    void putByte(byte v) {
+        ensureCapacity(1);
+        out.put(v);
+    }
+
+    void putShort(short v) {
+        ensureCapacity(2);
+        out.putShort(v);
+    }
+
+    void putChar(char v) {
+        ensureCapacity(2);
+        out.putChar(v);
+    }
+
+    void putInt(int v) {
+        ensureCapacity(4);
+        out.putInt(v);
+    }
+
+    void putFloat(float v) {
+        ensureCapacity(4);
+        out.putFloat(v);
+    }
+
+    void putLong(long v) {
+        ensureCapacity(8);
+        out.putLong(v);
+    }
+
+    void putDouble(double v) {
+        ensureCapacity(8);
+        out.putDouble(v);
+    }
+
+    void put(byte[] bytes) {
+        ensureCapacity(bytes.length);
+        out.put(bytes);
+    }
+}

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapOutputStream.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapOutputStream.java
@@ -4,6 +4,7 @@ import org.qbicc.context.CompilationContext;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 import java.util.IdentityHashMap;
 
 class HeapOutputStream {
@@ -23,10 +24,8 @@ class HeapOutputStream {
 
     private void ensureCapacity(int desired) {
         if (out.position() + desired >= out.limit()) {
-            byte[] newBuf = new byte[buffer.length + CHUNK_SIZE];
-            System.arraycopy(buffer, 0, newBuf, 0, out.position());
-            out = ByteBuffer.wrap(newBuf).position(out.position()).order(endianness);
-            buffer = newBuf;
+            buffer = Arrays.copyOf(buffer, buffer.length + CHUNK_SIZE);
+            out = ByteBuffer.wrap(buffer).position(out.position()).order(endianness);
         }
     }
 
@@ -42,9 +41,7 @@ class HeapOutputStream {
     }
 
     byte[] getBytes() {
-        byte[] ans = new byte[out.position()];
-        System.arraycopy(buffer, 0, ans, 0, out.position());
-        return ans;
+        return Arrays.copyOf(buffer, out.position());
     }
 
     int getNumberOfObjects() {

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/HeapSerializer.java
@@ -50,7 +50,7 @@ public class HeapSerializer implements Consumer<CompilationContext> {
         // TEMP TESTING: Serialize an int[] with known values to a known static field just to get the plumbing worked out
         LoadedTypeDefinition main = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/Main").load();
         FieldElement f = main.findField("watermark");
-        heap.addStaticField(f, new int[]{10, 32});
+        heap.addStaticField(f, new int[]{1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610 });
         // END TEMP TESTING
 
         heap.serializeHeap();

--- a/runtime/deserialization/src/main/java/org/qbicc/runtime/deserialization/DeserializationBuffer.java
+++ b/runtime/deserialization/src/main/java/org/qbicc/runtime/deserialization/DeserializationBuffer.java
@@ -7,9 +7,10 @@ package org.qbicc.runtime.deserialization;
  * (since their static fields are being initialized by this code).
  */
 public final class DeserializationBuffer {
-    // Eventually buf will be serialized using the native endianness of the target platform.
-    // For now, we are serializing with a DataOutputStream, so it is always BigEndian.
-    static final boolean LE = false;
+    // TODO: This should be set at compile-time based on the endianness of the target.
+    //       However, we are going to get rid of all of this deserialization code in
+    //       favor of writing a fully formed heap soon, so just hardwire to LE as an expedient.
+    static final boolean LE = true;
 
     private final byte[] buf;
     private int current;

--- a/runtime/deserialization/src/main/java/org/qbicc/runtime/deserialization/SerializationConstants.java
+++ b/runtime/deserialization/src/main/java/org/qbicc/runtime/deserialization/SerializationConstants.java
@@ -1,61 +1,61 @@
 package org.qbicc.runtime.deserialization;
 
 public interface SerializationConstants {
-    int NULL = 0x00;
+    byte NULL = 0x00;
 
-    int TAG_MASK = 0xF0;
+    byte TAG_MASK = (byte)0xF0;
 
     // A new object: 0x1G
-    int OBJECT_TAG = 0x10;
-    int OBJECT = OBJECT_TAG | 0x01; // 2 byte typeid + instance fields
-    int OBJECT_LONG_LIVED = OBJECT_TAG | 0x02; // 2 byte typeid + instance fields
-    int OBJECT_IMMORTAL = OBJECT_TAG | 0x03; // 2 byte typeid + instance fields
+    byte OBJECT_TAG = 0x10;
+    byte OBJECT = OBJECT_TAG | 0x01; // 2 byte typeid + instance fields
+    byte OBJECT_LONG_LIVED = OBJECT_TAG | 0x02; // 2 byte typeid + instance fields
+    byte OBJECT_IMMORTAL = OBJECT_TAG | 0x03; // 2 byte typeid + instance fields
 
     // A String literal: 0x2S
-    int STRING_TAG = 0x20;
-    int STRING_SMALL_L1 = STRING_TAG | 0x01;  // 1 byte length + data
-    int STRING_LARGE_L1 = STRING_TAG | 0x02;  // 4 byte length + data
-    int STRING_SMALL_U16 = STRING_TAG | 0x03; // 1 byte length + data
-    int STRING_LARGE_U16 = STRING_TAG | 0x04; // 4 byte length + data
+    byte STRING_TAG = 0x20;
+    byte STRING_SMALL_L1 = STRING_TAG | 0x01;  // 1 byte length + data
+    byte STRING_LARGE_L1 = STRING_TAG | 0x02;  // 4 byte length + data
+    byte STRING_SMALL_U16 = STRING_TAG | 0x03; // 1 byte length + data
+    byte STRING_LARGE_U16 = STRING_TAG | 0x04; // 4 byte length + data
 
-    // Arrays: are either 0x3T (1 int length) or 0x4T (4 int length)
-    int ARRAY_SMALL_TAG = 0x30;
-    int ARRAY_SMALL_BOOLEAN = ARRAY_SMALL_TAG | 0x01; // 1 byte length + data
-    int ARRAY_SMALL_BYTE = ARRAY_SMALL_TAG | 0x02; // 1 byte length + data
-    int ARRAY_SMALL_SHORT = ARRAY_SMALL_TAG | 0x03; // 1 byte length + data
-    int ARRAY_SMALL_CHAR = ARRAY_SMALL_TAG | 0x04; // 1 byte length + data
-    int ARRAY_SMALL_INT = ARRAY_SMALL_TAG | 0x05; // 1 byte length + data
-    int ARRAY_SMALL_FLOAT = ARRAY_SMALL_TAG | 0x06; // 1 byte length + data
-    int ARRAY_SMALL_LONG = ARRAY_SMALL_TAG | 0x07; // 1 byte length + data
-    int ARRAY_SMALL_DOUBLE = ARRAY_SMALL_TAG | 0x08; // 1 byte length + data
-    int ARRAY_SMALL_OBJECT = ARRAY_SMALL_TAG | 0x09; // 1 byte length + elements
-    int ARRAY_SMALL_STRING = ARRAY_SMALL_TAG | 0x0A; // 1 byte length + elements
-    int ARRAY_SMALL_CLASS = ARRAY_SMALL_TAG | 0x0B; // 1 byte length + 2 int typeid + elements
+    // Arrays: are either 0x3T (1 byte length) or 0x4T (4 byte length)
+    byte ARRAY_SMALL_TAG = 0x30;
+    byte ARRAY_SMALL_BOOLEAN = ARRAY_SMALL_TAG | 0x01; // 1 byte length + data
+    byte ARRAY_SMALL_BYTE = ARRAY_SMALL_TAG | 0x02; // 1 byte length + data
+    byte ARRAY_SMALL_SHORT = ARRAY_SMALL_TAG | 0x03; // 1 byte length + data
+    byte ARRAY_SMALL_CHAR = ARRAY_SMALL_TAG | 0x04; // 1 byte length + data
+    byte ARRAY_SMALL_INT = ARRAY_SMALL_TAG | 0x05; // 1 byte length + data
+    byte ARRAY_SMALL_FLOAT = ARRAY_SMALL_TAG | 0x06; // 1 byte length + data
+    byte ARRAY_SMALL_LONG = ARRAY_SMALL_TAG | 0x07; // 1 byte length + data
+    byte ARRAY_SMALL_DOUBLE = ARRAY_SMALL_TAG | 0x08; // 1 byte length + data
+    byte ARRAY_SMALL_OBJECT = ARRAY_SMALL_TAG | 0x09; // 1 byte length + elements
+    byte ARRAY_SMALL_STRING = ARRAY_SMALL_TAG | 0x0A; // 1 byte length + elements
+    byte ARRAY_SMALL_CLASS = ARRAY_SMALL_TAG | 0x0B; // 1 byte length + 2 byte typeid + elements
 
-    // Arrays are 0x3T (1 int length) or 0x4T (4 int length)
-    int ARRAY_LARGE_TAG = 0x40;
-    int ARRAY_LARGE_BOOLEAN = ARRAY_LARGE_TAG | 0x01; // 4 byte length + data
-    int ARRAY_LARGE_BYTE = ARRAY_LARGE_TAG | 0x02; // 4 byte length + data
-    int ARRAY_LARGE_SHORT = ARRAY_LARGE_TAG | 0x03; // 4 byte length + data
-    int ARRAY_LARGE_CHAR = ARRAY_LARGE_TAG | 0x04; // 4 byte length + data
-    int ARRAY_LARGE_INT = ARRAY_LARGE_TAG | 0x05; // 4 byte length + data
-    int ARRAY_LARGE_FLOAT = ARRAY_LARGE_TAG | 0x06; // 4 byte length + data
-    int ARRAY_LARGE_LONG = ARRAY_LARGE_TAG | 0x07; // 4 byte length + data
-    int ARRAY_LARGE_DOUBLE = ARRAY_LARGE_TAG | 0x08; // 4 byte length + data
-    int ARRAY_LARGE_OBJECT = ARRAY_LARGE_TAG | 0x09; // 4 byte length + elements
-    int ARRAY_LARGE_STRING = ARRAY_LARGE_TAG | 0x0A; // 4 byte length + elements
-    int ARRAY_LARGE_CLASS = ARRAY_LARGE_TAG | 0x0B; // 4 byte length + 2 int typeid + elements
+    // Arrays are 0x3T (1 byte length) or 0x4T (4 byte length)
+    byte ARRAY_LARGE_TAG = 0x40;
+    byte ARRAY_LARGE_BOOLEAN = ARRAY_LARGE_TAG | 0x01; // 4 byte length + data
+    byte ARRAY_LARGE_BYTE = ARRAY_LARGE_TAG | 0x02; // 4 byte length + data
+    byte ARRAY_LARGE_SHORT = ARRAY_LARGE_TAG | 0x03; // 4 byte length + data
+    byte ARRAY_LARGE_CHAR = ARRAY_LARGE_TAG | 0x04; // 4 byte length + data
+    byte ARRAY_LARGE_INT = ARRAY_LARGE_TAG | 0x05; // 4 byte length + data
+    byte ARRAY_LARGE_FLOAT = ARRAY_LARGE_TAG | 0x06; // 4 byte length + data
+    byte ARRAY_LARGE_LONG = ARRAY_LARGE_TAG | 0x07; // 4 byte length + data
+    byte ARRAY_LARGE_DOUBLE = ARRAY_LARGE_TAG | 0x08; // 4 byte length + data
+    byte ARRAY_LARGE_OBJECT = ARRAY_LARGE_TAG | 0x09; // 4 byte length + elements
+    byte ARRAY_LARGE_STRING = ARRAY_LARGE_TAG | 0x0A; // 4 byte length + elements
+    byte ARRAY_LARGE_CLASS = ARRAY_LARGE_TAG | 0x0B; // 4 byte length + 2 byte typeid + elements
 
     // A class literal
-    int CLASS_LITERAL_TAG = 0x50;
+    byte CLASS_LITERAL_TAG = 0x50;
 
     // A non-tiny backref
-    int BACKREF_TAG = 0x70;
-    int BACKREF_SMALL = BACKREF_TAG | 0x01; // followed by 2 byte backref
-    int BACKREF_LARGE = BACKREF_TAG | 0x03; // followed by 4 byte backref
+    byte BACKREF_TAG = 0x70;
+    byte BACKREF_SMALL = BACKREF_TAG | 0x01; // followed by 2 byte backref
+    byte BACKREF_LARGE = BACKREF_TAG | 0x03; // followed by 4 byte backref
 
     // A Tiny backref can encode 1 to 127 objects back in the serialization buffer
     // We reserve the top bit of the TAG to indicate the other 7 bits are a tiny backref
-    int TINY_REF_TAG_BIT = 0x80;
-    int TINY_REF_MASK = 0x7F;
+    byte TINY_REF_TAG_BIT = (byte)0x80;
+    byte TINY_REF_MASK = 0x7F;
 }

--- a/runtime/deserialization/src/test/java/org/qbicc/runtime/deserialization/TestDeserialization.java
+++ b/runtime/deserialization/src/test/java/org/qbicc/runtime/deserialization/TestDeserialization.java
@@ -4,14 +4,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
 public class TestDeserialization {
 
     static MockObjectDeserializer mock = new MockObjectDeserializer();
+    static ByteOrder endianness = DeserializationBuffer.LE ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
 
     static class Test1 {
         int a;
@@ -25,40 +26,44 @@ public class TestDeserialization {
     }
 
 
-    void writeStringL1(String str, DataOutputStream out) throws IOException {
+    void writeStringL1(String str, ByteBuffer out) {
         if (str.length() < 20) { // artificially small for testing. Actually support up to 255.
-            out.write(SerializationConstants.STRING_SMALL_L1);
-            out.writeByte(str.getBytes(StandardCharsets.ISO_8859_1).length);
+            out.put(SerializationConstants.STRING_SMALL_L1);
+            out.put((byte)str.getBytes(StandardCharsets.ISO_8859_1).length);
         } else {
-            out.write(SerializationConstants.STRING_LARGE_L1);
-            out.writeInt(str.getBytes(StandardCharsets.ISO_8859_1).length);
+            out.put(SerializationConstants.STRING_LARGE_L1);
+            out.putInt(str.getBytes(StandardCharsets.ISO_8859_1).length);
         }
-        out.write(str.getBytes(StandardCharsets.ISO_8859_1));
+        out.put(str.getBytes(StandardCharsets.ISO_8859_1));
     }
 
-    void writeStringU16(String str, DataOutputStream out) throws IOException {
+    void writeStringU16(String str, ByteBuffer out) {
         if (str.length() < 20) { // artificially small for testing. Actually support up to 255.
-            out.write(SerializationConstants.STRING_SMALL_U16);
-            out.writeByte(str.getBytes(StandardCharsets.UTF_16BE).length/2);
+            out.put(SerializationConstants.STRING_SMALL_U16);
+            out.put((byte)(str.getBytes(StandardCharsets.UTF_16BE).length/2));
         } else {
-            out.write(SerializationConstants.STRING_LARGE_U16);
-            out.writeInt(str.getBytes(StandardCharsets.UTF_16BE).length/2);
+            out.put(SerializationConstants.STRING_LARGE_U16);
+            out.putInt(str.getBytes(StandardCharsets.UTF_16BE).length/2);
         }
-        out.write(str.getBytes(StandardCharsets.UTF_16BE));
+        out.put(str.getBytes(StandardCharsets.UTF_16BE));
+    }
+
+    byte[] toArray(ByteBuffer buf) {
+        byte[] ans = new byte[buf.position()];
+        System.arraycopy(buf.array(), 0, ans, 0, buf.position());
+        return ans;
     }
 
     @Test
-    public void testStrings() throws Exception {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(os);
+    public void testStrings() {
+        ByteBuffer out = ByteBuffer.wrap(new byte[256]).order(endianness);
 
         String hello = "Hello World!";
         String ciao = "See you later alligator";
         writeStringL1(hello, out);
         writeStringU16(ciao, out);
 
-        out.flush();
-        Deserializer ds = new Deserializer(os.toByteArray(), 2, mock);
+        Deserializer ds = new Deserializer(toArray(out), 2, mock);
         ObjectGraph graph = ds.readAll();
 
         assertEquals(graph.getObject(0), hello);
@@ -66,17 +71,15 @@ public class TestDeserialization {
     }
 
     @Test
-    public void testCell() throws Exception {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(os);
+    public void testCell() {
+        ByteBuffer out = ByteBuffer.wrap(new byte[256]).order(endianness);
 
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(42);
-        out.writeByte(SerializationConstants.NULL);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(42);
+        out.put(SerializationConstants.NULL);
 
-        out.flush();
-        Deserializer ds = new Deserializer(os.toByteArray(), 1, mock);
+        Deserializer ds = new Deserializer(toArray(out), 1, mock);
         ObjectGraph graph = ds.readAll();
 
         Test1 obj = (Test1) graph.getObject(0);
@@ -85,24 +88,22 @@ public class TestDeserialization {
     }
 
     @Test
-    void testLinkedList() throws Exception {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(os);
+    void testLinkedList() {
+        ByteBuffer out = ByteBuffer.wrap(new byte[256]).order(endianness);
 
         // Linked list containing first 3 primes
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(2);
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(3);
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(5);
-        out.writeByte(SerializationConstants.NULL);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(2);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(3);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(5);
+        out.put(SerializationConstants.NULL);
 
-        out.flush();
-        Deserializer ds = new Deserializer(os.toByteArray(), 3, mock);
+        Deserializer ds = new Deserializer(toArray(out), 3, mock);
         ObjectGraph graph = ds.readAll();
 
         assertEquals(2, ((Test1) graph.getObject(0)).a);
@@ -114,24 +115,22 @@ public class TestDeserialization {
     }
 
     @Test
-    void testCyclicList() throws Exception {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(os);
+    void testCyclicList() {
+        ByteBuffer out = ByteBuffer.wrap(new byte[256]).order(endianness);
 
         // Cyclic linked list containing first 3 primes
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(2);
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(3);
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(5);
-        out.writeByte(SerializationConstants.TINY_REF_TAG_BIT | 3);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(2);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(3);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(5);
+        out.put((byte)(SerializationConstants.TINY_REF_TAG_BIT | 3));
 
-        out.flush();
-        Deserializer ds = new Deserializer(os.toByteArray(), 3, mock);
+        Deserializer ds = new Deserializer(toArray(out), 3, mock);
         ObjectGraph graph = ds.readAll();
 
         assertEquals(2, ((Test1) graph.getObject(0)).a);
@@ -143,30 +142,28 @@ public class TestDeserialization {
     }
 
     @Test
-    void testSubclass() throws Exception {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(os);
+    void testSubclass() {
+        ByteBuffer out = ByteBuffer.wrap(new byte[256]).order(endianness);
 
         // Cyclic linked list containing first 3 primes;  first & third cells are subclass that add self-pointer and String to the "c" field
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST2);
-        out.writeInt(2);
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(3);
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST2);
-        out.writeInt(5);
-        out.writeByte(SerializationConstants.TINY_REF_TAG_BIT | 3);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST2);
+        out.putInt(2);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(3);
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST2);
+        out.putInt(5);
+        out.put((byte)(SerializationConstants.TINY_REF_TAG_BIT | 3));
         String hello = "Hello World!";
         writeStringU16(hello, out);
 
         // Now, finally back to the "c" field of the first cell using a SMALL instead of TINY just for testing..
-        out.writeByte(SerializationConstants.BACKREF_SMALL);
-        out.writeShort(4);
+        out.put(SerializationConstants.BACKREF_SMALL);
+        out.putShort((short)4);
 
-        out.flush();
-        Deserializer ds = new Deserializer(os.toByteArray(), 4, mock);
+        Deserializer ds = new Deserializer(toArray(out), 4, mock);
         ObjectGraph graph = ds.readAll();
 
         assertEquals(2, ((Test1) graph.getObject(0)).a);
@@ -180,22 +177,20 @@ public class TestDeserialization {
     }
 
     @Test
-    void testObjectArray() throws IOException {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(os);
+    void testObjectArray() {
+        ByteBuffer out = ByteBuffer.wrap(new byte[256]).order(endianness);
 
-        out.writeByte(SerializationConstants.ARRAY_SMALL_OBJECT);
-        out.writeByte(4);
+        out.put(SerializationConstants.ARRAY_SMALL_OBJECT);
+        out.put((byte)4);
         writeStringL1("Eureka; I think we got it", out);
-        out.writeByte(SerializationConstants.TINY_REF_TAG_BIT | 2);
-        out.writeByte(SerializationConstants.OBJECT);
-        out.writeShort(MockObjectDeserializer.TYPEID_TEST1);
-        out.writeInt(3);
-        out.writeByte(SerializationConstants.TINY_REF_TAG_BIT | 1);
+        out.put((byte)(SerializationConstants.TINY_REF_TAG_BIT | 2));
+        out.put(SerializationConstants.OBJECT);
+        out.putShort((short)MockObjectDeserializer.TYPEID_TEST1);
+        out.putInt(3);
+        out.put((byte)(SerializationConstants.TINY_REF_TAG_BIT | 1));
         writeStringU16("QED", out);
 
-        out.flush();
-        Deserializer ds = new Deserializer(os.toByteArray(), 4, mock);
+        Deserializer ds = new Deserializer(toArray(out), 4, mock);
         ObjectGraph graph = ds.readAll();
 
         Object[] spine = (Object[])graph.getObject(0);

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/Main.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/Main.java
@@ -39,7 +39,7 @@ public final class Main {
         RuntimeObjectDeserializer.initializeHeap();
 
         // TEMP: Remove watermark check once we are using heap serialization to initialize statics
-        if (watermark.length != 2 || (watermark[0] + watermark[1] != 42)) {
+        if (watermark.length != 15 || (watermark[0] + watermark[14] != 611)) {
             if (Build.Target.isPosix()) {
                 pthread_exit(word(1L).cast(void_ptr.class));
             }


### PR DESCRIPTION
Refactor heap serialization plugin to use a ByteBuffer
as the lowlevel output target.  This allows us to
select the endianness at compile time to match the
target platform.