### PR TITLE
Add llvm-link stage

### DIFF
--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmLinkInvoker.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmLinkInvoker.java
@@ -1,0 +1,19 @@
+package org.qbicc.tool.llvm;
+
+import org.qbicc.machine.tool.MessagingToolInvoker;
+
+import java.nio.file.Path;
+
+public interface LlvmLinkInvoker extends LlvmInvoker {
+    void addBitcodeFile(Path path);
+
+    default void addBitcodeFiles(Iterable<Path> paths) {
+        for (Path path : paths) {
+            addBitcodeFile(path);
+        }
+    }
+
+    int getBitcodeFileCount();
+
+    Path getBitcodeFile(int index) throws IndexOutOfBoundsException;
+}

--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmLinkInvokerImpl.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmLinkInvokerImpl.java
@@ -1,0 +1,44 @@
+package org.qbicc.tool.llvm;
+
+import io.smallrye.common.constraint.Assert;
+import org.qbicc.machine.tool.Tool;
+import org.qbicc.machine.tool.ToolMessageHandler;
+import org.qbicc.machine.tool.process.InputSource;
+import org.qbicc.machine.tool.process.OutputDestination;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LlvmLinkInvokerImpl extends AbstractLlvmInvoker implements LlvmLinkInvoker {
+    private final List<Path> objectFiles = new ArrayList<>(4);
+
+    LlvmLinkInvokerImpl(LlvmToolChainImpl tool, Path path) {
+        super(tool, path);
+    }
+
+    @Override
+    void addArguments(List<String> cmd) {
+        for (Path file: objectFiles) {
+            cmd.add(file.toString());
+        }
+    }
+
+    @Override
+    public void addBitcodeFile(Path path) {
+        synchronized (objectFiles) {
+            objectFiles.add(Assert.checkNotNullParam("path", path));
+        }
+    }
+
+    @Override
+    public int getBitcodeFileCount() {
+        return objectFiles.size();
+    }
+
+    @Override
+    public Path getBitcodeFile(int index) throws IndexOutOfBoundsException {
+        return objectFiles.get(index);
+    }
+}

