### PR TITLE
Implement CProbe for functions

### DIFF
--- a/machine/file/elf/src/main/java/org/qbicc/machine/file/elf/ElfObjectFileProvider.java
+++ b/machine/file/elf/src/main/java/org/qbicc/machine/file/elf/ElfObjectFileProvider.java
@@ -128,6 +128,24 @@ public class ElfObjectFileProvider implements ObjectFileProvider {
                 };
             }
 
+            @Override
+            public String getRelocationSymbolForSymbolValue(String symbol) {
+                ElfSymbolTableEntry symbolEntry = findSymbol(symbol);
+                /* Search relocation info section for the data section i.e. section with name ".rel.data" or ".rela.data" */
+                ElfRelocationTableEntry entry = elfHeader.findReloEntryForOffset(".rel.data", symbolEntry.getValue());
+                if (entry == null) {
+                    entry = elfHeader.findReloEntryForOffset(".rela.data", symbolEntry.getValue());
+                    if (entry == null) {
+                        return null;
+                    }
+                }
+                ElfSymbolTableEntry reloSymbol = elfHeader.findSymbol(entry.getSymbolIndex());
+                if (reloSymbol == null) {
+                    return null;
+                }
+                return reloSymbol.getName();
+            }
+
             private ElfSymbolTableEntry findSymbol(final String name) {
                 final ElfSymbolTableEntry symbol = elfHeader.findSymbol(name);
                 if (symbol == null) {

--- a/machine/file/macho/src/main/java/org/qbicc/machine/file/macho/MachOObjectFile.java
+++ b/machine/file/macho/src/main/java/org/qbicc/machine/file/macho/MachOObjectFile.java
@@ -236,6 +236,11 @@ public final class MachOObjectFile implements ObjectFile {
         };
     }
 
+    @Override
+    public String getRelocationSymbolForSymbolValue(String symbol) {
+        return null;
+    }
+
     public void close() {
         buffer.close();
     }

--- a/machine/file/object/src/main/java/org/qbicc/machine/object/ObjectFile.java
+++ b/machine/file/object/src/main/java/org/qbicc/machine/object/ObjectFile.java
@@ -29,4 +29,6 @@ public interface ObjectFile extends Closeable {
     ObjectType getObjectType();
 
     Section getSection(String name);
+
+    String getRelocationSymbolForSymbolValue(String symbol);
 }

--- a/machine/probe/src/main/java/org/qbicc/machine/probe/CProbe.java
+++ b/machine/probe/src/main/java/org/qbicc/machine/probe/CProbe.java
@@ -116,8 +116,8 @@ public final class CProbe {
                 final Map<String, FunctionInfo> functionInfos = new HashMap<>(cnt);
                 for (int i = 0; i < cnt; i ++) {
                     String name = functions.get(i);
-                    // get the symbol value (todo)
-                    throw new UnsupportedOperationException("Read symbol relocation data from object file");
+                    String fnName = objectFile.getRelocationSymbolForSymbolValue("fn_address" + i);
+                    functionInfos.put(name, new FunctionInfo(fnName));
                 }
                 cnt = types.size();
                 final Map<Type, Type.Info> typeInfos = new HashMap<>(cnt);
@@ -840,7 +840,15 @@ public final class CProbe {
     }
 
     public static final class FunctionInfo {
+        private final String resolvedName;
 
+        FunctionInfo(String resolvedName) {
+            this.resolvedName = resolvedName;
+        }
+
+        public String getResolvedName() {
+            return resolvedName;
+        }
     }
 
 


### PR DESCRIPTION
This patch extends CProbe to allow it to get the actual function name
if the function exposed as an API is just a C macro.
This is the case with many of libunwind APIs.
For example `unw_init_local` is defined as a macro which expands to a
platform specific function.
To get the actual function name CProbe would emit a file like:

	void * fn_address0 = <function_to_probe>;

Object file for this code would contain entry in symbol table for
`fn_address0` and its offset in data section.
For the same offset there would be an entry in the relocation section
and the symbol corresponding to that entry would give us the actual
function name.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>