### PR TITLE
Add fence optimization

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/Fence.java
+++ b/compiler/src/main/java/org/qbicc/graph/Fence.java
@@ -1,12 +1,15 @@
 package org.qbicc.graph;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public class Fence extends AbstractNode implements Action, OrderedNode {
     private final Node dependency;
-    private final MemoryAtomicityMode atomicityMode;
+    private MemoryAtomicityMode atomicityMode;
+    private Set<Node> incoming = Set.of();
 
     Fence(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final MemoryAtomicityMode atomicityMode) {
         super(callSite, element, line, bci);
@@ -16,6 +19,10 @@ public class Fence extends AbstractNode implements Action, OrderedNode {
 
     public MemoryAtomicityMode getAtomicityMode() {
         return atomicityMode;
+    }
+
+    public void setAtomicityMode(MemoryAtomicityMode mode) {
+        atomicityMode = mode;
     }
 
     int calcHashCode() {
@@ -39,5 +46,28 @@ public class Fence extends AbstractNode implements Action, OrderedNode {
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    public void setIncoming(Node from) {
+        if (from != null) {
+            if (incoming.isEmpty()) {
+                incoming = Set.of(from);
+            } else if (incoming.size() == 1) {
+                if (! incoming.contains(from)) {
+                    incoming = Set.of(from, incoming.iterator().next());
+                }
+            } else if (incoming.size() == 2) {
+                Set<Node> old = this.incoming;
+                incoming = new HashSet<>();
+                incoming.addAll(old);
+                incoming.add(from);
+            } else {
+                incoming.add(from);
+            }
+        }
+    }
+
+    public Set<Node> getIncoming() {
+        return incoming;
     }
 }

--- a/compiler/src/main/java/org/qbicc/graph/Load.java
+++ b/compiler/src/main/java/org/qbicc/graph/Load.java
@@ -1,6 +1,8 @@
 package org.qbicc.graph;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -11,7 +13,7 @@ import org.qbicc.type.definition.element.ExecutableElement;
 public class Load extends AbstractValue implements OrderedNode {
     private final Node dependency;
     private final ValueHandle handle;
-    private final MemoryAtomicityMode mode;
+    private MemoryAtomicityMode mode;
 
     Load(Node callSite, ExecutableElement element, int line, int bci, Node dependency, ValueHandle handle, MemoryAtomicityMode mode) {
         super(callSite, element, line, bci);
@@ -46,6 +48,10 @@ public class Load extends AbstractValue implements OrderedNode {
 
     public MemoryAtomicityMode getMode() {
         return mode;
+    }
+
+    public void setMode(MemoryAtomicityMode mode) {
+        this.mode = mode;
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/graph/Store.java
+++ b/compiler/src/main/java/org/qbicc/graph/Store.java
@@ -11,7 +11,7 @@ public class Store extends AbstractNode implements Action, OrderedNode {
     private final Node dependency;
     private final ValueHandle handle;
     private final Value value;
-    private final MemoryAtomicityMode mode;
+    private MemoryAtomicityMode mode;
 
     Store(Node callSite, ExecutableElement element, int line, int bci, Node dependency, ValueHandle handle, Value value, MemoryAtomicityMode mode) {
         super(callSite, element, line, bci);
@@ -35,6 +35,10 @@ public class Store extends AbstractNode implements Action, OrderedNode {
 
     public MemoryAtomicityMode getMode() {
         return mode;
+    }
+
+    public void setMode(MemoryAtomicityMode mode) {
+        this.mode = mode;
     }
 
     int calcHashCode() {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -232,6 +232,8 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
                 return builder.fence(OrderingConstraint.acq_rel);
             case SEQUENTIALLY_CONSISTENT:
                 return builder.fence(OrderingConstraint.seq_cst);
+            case UNORDERED:
+                return null;
         }
         throw Assert.unreachableCode();
     }

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FenceAnalyzerVisitor.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FenceAnalyzerVisitor.java
@@ -1,0 +1,750 @@
+package org.qbicc.plugin.opt;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.Action;
+import org.qbicc.graph.Add;
+import org.qbicc.graph.AddressOf;
+import org.qbicc.graph.And;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BitCast;
+import org.qbicc.graph.BlockEntry;
+import org.qbicc.graph.BlockLabel;
+import org.qbicc.graph.Call;
+import org.qbicc.graph.CallNoSideEffects;
+import org.qbicc.graph.CallNoReturn;
+import org.qbicc.graph.Cmp;
+import org.qbicc.graph.CmpG;
+import org.qbicc.graph.CmpL;
+import org.qbicc.graph.Convert;
+import org.qbicc.graph.Div;
+import org.qbicc.graph.ElementOf;
+import org.qbicc.graph.Extend;
+import org.qbicc.graph.ExtractElement;
+import org.qbicc.graph.ExtractMember;
+import org.qbicc.graph.Fence;
+import org.qbicc.graph.GlobalVariable;
+import org.qbicc.graph.Goto;
+import org.qbicc.graph.If;
+import org.qbicc.graph.Invoke;
+import org.qbicc.graph.InvokeNoReturn;
+import org.qbicc.graph.IsEq;
+import org.qbicc.graph.IsGe;
+import org.qbicc.graph.IsGt;
+import org.qbicc.graph.IsLe;
+import org.qbicc.graph.IsLt;
+import org.qbicc.graph.IsNe;
+import org.qbicc.graph.Load;
+import org.qbicc.graph.MemberOf;
+import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.Mod;
+import org.qbicc.graph.Multiply;
+import org.qbicc.graph.CheckCast;
+import org.qbicc.graph.Neg;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.NotNull;
+import org.qbicc.graph.Or;
+import org.qbicc.graph.ParameterValue;
+import org.qbicc.graph.PhiValue;
+import org.qbicc.graph.PointerHandle;
+import org.qbicc.graph.Return;
+import org.qbicc.graph.Select;
+import org.qbicc.graph.Shl;
+import org.qbicc.graph.Shr;
+import org.qbicc.graph.StackAllocation;
+import org.qbicc.graph.Store;
+import org.qbicc.graph.Sub;
+import org.qbicc.graph.Switch;
+import org.qbicc.graph.TailCall;
+import org.qbicc.graph.TailInvoke;
+import org.qbicc.graph.Terminator;
+import org.qbicc.graph.Truncate;
+import org.qbicc.graph.Unreachable;
+import org.qbicc.graph.Unschedulable;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.ValueReturn;
+import org.qbicc.graph.Xor;
+import org.qbicc.graph.literal.SymbolLiteral;
+import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.MethodElement;
+
+import org.jboss.logging.Logger;
+
+
+public class FenceAnalyzerVisitor implements NodeVisitor<Void, Value, Node, Void, ValueHandle> {
+    private final CompilationContext ctxt;
+    static final Logger logger = Logger.getLogger("org.qbicc.plugin.opt.fence");
+    private Set<BasicBlock> tracedBlocks;
+    private Set<Node> visitedActions;
+    private Set<Node> visitedValues;
+    private static final ConcurrentMap<String, FunctionInfo> functionInfoMap = new ConcurrentHashMap<>();
+    private static FunctionInfo functionInfo;
+    private ConcurrentMap<BasicBlock, BlockInfo> blockInfoMap;
+    private BlockInfo blockInfo;
+    private final Queue<PhiValue> phiQueue = new ArrayDeque<>();
+    private String functionName;
+    private int depth;
+
+    public FenceAnalyzerVisitor(final CompilationContext ctxt) {
+        this.ctxt = ctxt;
+    }
+
+    public static Map<String, FunctionInfo> getAnalysis() {
+        return functionInfoMap;
+    }
+
+    private void init(BasicBlock entryBlock, String functionName) {
+        this.functionName = functionName;
+        tracedBlocks = new HashSet<BasicBlock>();
+        visitedActions = new HashSet<Node>();
+        visitedValues = new HashSet<Node>();
+        blockInfoMap = new ConcurrentHashMap<BasicBlock, BlockInfo>();
+        blockInfo = new BlockInfo();
+        blockInfoMap.put(entryBlock, blockInfo);
+        functionInfo = new FunctionInfo(blockInfoMap);
+        functionInfoMap.put(functionName, functionInfo);
+        depth = 0;
+    }
+
+    /**
+     * This method is invoked for each function
+     *
+     */
+    public void execute(BasicBlock entryBlock, String functionName) {
+        init(entryBlock, functionName);
+        entryBlock.getTerminator().accept(this, null);
+
+        PhiValue phi;
+        while ((phi = phiQueue.poll()) != null) {
+            BasicBlock ourBlock = phi.getPinnedBlock();
+            Set<Node> incomingSet = getIncoming(ourBlock, functionName);
+            BlockInfo blockInfo = blockInfoMap.get(ourBlock);
+            blockInfo.addIncoming(incomingSet);
+            blockInfoMap.put(ourBlock, blockInfo);
+        }
+    }
+
+    /**
+     * @return a set of nodes if it succeeded in collecting incoming nodes
+     *         correctly, {@code null} otherwise.
+     *
+     */
+    public Set<Node> getIncoming(BasicBlock block, String functionName) {
+        Set<Node> incomingSet = new HashSet<Node>();
+
+        if (!getIncoming(block, functionName, incomingSet, new ArrayList<BasicBlock>())) {
+            return null;
+        }
+
+        return incomingSet;
+    }
+
+    /**
+     * @return {@code true} if it succeeded in collecting incoming nodes correctly,
+     *         {@code false} otherwise.
+     *
+     */
+    private boolean getIncoming(BasicBlock block, String functionName, Set<Node> incomingSet, List<BasicBlock> trace) {
+        if (trace.contains(block)) {
+            return true;
+        }
+        trace.add(block);
+
+        Object[] blocks = block.getIncoming().toArray();
+        for (int i = 0; i < blocks.length; ++i) {
+            BasicBlock bb = (BasicBlock) blocks[i];
+            Map<BasicBlock, BlockInfo> blockInfoMap = functionInfoMap.get(functionName).getMap();
+            BlockInfo blockInfo = blockInfoMap.get(bb);
+
+            if (blockInfo == null // Not get this block information yet
+                    || blockInfo.isFailed()) {
+                return false;
+            }
+
+            List<Node> list = blockInfo.getList();
+            if (list.size() == 0) {
+                if (!getIncoming(bb, functionName, incomingSet, trace)) {
+                    return false;
+                }
+            } else {
+                incomingSet.add(list.get(list.size() - 1));
+            }
+        }
+
+        return true;
+    }
+
+    private void map(BasicBlock block) {
+        if (tracedBlocks.contains(block)) {
+            return;
+        }
+        tracedBlocks.add(block);
+
+        blockInfo = new BlockInfo();
+        blockInfo.addIncoming(getIncoming(block, functionName));
+        blockInfoMap.put(block, blockInfo);
+        block.getTerminator().accept(this, null);
+    }
+
+    private void map(Node unknown) {
+        if (depth++ > 500) {
+            throw new TooBigException();
+        }
+
+        if (unknown instanceof Action) {
+            if (visitedActions.add(unknown)) {
+                ((Action) unknown).accept(this, null);
+            }
+        } else if (unknown instanceof Value) {
+            if (visitedValues.add(unknown)) {
+                ((Value) unknown).accept(this, null);
+            }
+        } else {
+            throw new IllegalStateException();
+        }
+
+        depth--;
+    }
+
+    // terminators
+
+    public Void visit(final Void param, final Goto node) {
+        map(node.getDependency());
+
+        BlockLabel label = ((Goto) node).getResumeTargetLabel();
+        map(BlockLabel.getTargetOf(label));
+
+        return null;
+    }
+
+    public Void visit(final Void param, final If node) {
+        map(node.getDependency());
+
+        If ifnode = (If) node;
+        map(ifnode.getCondition());
+        map(ifnode.getTrueBranch());
+        map(ifnode.getFalseBranch());
+
+        return null;
+    }
+
+    public Void visit(final Void param, final Return node) {
+        map(node.getDependency());
+
+        blockInfo.setReturnBlock();
+
+        return null;
+    }
+
+    public Void visit(final Void param, final Unreachable node) {
+        map(node.getDependency());
+
+        return null;
+    }
+
+    public Void visit(final Void param, final Switch node) {
+        map(node.getDependency());
+
+        map(node.getSwitchValue());
+        map(node.getDefaultTarget());
+
+        for (int i = 0; i < node.getNumberOfValues(); i++) {
+            map(node.getTargetForIndex(i));
+        }
+
+        return null;
+    }
+
+    public Void visit(final Void param, final ValueReturn node) {
+        map(node.getDependency());
+
+        blockInfo.setReturnBlock();
+
+        return null;
+    }
+
+    public Node visit(final Void param, Fence node) {
+        blockInfo.add(node);
+        logger.debugf("Fence %s with mode %s", node, node.getAtomicityMode());
+        map(node.getDependency());
+
+        return node;
+    }
+
+    public Node visit(final Void param, BlockEntry node) {
+        return node;
+    }
+
+    public Node visit(final Void param, Store node) {
+        if (node.getMode() == MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT) {
+            logger.debugf("Store %s with mode %s", node, node.getMode());
+            blockInfo.add(node);
+        }
+        map(node.getDependency());
+
+        return node;
+    }
+
+    public Value visit(final Void param, Load node) {
+        if (node.getMode() == MemoryAtomicityMode.ACQUIRE) {
+            logger.debugf("Load %s with mode %s", node, node.getMode());
+            blockInfo.add(node);
+        }
+        map(node.getDependency());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Add node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final AddressOf node) {
+        node.getValueHandle().accept(this, null);
+
+        return node;
+    }
+
+    public Value visit(final Void param, final And node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(Void param, Cmp node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(Void param, CmpG node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(Void param, CmpL node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final IsEq node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final IsNe node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final IsLt node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final IsLe node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final IsGt node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final IsGe node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Or node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Xor node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Multiply node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Select node) {
+        map(node.getCondition());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final PhiValue node) {
+        phiQueue.add(node);
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Neg node) {
+        map(node.getInput());
+
+        return node;
+    }
+
+    public Value visit(Void param, NotNull node) {
+        map(node.getInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Shr node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Shl node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Sub node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Div node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Mod node) {
+        map(node.getLeftInput());
+        map(node.getRightInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final BitCast node) {
+        map(node.getInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Convert node) {
+        map(node.getInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Extend node) {
+        map(node.getInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final ExtractElement node) {
+        map(node.getArrayValue());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final ExtractMember node) {
+        map(node.getCompoundValue());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Invoke.ReturnValue node) {
+        map(node.getDependency());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final CheckCast node) {
+        map(node.getDependency());
+        map(node.getInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final Truncate node) {
+        map(node.getInput());
+
+        return node;
+    }
+
+    public Value visit(final Void param, final StackAllocation node) {
+        return node;
+    }
+
+    // calls
+    public Value visit(final Void param, final Call node) {
+        logger.debugf("Call %s", node);
+        blockInfo.add(node);
+
+        map(node.getDependency());
+        List<Value> arguments = node.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            map(arguments.get(i));
+        }
+
+        return node;
+    }
+
+    public Value visit(final Void param, final CallNoSideEffects node) {
+        logger.debugf("CallNoSideEffects %s", node);
+        blockInfo.add(node);
+
+        List<Value> arguments = node.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            map(arguments.get(i));
+        }
+
+        return null;
+    }
+
+    public Void visit(final Void param, final CallNoReturn node) {
+        logger.debugf("CallNoReturn %s", node);
+        blockInfo.add(node);
+
+        map(node.getDependency());
+        List<Value> arguments = node.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            map(arguments.get(i));
+        }
+
+        return null;
+    }
+
+    public Void visit(final Void param, final TailCall node) {
+        logger.debugf("TailCall %s", node);
+        blockInfo.add(node);
+
+        map(node.getDependency());
+        List<Value> arguments = node.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            map(arguments.get(i));
+        }
+
+        return null;
+    }
+
+    public Void visit(final Void param, final Invoke node) {
+        logger.debugf("Invoke %s", node);
+        blockInfo.add(node);
+
+        map(node.getDependency());
+        List<Value> arguments = node.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            map(arguments.get(i));
+        }
+
+        return null;
+    }
+
+    public Void visit(final Void param, final InvokeNoReturn node) {
+        logger.debugf("InvokeNoReturn %s", node);
+        blockInfo.add(node);
+
+        map(node.getDependency());
+        List<Value> arguments = node.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            map(arguments.get(i));
+        }
+
+        return null;
+    }
+
+    public Void visit(final Void param, final TailInvoke node) {
+        logger.debugf("TailInvoke %s", node);
+        blockInfo.add(node);
+
+        map(node.getDependency());
+        List<Value> arguments = node.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            map(arguments.get(i));
+        }
+
+        return null;
+    }
+
+    class FunctionInfo {
+        private Set<Node> tailNodes;
+        private Set<Node> unweakened;
+        private final Map<BasicBlock, BlockInfo> blockInfoMap;
+        private boolean isFailed;
+        private boolean weakening;
+
+        public FunctionInfo(Map<BasicBlock, BlockInfo> blockInfoMap) {
+            this.blockInfoMap = blockInfoMap;
+        }
+
+        public synchronized void setWeakening() {
+            weakening = true;
+        }
+
+        public synchronized void setWeakened() {
+            weakening = false;
+        }
+
+        public boolean isWeakening() {
+            return weakening;
+        }
+
+        public Map<BasicBlock, BlockInfo> getMap() {
+            return blockInfoMap;
+        }
+
+        public void addTailNode(Node n) {
+            if (isFailed) {
+                return;
+            }
+
+            if (tailNodes == null) {
+                tailNodes = new HashSet<Node>();
+            }
+
+            tailNodes.add(n);
+        }
+
+        public void addTailNode(Set<Node> set) {
+            if (isFailed) {
+                return;
+            }
+
+            if (tailNodes == null) {
+                tailNodes = new HashSet<Node>();
+            }
+
+            tailNodes.addAll(set);
+        }
+
+        public boolean resolved() {
+            return isFailed || tailNodes != null;
+        }
+
+        public Set<Node> getTailNodes() {
+            return tailNodes;
+        }
+
+        public void setFailed() {
+            isFailed = true;
+            tailNodes = null;
+        }
+
+        public boolean isFailed() {
+            return isFailed;
+        }
+    }
+
+    /**
+     * Information on a basic block about the existence of Fence, ordered Load, ordered
+     * Store, and Call/Invoke reateld nodes. It holds 1) a list of these nodes stored in
+     * the program order and 2) a set of these nodes in the incoming basic blocks.
+     *
+     **/
+    class BlockInfo {
+        private Set<Node> incoming;
+        private List<Node> list; // can be null
+        private boolean isFailed;
+        private boolean isReturnBlock;
+
+        public BlockInfo() {
+            this.incoming = new HashSet<Node>();
+            this.list = new ArrayList<Node>();
+        }
+
+        public boolean isFailed() {
+            return isFailed;
+        }
+
+        public void setFail() {
+            isFailed = true;
+            list = null;
+        }
+
+        public Set<Node> getIncoming() {
+            return incoming;
+        }
+
+        public void add(Node node) {
+            if (!isFailed()) {
+                list.add(0, node);
+            }
+        }
+
+        public void addIncoming(Set<Node> subSet) {
+            if (subSet != null) {
+                incoming.addAll(subSet);
+            }
+        }
+
+        public List<Node> getList() {
+            return list;
+        }
+
+        public void addList(List<Node> subList) {
+            list.addAll(subList);
+        }
+
+        public boolean isReturnBlock() {
+            return isReturnBlock;
+        }
+
+        public void setReturnBlock() {
+            isReturnBlock = true;
+        }
+    }
+
+    class TooBigException extends RuntimeException {
+    }    
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FenceOptimizer.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FenceOptimizer.java
@@ -265,21 +265,6 @@ public class FenceOptimizer implements Consumer<CompilationContext> {
     }
 
     private boolean weaken(Store store, Node prev) {
-        if (prev instanceof Store) {
-            Store prev_store = (Store) prev;
-            //
-            // prev_store
-            //  seq_cst
-            //     +
-            //  release   <- not needed
-            //   store
-            //
-            if (prev_store.getMode() == MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT
-                    && store.getMode() == MemoryAtomicityMode.RELEASE) {
-                store.setMode(MemoryAtomicityMode.UNORDERED);
-            }
-        }
-
         return true;
     }
 

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FenceOptimizer.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FenceOptimizer.java
@@ -1,0 +1,478 @@
+package org.qbicc.plugin.opt;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.AbstractProgramObjectHandle;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.Call;
+import org.qbicc.graph.CallNoSideEffects;
+import org.qbicc.graph.CallNoReturn;
+import org.qbicc.graph.Fence;
+import org.qbicc.graph.FunctionHandle;
+import org.qbicc.graph.FunctionDeclarationHandle;
+import org.qbicc.graph.Invoke;
+import org.qbicc.graph.InvokeNoReturn;
+import org.qbicc.graph.Load;
+import org.qbicc.graph.MemberOf;
+import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.PointerHandle;
+import org.qbicc.graph.Store;
+import org.qbicc.graph.TailCall;
+import org.qbicc.graph.TailInvoke;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.literal.SymbolLiteral;
+import org.qbicc.object.Data;
+import org.qbicc.object.DataDeclaration;
+import org.qbicc.object.Function;
+import org.qbicc.object.FunctionDeclaration;
+import org.qbicc.object.ProgramModule;
+import org.qbicc.object.ProgramObject;
+import org.qbicc.object.Section;
+import org.qbicc.type.FunctionType;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.MethodElement;
+
+import org.jboss.logging.Logger;
+
+
+/**
+ *
+ */
+public class FenceOptimizer implements Consumer<CompilationContext> {
+    static final Logger logger = Logger.getLogger("org.qbicc.plugin.opt.fence");
+    private FenceAnalyzerVisitor analyzer;
+
+    public void accept(final CompilationContext ctxt) {
+        // Analyze
+        analyzer = new FenceAnalyzerVisitor(ctxt);
+        for (ProgramModule programModule : ctxt.getAllProgramModules()) {
+            for (Section section : programModule.sections()) {
+                String sectionName = section.getName();
+                for (ProgramObject item : section.contents()) {
+                    String name = item.getName();
+                    if (item instanceof Function) {
+                        ExecutableElement element = ((Function) item).getOriginalElement();
+                        MethodBody body = ((Function) item).getBody();
+                        boolean isExact = item == ctxt.getExactFunction(element);
+                        if (body == null) {
+                            ctxt.error("Function `%s` has no body", name);
+                            continue;
+                        }
+                        BasicBlock entryBlock = body.getEntryBlock();
+                        logger.debugf("Analyze %s", ((Function) item).getName());
+                        try {
+                            analyzer.execute(entryBlock, ((Function) item).getName());
+                        } catch (FenceAnalyzerVisitor.TooBigException e) {
+                            ctxt.warning("Element \"%s\" is too big. Abort fence optimization.", element);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Analysis done. Call/Invoke related nodes are not resolved yet.
+        Map<String, FenceAnalyzerVisitor.FunctionInfo> functionInfoMap = FenceAnalyzerVisitor.getAnalysis();
+
+
+        // Optimize
+        for (String functionName : functionInfoMap.keySet()) {
+            weaken(functionName, functionInfoMap.get(functionName));
+        }
+    }
+
+    private void weaken(String functionName, FenceAnalyzerVisitor.FunctionInfo functionInfo) {
+        if (functionInfo == null || functionInfo.isWeakening() || functionInfo.resolved()) {
+            return;
+        }
+        functionInfo.setWeakening();
+
+        logger.debugf("Attempt to optimize %s", functionName);
+        Map<BasicBlock, FenceAnalyzerVisitor.BlockInfo> blockInfoMap = functionInfo.getMap();
+        for (BasicBlock block : blockInfoMap.keySet()) {
+            FenceAnalyzerVisitor.BlockInfo blockInfo = blockInfoMap.get(block);
+            if (blockInfo.isFailed()) {
+                logger.debugf("Couldn't get the information on fences in BasicBlock %s", block);
+                continue;
+            }
+            List<Node> list = blockInfo.getList();
+            if (list.size() == 0) {
+                continue;
+            }
+
+            // Try to weaken fences in a basic block.
+            // A node will be weakened by checking previous nodes.
+            for (int i = list.size() - 1; i >= 0; --i) {
+                Node target = list.get(i);
+                if (isFunctionCall(target)) {
+                    continue;
+                }
+
+                int j = i - 1;
+                for (; j >= 0; --j) {
+                    Node prev = list.get(j);
+                    if (weaken(target, prev)) {
+                        break;
+                    }
+                }
+
+                if (j < 0) {
+                    weaken(target, blockInfo.getIncoming());
+                }
+            }
+        }
+
+        addTail(functionName, functionInfo);
+
+        functionInfo.setWeakened();
+    }
+
+    /**
+     * Calculate tail nodes for a function after resolving Call/Invoke related nodes.
+     *
+     */
+    private void addTail(String functionName, FenceAnalyzerVisitor.FunctionInfo functionInfo) {
+        if (functionInfo.resolved()) {
+            return;
+        }
+
+        Map<BasicBlock, FenceAnalyzerVisitor.BlockInfo> blockInfoMap = functionInfo.getMap();
+        logger.debugf("Add tail nodes %s", functionName);
+        boolean noTail = false;
+        for (BasicBlock block : blockInfoMap.keySet()) {
+            FenceAnalyzerVisitor.BlockInfo blockInfo = blockInfoMap.get(block);
+            if (blockInfo.isReturnBlock()) {
+                if (blockInfo.isFailed()) {
+                    functionInfo.setFailed();
+                    return;
+                }
+
+                List<Node> list_returnBlock = blockInfo.getList();
+                if (list_returnBlock == null) {
+                    functionInfo.setFailed();
+                    return;
+                } else if (list_returnBlock.size() == 0) {
+                    // Search incoming blocks of this block
+                    Set<Node> set = findTail(block, functionName);
+                    if (set == null) {
+                        functionInfo.setFailed();
+                        return;
+                    }
+                    if (set.size() == 0) {
+                        noTail = true;
+                    }
+                    functionInfo.addTailNode(set);
+                } else {
+                    // Return block has a list.
+                    boolean foundTail = false;
+                    for (int i = list_returnBlock.size() - 1; i >= 0; --i) {
+                        Node n = list_returnBlock.get(i);
+                        Object[] ret = new Object[1];
+                        if (getIncomingIfFunctionCall(n, ret)) {
+                            Set<Node> set = (Set<Node>) ret[0];
+                            if (set == null) {
+                                functionInfo.setFailed();
+                                return;
+                            } else if (set.size() != 0) {
+                                functionInfo.addTailNode(set);
+                                foundTail = true;
+                                break;
+                            }
+                        } else {
+                            functionInfo.addTailNode(n);
+                            foundTail = true;
+                            break;
+                        }
+                    }
+                    if (!foundTail) {
+                        // Search incoming blocks of this block
+                        Set<Node> set = findTail(block, functionName);
+                        if (set == null) {
+                            functionInfo.setFailed();
+                            return;
+                        }
+                        if (set.size() == 0) {
+                            noTail = true;
+                        }
+                        functionInfo.addTailNode(set);
+                    }
+                }
+                if (functionInfo.getTailNodes().size() != 0 && noTail) {
+                    functionInfo.setFailed();
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     */
+    private Set<Node> findTail(BasicBlock block, String functionName) {
+        Set<Node> incomingSet = analyzer.getIncoming(block, functionName);
+
+        if (incomingSet == null) {
+            return null;
+        } else if (incomingSet.size() == 0) {
+            return Set.of();
+        } else {
+            Set<Node> functionCallFreeSet = new HashSet<Node>();
+            for (Node n : incomingSet) {
+                Object[] ret = new Object[1];
+                if (getIncomingIfFunctionCall(n, ret)) {
+                    Set<Node> set = (Set<Node>) ret[0];
+                    if (set == null) {
+                        return null;
+                    }
+                    if (set.size() == 0) {
+                        return Set.of();
+                    }
+                    functionCallFreeSet.addAll(set);
+                } else {
+                    functionCallFreeSet.add(n);
+                }
+            }
+            return functionCallFreeSet;
+        }
+    }
+
+    private boolean weaken(Node node, Node prev) {
+        Object[] ret = new Object[1];
+        if (getIncomingIfFunctionCall(prev, ret)) {
+            Set<Node> set = (Set<Node>) ret[0];
+            return weaken(node, set);
+        }
+
+        if (node instanceof Fence) {
+            return weaken((Fence) node, prev);
+        } else if (node instanceof Load) {
+            return weaken((Load) node, prev);
+        } else if (node instanceof Store) {
+            return weaken((Store) node, prev);
+        }
+
+        return false;
+    }
+
+    private boolean weaken(Store store, Node prev) {
+        if (prev instanceof Store) {
+            Store prev_store = (Store) prev;
+            //
+            // prev_store
+            //  seq_cst
+            //     +
+            //  release   <- not needed
+            //   store
+            //
+            if (prev_store.getMode() == MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT
+                    && store.getMode() == MemoryAtomicityMode.RELEASE) {
+                store.setMode(MemoryAtomicityMode.UNORDERED);
+            }
+        }
+
+        return true;
+    }
+
+    private boolean weaken(Load load, Node prev) {
+        if (prev instanceof Fence) {
+            Fence prev_fence = (Fence) prev;
+            //
+            // acquire
+            //    +
+            // acquire <- not needed
+            //  load
+            //
+            // An acquire fence can be removed.
+            //
+            if (prev_fence.getAtomicityMode() == MemoryAtomicityMode.ACQUIRE
+                    && load.getMode() == MemoryAtomicityMode.ACQUIRE) {
+                load.setMode(MemoryAtomicityMode.UNORDERED);
+            }
+        } else if (prev instanceof Store) {
+            Store prev_store = (Store) prev;
+            //
+            // prev_store
+            //  seq_cst
+            //    +
+            //  acquire   <- not needed
+            //   load
+            //
+            if (prev_store.getMode() == MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT
+                    && load.getMode() == MemoryAtomicityMode.ACQUIRE) {
+                load.setMode(MemoryAtomicityMode.UNORDERED);
+            }
+        }
+
+        return true;
+    }
+
+    private boolean weaken(Fence fence, Node prev) {
+        if (prev instanceof Store) {
+            Store prev_store = (Store) prev;
+            //
+            // prev_store
+            // seq_cst
+            //    +
+            // release <- not needed
+            //
+            if (prev_store.getMode() == MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT
+                    && fence.getAtomicityMode() == MemoryAtomicityMode.RELEASE) {
+                fence.setAtomicityMode(MemoryAtomicityMode.UNORDERED);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Try to weaken fence by calculating the weakest fence in the incoming set.
+     *
+     * @return {@code true} if optimization should finish because of either successful optimization or
+     *         giving up optimization due to some reasons, {@code false} otherwise .
+     *
+     */
+    private boolean weaken(Node n, Set<Node> incomingSet) {
+        if (incomingSet == null) {
+            return true;
+        }
+
+        Set<Node> functionCallFreeSet = new HashSet<Node>();
+        boolean isEmptySet = false;
+        for (Node prev : incomingSet) {
+            Object[] ret = new Object[1];
+            if (getIncomingIfFunctionCall(prev, ret)) {
+                Set<Node> set = (Set<Node>) ret[0];
+                if (set == null) { // Couldn't get the information. Give up optimizing node n.
+                    return true;
+                }
+                if (set.size() == 0) { // No fence exists.
+                    isEmptySet = true;
+                    continue;
+                }
+                functionCallFreeSet.addAll(set);
+            } else {
+                functionCallFreeSet.add(prev);
+            }
+        }
+        if (functionCallFreeSet.size() == 0) { // No node is found
+            return false;
+        } else if (isEmptySet) { // Set is not empty but at least a path has empty list. Should give up optimization.
+            return true;
+        }
+
+        EnumSet<MemoryAtomicityMode> modeSet = EnumSet.noneOf(MemoryAtomicityMode.class);
+        for (Node prev : functionCallFreeSet) {
+            modeSet.add(getMode(prev));
+        }
+
+        if (modeSet.contains(MemoryAtomicityMode.RELEASE) && !modeSet.contains(MemoryAtomicityMode.ACQUIRE)) {
+            // Weakest fence in modeSet is release. Check node n is also the release fence.
+            if (n instanceof Fence) {
+                Fence fence = (Fence) n;
+                if (fence.getAtomicityMode() == MemoryAtomicityMode.RELEASE) {
+                    fence.setAtomicityMode(MemoryAtomicityMode.UNORDERED);
+                }
+            }
+        }
+
+        if (modeSet.contains(MemoryAtomicityMode.ACQUIRE) && !modeSet.contains(MemoryAtomicityMode.RELEASE)) {
+            // Weakest fence in modeSet is acquire. Check node n includes the acquire fence.
+            if (n instanceof Load) {
+                Load load = (Load) n;
+                if (load.getMode() == MemoryAtomicityMode.ACQUIRE) {
+                    load.setMode(MemoryAtomicityMode.UNORDERED);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private MemoryAtomicityMode getMode(Node n) {
+        if (n instanceof Fence) {
+            return ((Fence) n).getAtomicityMode();
+        } else if (n instanceof Load) {
+            return ((Load) n).getMode();
+        } else if (n instanceof Store) {
+            return ((Store) n).getMode();
+        } else {
+            // Should not reach here
+            return null;
+        }
+    }
+
+    private boolean isFunctionCall(Node node) {
+        return node instanceof Call
+            || node instanceof CallNoSideEffects
+            || node instanceof CallNoReturn
+            || node instanceof TailCall
+            || node instanceof Invoke
+            || node instanceof InvokeNoReturn
+            || node instanceof TailInvoke;
+    }
+
+    private boolean getIncomingIfFunctionCall(Node node, Object[] ret) {
+        if (node instanceof Call) {
+            ret[0] = getIncoming(((Call) node).getValueHandle());
+            return true;
+        } else if (node instanceof CallNoSideEffects) {
+            ret[0] = getIncoming(((CallNoSideEffects) node).getValueHandle());
+            return true;
+        } else if (node instanceof CallNoReturn) {
+            ret[0] = getIncoming(((CallNoReturn) node).getValueHandle());
+            return true;
+        } else if (node instanceof TailCall) {
+            ret[0] = getIncoming(((TailCall) node).getValueHandle());
+            return true;
+        } else if (node instanceof Invoke) {
+            ret[0] = getIncoming(((Invoke) node).getValueHandle());
+            return true;
+        } else if (node instanceof InvokeNoReturn) {
+            ret[0] = getIncoming(((Invoke) node).getValueHandle());
+            return true;
+        } else if (node instanceof TailInvoke) {
+            ret[0] = getIncoming(((Invoke) node).getValueHandle());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @return a set of nodes after resolving Call/Invoke related nodes if it succeeded in
+     * collecting incoming nodes, {@code null} otherwise.
+     *
+     */
+    private Set<Node> getIncoming(ValueHandle valueHandle) {
+        if (valueHandle instanceof FunctionHandle || valueHandle instanceof FunctionDeclarationHandle) {
+            String callName = ((AbstractProgramObjectHandle) valueHandle).getProgramObject().getName();
+            Map<String, FenceAnalyzerVisitor.FunctionInfo> functionInfoMap = FenceAnalyzerVisitor.getAnalysis();
+            FenceAnalyzerVisitor.FunctionInfo functionInfo = functionInfoMap.get(callName);
+            if (functionInfo == null) {
+                logger.debugf("No record on %s", callName);
+                return null;
+            }
+
+            logger.debugf("Looking for record on %s", callName);
+            if (functionInfo.resolved()) {
+                return functionInfo.getTailNodes();
+            }
+
+            weaken(callName, functionInfo);
+
+            return functionInfo.getTailNodes();
+        } else { // TODO: Support PointerHandle case
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
An analyzer visitor and an optimizer are post-hooked at the LOWER phase in which fences are already emitted.
It covers inter-procedural analysis and optimization. It currently runs in a single thread and avoids StackoverflowError by a predefined maximum stack count as DotGenerator does. 

This change removes redundant fences, for example, acquire fences are currently emitted before and after a load like
acquire; load x; acquire; acquire; load y; acquire
This change removes a redundant acquire fence:
acquire; load x; acquire; load y; acquire