### PR TITLE
Generalize member copying and move function lowering to the lowering plugin

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/CompilationContext.java
+++ b/compiler/src/main/java/org/qbicc/context/CompilationContext.java
@@ -2,8 +2,14 @@ package org.qbicc.context;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.SymbolLiteral;
 import org.qbicc.interpreter.VmObject;
@@ -95,4 +101,12 @@ public interface CompilationContext extends DiagnosticContext {
      *  running
      */
     void runParallelTask(Consumer<CompilationContext> task) throws IllegalStateException;
+
+    /**
+     * Get the copier for the current phase.
+     *
+     * @return the copier (not {@code null})
+     * @throws IllegalStateException if the current phase does not have a copier
+     */
+    BiFunction<CompilationContext, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>> getCopier();
 }

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -13,8 +14,12 @@ import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.context.Diagnostic;
 import org.qbicc.context.Location;
+import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.SymbolLiteral;
 import org.qbicc.interpreter.VmObject;
@@ -141,6 +146,10 @@ public class TestClassContext implements ClassContext {
         }
 
         public void runParallelTask(Consumer<CompilationContext> task) throws IllegalStateException {
+        }
+
+        public BiFunction<CompilationContext, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>> getCopier() {
+            return null;
         }
 
         public <T> T getAttachment(final AttachmentKey<T> key) {

--- a/driver/src/main/java/org/qbicc/driver/ElementBodyCopier.java
+++ b/driver/src/main/java/org/qbicc/driver/ElementBodyCopier.java
@@ -1,0 +1,44 @@
+package org.qbicc.driver;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * An element handler which copies the body of the method.
+ */
+public final class ElementBodyCopier implements Consumer<ExecutableElement> {
+    /**
+     * Construct a new instance.
+     */
+    public ElementBodyCopier() {
+    }
+
+    @Override
+    public void accept(ExecutableElement element) {
+        // rewrite the method body
+        if (element.hasMethodBody()) {
+            ClassContext classContext = element.getEnclosingType().getContext();
+            CompilationContext compilationContext = classContext.getCompilationContext();
+            BiFunction<CompilationContext, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>> copier = compilationContext.getCopier();
+            MethodBody original = element.getMethodBody();
+            BasicBlock entryBlock = original.getEntryBlock();
+            BasicBlockBuilder builder = classContext.newBasicBlockBuilder(element);
+            builder.startMethod(original.getParameterValues());
+            BasicBlock copyBlock = Node.Copier.execute(entryBlock, builder, compilationContext, copier);
+            builder.finish();
+            element.replaceMethodBody(MethodBody.of(copyBlock, Schedule.forMethod(copyBlock), original.getThisValue(), original.getParameterValues()));
+        }
+    }
+}

--- a/driver/src/main/java/org/qbicc/driver/ElementBodyCreator.java
+++ b/driver/src/main/java/org/qbicc/driver/ElementBodyCreator.java
@@ -1,0 +1,21 @@
+package org.qbicc.driver;
+
+import java.util.function.Consumer;
+
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * An element consumer which creates the element body, if any.
+ */
+public final class ElementBodyCreator implements Consumer<ExecutableElement> {
+    /**
+     * Construct a new instance.
+     */
+    public ElementBodyCreator() {
+    }
+
+    @Override
+    public void accept(ExecutableElement executableElement) {
+        executableElement.tryCreateMethodBody();
+    }
+}

--- a/driver/src/main/java/org/qbicc/driver/ElementVisitorAdapter.java
+++ b/driver/src/main/java/org/qbicc/driver/ElementVisitorAdapter.java
@@ -1,0 +1,23 @@
+package org.qbicc.driver;
+
+import java.util.function.Consumer;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.type.definition.element.ElementVisitor;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ *
+ */
+public final class ElementVisitorAdapter implements Consumer<ExecutableElement> {
+    private final ElementVisitor<CompilationContext, Void> visitor;
+
+    public ElementVisitorAdapter(ElementVisitor<CompilationContext, Void> visitor) {
+        this.visitor = visitor;
+    }
+
+    @Override
+    public void accept(ExecutableElement executableElement) {
+        executableElement.accept(visitor, executableElement.getEnclosingType().getContext().getCompilationContext());
+    }
+}

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/FunctionLoweringElementHandler.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/FunctionLoweringElementHandler.java
@@ -1,0 +1,75 @@
+package org.qbicc.plugin.lowering;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.ParameterValue;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.object.Function;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.FunctionElement;
+
+/**
+ * An element handler which lowers each element to a function program object.
+ */
+public final class FunctionLoweringElementHandler implements Consumer<ExecutableElement> {
+    /**
+     * Construct a new instance.
+     */
+    public FunctionLoweringElementHandler() {
+    }
+
+    @Override
+    public void accept(ExecutableElement element) {
+        if (element.hasMethodBody()) {
+            // copy to a function.
+            ClassContext classContext = element.getEnclosingType().getContext();
+            CompilationContext compilationContext = classContext.getCompilationContext();
+            BiFunction<CompilationContext, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle>> copier = compilationContext.getCopier();
+            LoadedTypeDefinition threadClass = compilationContext.getBootstrapClassContext().findDefinedType("java/lang/Thread").load();
+            MethodBody original = element.getMethodBody();
+            BasicBlock entryBlock = original.getEntryBlock();
+            List<ParameterValue> paramValues;
+            ParameterValue thisValue;
+            BasicBlockBuilder builder = classContext.newBasicBlockBuilder(element);
+            if (element instanceof FunctionElement) {
+                // it is already a function with a C calling convention and ABI.
+                paramValues = original.getParameterValues();
+                thisValue = null;
+            } else {
+                // make a function with a Java calling convention and ABI.
+                List<ParameterValue> origParamValues = original.getParameterValues();
+                paramValues = new ArrayList<>(origParamValues.size() + 2);
+                // first parameter is the current thread.
+                paramValues.add(builder.parameter(threadClass.getClassType().getReference(), "thr", 0));
+                if (! element.isStatic()) {
+                    // instance methods get `this` as an implicit second parameter.
+                    thisValue = original.getThisValue();
+                    paramValues.add(thisValue);
+                } else {
+                    thisValue = null;
+                }
+                paramValues.addAll(origParamValues);
+            }
+            builder.startMethod(paramValues);
+            Function function = compilationContext.getExactFunction(element);
+            // perform the copy.
+            BasicBlock copyBlock = Node.Copier.execute(entryBlock, builder, compilationContext, copier);
+            builder.finish();
+            function.replaceBody(MethodBody.of(copyBlock, Schedule.forMethod(copyBlock), thisValue, paramValues));
+            element.replaceMethodBody(function.getBody());
+        }
+    }
+}


### PR DESCRIPTION
This is an API cleanup and does not add significant functionality.  It was just a long-standing todo.