### PR TITLE
Enable runtime class initialization

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
@@ -12,6 +12,10 @@ public interface ActionVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, ClassInitCheck node) {
+        return visitUnknown(param, node);
+    }
+
     default R visit(T param, Fence node) {
         return visitUnknown(param, node);
     }
@@ -36,6 +40,10 @@ public interface ActionVisitor<T, R> {
         }
 
         default R visit(T param, BlockEntry node) {
+            return getDelegateActionVisitor().visit(param, node);
+        }
+
+        default R visit(T param, ClassInitCheck node) {
             return getDelegateActionVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -367,6 +367,8 @@ public interface BasicBlockBuilder extends Locatable {
 
     Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode);
 
+    Node classInitCheck(ObjectType objectType);
+
     Node fence(MemoryAtomicityMode fenceType);
 
     Node monitorEnter(Value obj);

--- a/compiler/src/main/java/org/qbicc/graph/ClassInitCheck.java
+++ b/compiler/src/main/java/org/qbicc/graph/ClassInitCheck.java
@@ -1,0 +1,44 @@
+package org.qbicc.graph;
+
+import java.util.Objects;
+
+import org.qbicc.type.ObjectType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+public class ClassInitCheck extends AbstractNode implements Action, OrderedNode {
+    private final Node dependency;
+    private final ObjectType objectType;
+
+    ClassInitCheck(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ObjectType objectType) {
+        super(callSite, element, line, bci);
+        this.dependency = dependency;
+        this.objectType = objectType;
+    }
+
+    public ObjectType getObjectType() {
+        return objectType;
+    }
+
+    int calcHashCode() {
+        return Objects.hash(ClassInitCheck.class, dependency, objectType);
+    }
+
+    @Override
+    public Node getDependency() {
+        return dependency;
+    }
+
+    public boolean equals(Object other) {
+        return other instanceof ClassInitCheck && equals((ClassInitCheck) other);
+    }
+
+    public boolean equals(final ClassInitCheck other) {
+        return this == other || other != null
+               && dependency.equals(other.dependency)
+               && objectType == other.objectType;
+    }
+
+    public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -351,6 +351,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().store(handle, value, mode);
     }
 
+    public Node classInitCheck(final ObjectType objectType) {
+        return getDelegate().classInitCheck(objectType);
+    }
+
     public Node fence(final MemoryAtomicityMode fenceType) {
         return getDelegate().fence(fenceType);
     }

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -334,6 +334,11 @@ public interface Node {
                 return param.getBlockBuilder().monitorExit(param.copyValue(node.getInstance()));
             }
 
+            public Node visit(Copier param, ClassInitCheck node) {
+                param.copyNode(node.getDependency());
+                return param.getBlockBuilder().classInitCheck(node.getObjectType());
+            }
+
             public Node visit(Copier param, Fence node) {
                 param.copyNode(node.getDependency());
                 return param.getBlockBuilder().fence(node.getAtomicityMode());

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -632,6 +632,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new Store(callSite, element, line, bci, requireDependency(), handle, value, mode));
     }
 
+    public Node classInitCheck(final ObjectType objectType) {
+        return asDependency(new ClassInitCheck(callSite, element, line, bci, requireDependency(), objectType));
+    }
+
     public Node fence(final MemoryAtomicityMode fenceType) {
         return asDependency(new Fence(callSite, element, line, bci, requireDependency(), fenceType));
     }

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -42,6 +42,7 @@ import org.qbicc.plugin.gc.nogc.NoGcSetupHook;
 import org.qbicc.plugin.gc.nogc.NoGcTypeSystemConfigurator;
 import org.qbicc.plugin.instanceofcheckcast.ClassInitializerRegister;
 import org.qbicc.plugin.instanceofcheckcast.InstanceOfCheckCastBasicBlockBuilder;
+import org.qbicc.plugin.instanceofcheckcast.LowerClassInitCheckBlockBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayEmitter;
 import org.qbicc.plugin.intrinsics.IntrinsicBasicBlockBuilder;