--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmToolChain.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmToolChain.java
@@ -29,10 +29,13 @@ public interface LlvmToolChain extends Tool {
 
     OptInvoker newOptInvoker();
 
+    LlvmLinkInvoker newLlvmLinkInvoker();
+
     static Iterable<LlvmToolChain> findAllLlvmToolChains(Platform platform, Predicate<? super LlvmToolChain> filter, ClassLoader classLoader) {
         Path llcPath = ToolUtil.findExecutable("llc");
-        if (llcPath != null) {
-            Path optPath = ToolUtil.findExecutable("opt");
+        Path optPath = ToolUtil.findExecutable("opt");
+        Path llvmLinkPath = ToolUtil.findExecutable("llvm-link");
+        if (llcPath != null && optPath != null && llvmLinkPath != null) {
             if (optPath != null) {
                 // check versions
                 ProcessBuilder pb = new ProcessBuilder(List.of(llcPath.toString(), "--version"));
@@ -46,7 +49,7 @@ public interface LlvmToolChain extends Tool {
                 Matcher matcher = Llvm.LLVM_VERSION_PATTERN.matcher(stdOut);
                 if (matcher.find()) {
                     String version = matcher.group(1);
-                    return List.of(new LlvmToolChainImpl(llcPath, optPath, platform, version));
+                    return List.of(new LlvmToolChainImpl(llcPath, optPath, llvmLinkPath, platform, version));
                 }
                 Llvm.log.warn("Failed to identify LLVM version string; skipping");
             }

--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmToolChainImpl.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmToolChainImpl.java
@@ -8,12 +8,14 @@ import io.smallrye.common.version.VersionScheme;
 final class LlvmToolChainImpl implements LlvmToolChain {
     private final Path llcPath;
     private final Path optPath;
+    private final Path llvmLinkPath;
     private final Platform platform;
     private final String version;
 
-    LlvmToolChainImpl(final Path llcPath, final Path optPath, final Platform platform, final String version) {
+    LlvmToolChainImpl(final Path llcPath, final Path optPath, final Path llvmLinkPath, final Platform platform, final String version) {
         this.llcPath = llcPath;
         this.optPath = optPath;
+        this.llvmLinkPath = llvmLinkPath;
         this.platform = platform;
         this.version = version;
     }
@@ -24,6 +26,10 @@ final class LlvmToolChainImpl implements LlvmToolChain {
 
     public OptInvoker newOptInvoker() {
         return new OptInvokerImpl(this, optPath);
+    }
+
+    public LlvmLinkInvoker newLlvmLinkInvoker() {
+        return new LlvmLinkInvokerImpl(this, llvmLinkPath);
     }
 
     public Platform getPlatform() {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompileStage.java
@@ -2,7 +2,9 @@ package org.qbicc.plugin.llvm;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.Consumer;
 
 import org.qbicc.context.CompilationContext;
@@ -15,6 +17,7 @@ import org.qbicc.machine.tool.process.InputSource;
 import org.qbicc.machine.tool.process.OutputDestination;
 import org.qbicc.plugin.linker.Linker;
 import org.qbicc.tool.llvm.LlcInvoker;
+import org.qbicc.tool.llvm.LlvmLinkInvoker;
 import org.qbicc.tool.llvm.LlvmToolChain;
 import org.qbicc.tool.llvm.OptInvoker;
 import org.qbicc.tool.llvm.OptPass;
@@ -48,19 +51,12 @@ public class LLVMCompileStage implements Consumer<CompilationContext> {
         Linker linker = Linker.get(context);
 
         Iterator<Path> iterator = llvmState.getModulePaths().iterator();
-        context.runParallelTask(ctxt -> {
-            LlcInvoker llcInvoker = llvmToolChain.newLlcInvoker();
-            llcInvoker.setMessageHandler(ToolMessageHandler.reporting(ctxt));
-            llcInvoker.setOutputFormat(OutputFormat.ASM);
-            llcInvoker.setRelocationModel(isPie ? RelocationModel.Pic : RelocationModel.Static);
+        final List<Path> bitcodePaths = new ArrayList<>();
 
+        context.runParallelTask(ctxt -> {
             OptInvoker optInvoker = llvmToolChain.newOptInvoker();
             optInvoker.addOptimizationPass(OptPass.RewriteStatepointsForGc);
             optInvoker.addOptimizationPass(OptPass.AlwaysInline);
-
-            CCompilerInvoker ccInvoker = cToolChain.newCompilerInvoker();
-            ccInvoker.setMessageHandler(ToolMessageHandler.reporting(ctxt));
-            ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.ASM);
 
             for (;;) {
                 Path modulePath;
@@ -74,12 +70,7 @@ public class LLVMCompileStage implements Consumer<CompilationContext> {
                 if (moduleName.endsWith(".ll")) {
                     String baseName = moduleName.substring(0, moduleName.length() - 3);
                     String optBitCodeName = baseName + "_opt.bc";
-                    String assemblyName = baseName + ".s";
-                    String objectName = baseName + "." + cToolChain.getPlatform().getObjectType().objectSuffix();
-
                     Path optBitCodePath = modulePath.resolveSibling(optBitCodeName);
-                    Path assemblyPath = modulePath.resolveSibling(assemblyName);
-                    Path objectPath = modulePath.resolveSibling(objectName);
 
                     optInvoker.setSource(InputSource.from(modulePath));
                     optInvoker.setDestination(OutputDestination.of(optBitCodePath));
@@ -93,34 +84,65 @@ public class LLVMCompileStage implements Consumer<CompilationContext> {
                         }
                         continue;
                     }
-
-                    llcInvoker.setSource(InputSource.from(optBitCodePath));
-                    llcInvoker.setDestination(OutputDestination.of(assemblyPath));
-                    errCnt = ctxt.errors();
-                    try {
-                        llcInvoker.invoke();
-                    } catch (IOException e) {
-                        if (errCnt == ctxt.errors()) {
-                            // whatever the problem was, it wasn't reported, so add an additional error here
-                            ctxt.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`llc` invocation has failed: %s", e.toString());
-                        }
-                        continue;
+                    synchronized (bitcodePaths) {
+                        bitcodePaths.add(optBitCodePath);
                     }
-
-                    // now compile it
-                    ccInvoker.setSource(InputSource.from(assemblyPath));
-                    ccInvoker.setOutputPath(objectPath);
-                    try {
-                        ccInvoker.invoke();
-                    } catch (IOException e) {
-                        ctxt.error("Compiler invocation has failed for %s: %s", modulePath, e.toString());
-                        continue;
-                    }
-                    linker.addObjectFilePath(objectPath);
                 } else {
                     ctxt.warning("Ignoring unknown module file name \"%s\"", modulePath);
                 }
             }
         });
+
+        LlvmLinkInvoker llvmLinkInvoker = llvmToolChain.newLlvmLinkInvoker();
+
+        LlcInvoker llcInvoker = llvmToolChain.newLlcInvoker();
+        llcInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        llcInvoker.setOutputFormat(OutputFormat.ASM);
+        llcInvoker.setRelocationModel(isPie ? RelocationModel.Pic : RelocationModel.Static);
+
+
+        CCompilerInvoker ccInvoker = cToolChain.newCompilerInvoker();
+        ccInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.ASM);
+
+        String qbiccApp = "qbicc-app";
+        Path fatBitCodePath = context.getOutputDirectory().resolve(qbiccApp + ".bc");
+        Path assemblyPath = context.getOutputDirectory().resolve(qbiccApp + ".s");
+        Path objectPath = context.getOutputDirectory().resolve(qbiccApp + "." + cToolChain.getPlatform().getObjectType().objectSuffix());
+
+        llvmLinkInvoker.addBitcodeFiles(bitcodePaths);
+        llvmLinkInvoker.setSource(InputSource.empty());
+        llvmLinkInvoker.setDestination(OutputDestination.of(fatBitCodePath));
+        int errCnt = context.errors();
+        try {
+            llvmLinkInvoker.invoke();
+        } catch (IOException e) {
+            if (errCnt == context.errors()) {
+                // whatever the problem was, it wasn't reported, so add an additional error here
+                context.error("`llvm-link` invocation has failed: %s", e.toString());
+            }
+        }
+
+        llcInvoker.setSource(InputSource.from(fatBitCodePath));
+        llcInvoker.setDestination(OutputDestination.of(assemblyPath));
+        errCnt = context.errors();
+        try {
+            llcInvoker.invoke();
+        } catch (IOException e) {
+            if (errCnt == context.errors()) {
+                // whatever the problem was, it wasn't reported, so add an additional error here
+                context.error("`llc` invocation has failed: %s", e.toString());
+            }
+        }
+
+        // now compile it
+        ccInvoker.setSource(InputSource.from(assemblyPath));
+        ccInvoker.setOutputPath(objectPath);
+        try {
+            ccInvoker.invoke();
+        } catch (IOException e) {
+            context.error("Compiler invocation has failed for %s: %s", assemblyPath, e.toString());
+        }
+        linker.addObjectFilePath(objectPath);
     }
 }


### PR DESCRIPTION
This patch adds a new stage in the compilation process.
The new stage uses llvm-link to combine all the bitcode files into
a single bitcode file.
This bitcode file is then compiled into assembly, then to an object file
and finally linked to get the executable.
The single bitcode file is named as "qbicc-app.bc" and is created in the
output directory specified by the user.

This step is required so that instruction offset for the stackmap
records are in increasing order, which would allow us to correctly
identify the callsite instruction.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>