@@ -359,6 +360,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, StaticFieldLoweringBasicBlockBuilder::new);
                                 // InstanceOfCheckCastBB must come before ObjectAccessLoweringBuilder or typeIdOf won't be lowered correctly
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, InstanceOfCheckCastBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LowerClassInitCheckBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectAccessLoweringBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectMonitorBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LLVMCompatibleBasicBlockBuilder::new);

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
@@ -1,0 +1,65 @@
+package org.qbicc.plugin.instanceofcheckcast;
+
+import java.util.List;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.BlockEarlyTermination;
+import org.qbicc.graph.BlockLabel;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.ObjectType;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.definition.element.MethodElement;
+
+/**
+ * 
+ */
+public class LowerClassInitCheckBlockBuilder extends DelegatingBasicBlockBuilder {
+    private final CompilationContext ctxt;
+    private final ExecutableElement originalElement;
+
+    public LowerClassInitCheckBlockBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+        super(delegate);
+        originalElement = delegate.getCurrentElement();
+        this.ctxt = ctxt;
+    }
+ 
+    public Node classInitCheck(final ObjectType objectType) {
+        initCheck(objectType);
+        return nop();
+    }
+
+    private void initCheck(ObjectType objectType) {
+        SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
+        
+        final BlockLabel callInit = new BlockLabel();
+        final BlockLabel goAhead = new BlockLabel();
+        final LiteralFactory lf = ctxt.getLiteralFactory();
+
+        Value typeId = lf.literalOfType(objectType);
+
+        GlobalVariableElement clinitStates = tables.getAndRegisterGlobalClinitStateStruct(getCurrentElement());
+        CompoundType clinitStates_t = (CompoundType) clinitStates.getType();
+        ValueHandle init_state_array = memberOf(globalVariable(clinitStates), clinitStates_t.getMember("init_state"));
+        Value state = load(elementOf(init_state_array, typeId), MemoryAtomicityMode.ACQUIRE);
+
+        
+        if_(isEq(state, lf.literalOf(0)), callInit, goAhead);
+        try {
+            begin(callInit);
+            MethodElement helper = ctxt.getVMHelperMethod("initialize_class");
+            getFirstBuilder().call(getFirstBuilder().staticMethod(helper), List.of(getFirstBuilder().currentThread(), typeId));
+            goto_(goAhead);
+        } catch (BlockEarlyTermination ignored) {
+            //continue
+        }
+        begin(goAhead);
+    }
+}

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -653,6 +653,9 @@ public class SupersDisplayTables {
 
     // TODO: implement this for real
     boolean isAlreadyInitialized(LoadedTypeDefinition ltd) {
+        if (ltd.internalNameEquals("org/qbicc/runtime/main/VMHelpers$ClinitState")) { 
+            return true;
+        }
         return false;
     }
 }

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/LowerVerificationBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/LowerVerificationBasicBlockBuilder.java
@@ -68,6 +68,11 @@ public class LowerVerificationBasicBlockBuilder extends DelegatingBasicBlockBuil
         return nop();
     }
 
+    public Node classInitCheck(final ObjectType objectType) {
+        invalidNode("classInitCheck");
+        return nop();
+    }
+
     public Value new_(final ClassObjectType type) {
         invalidNode("new");
         return ctxt.getLiteralFactory().zeroInitializerLiteralOfType(type.getReference());

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -154,4 +154,23 @@ public class ObjectModel {
     public static native int get_number_of_bytes_in_interface_bits_array();
 
     public static native byte get_byte_of_interface_bits(CNative.type_id typeId, int index);
+
+    /**
+     * Check the `clinit_states` native structure to see if this typeid is initialized.
+     * 
+     * This is a fast check reading a bit in the structure.  A "true" value can be trusted
+     * as a fast path check while a "false" value requires the state-machine defined in
+     * VMHelpers.initialize_class() to validate the result and handle the transition.
+     * 
+     * @return true if initialized.  False if the state machine needs to validate.
+     */
+    public static native boolean is_initialized(CNative.type_id typdId);
+
+    /**
+     * Set the class initialized.  
+     * 
+     * This should only be done by the MHelpers.initialize_class() statemachine
+     * @param typdId the class to mark initialized
+     */
+    public static native void set_initialized(CNative.type_id typdId);
 }


### PR DESCRIPTION
With this commit, runtime class initialization works.  The "is_initialized()" checks are inserted before `get/putstatic` and `invokestatic` bytecodes as well as at `new` bytecodes.

The state machine correctly marks classes as initialized and everything seems to work OK with it.