### PR TITLE
Method data

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/CompilationContext.java
+++ b/compiler/src/main/java/org/qbicc/context/CompilationContext.java
@@ -76,6 +76,8 @@ public interface CompilationContext extends DiagnosticContext {
 
     List<ProgramModule> getAllProgramModules();
 
+    DefinedTypeDefinition getDefaultTypeDefinition();
+
     Section getImplicitSection(ExecutableElement element);
 
     Section getImplicitSection(DefinedTypeDefinition typeDefinition);

--- a/compiler/src/main/java/org/qbicc/context/CompilationContext.java
+++ b/compiler/src/main/java/org/qbicc/context/CompilationContext.java
@@ -72,6 +72,8 @@ public interface CompilationContext extends DiagnosticContext {
 
     Path getOutputDirectory(MemberElement element);
 
+    ProgramModule getProgramModule(final DefinedTypeDefinition type);
+
     ProgramModule getOrAddProgramModule(DefinedTypeDefinition type);
 
     List<ProgramModule> getAllProgramModules();

--- a/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
@@ -7,6 +7,7 @@ import org.qbicc.graph.literal.BooleanLiteral;
 import org.qbicc.graph.literal.ByteArrayLiteral;
 import org.qbicc.graph.literal.CompoundLiteral;
 import org.qbicc.graph.literal.ConstantLiteral;
+import org.qbicc.graph.literal.ElementOfLiteral;
 import org.qbicc.graph.literal.FloatLiteral;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.MethodDescriptorLiteral;
@@ -145,6 +146,10 @@ public interface ValueVisitor<T, R> {
     }
 
     default R visit(T param, Div node) {
+        return visitUnknown(param, node);
+    }
+
+    default R visit(T param, ElementOfLiteral node) {
         return visitUnknown(param, node);
     }
 
@@ -452,6 +457,10 @@ public interface ValueVisitor<T, R> {
         }
 
         default R visit(T param, Div node) {
+            return getDelegateValueVisitor().visit(param, node);
+        }
+
+        default R visit(T param, ElementOfLiteral node) {
             return getDelegateValueVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/literal/ElementOfLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ElementOfLiteral.java
@@ -1,0 +1,50 @@
+package org.qbicc.graph.literal;
+
+import org.qbicc.graph.ValueVisitor;
+import org.qbicc.type.ValueType;
+
+public class ElementOfLiteral extends Literal {
+    final Literal value;
+    final Literal index;
+
+    public ElementOfLiteral(Literal value, Literal index) {
+        this.value = value;
+        this.index = index;
+    }
+
+    @Override
+    public boolean isZero() {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Literal other) {
+        return other instanceof ElementOfLiteral && equals((ElementOfLiteral) other);
+    }
+
+    public boolean equals(ElementOfLiteral other) {
+        return other == this || other != null && value.equals(other.value) && index.equals(other.index);
+    }
+
+    @Override
+    public int hashCode() { return value.hashCode() * 19 + index.hashCode(); }
+
+    @Override
+    public ValueType getType() {
+        return value.getType();
+    }
+
+    public Literal getValue() { return value; }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+
+    public Literal getIndex() {
+        return index;
+    }
+
+    public String toString() {
+        return "element_of ("+value+", "+index+")";
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/literal/Literal.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/Literal.java
@@ -60,4 +60,8 @@ public abstract class Literal implements Unschedulable, Value {
     Literal convert(final LiteralFactory lf, final WordType toType) {
         return new ValueConvertLiteral(this, toType);
     }
+
+    Literal elementOf(LiteralFactory literalFactory, Literal index) {
+        return new ElementOfLiteral(this, index);
+    }
 }

--- a/compiler/src/main/java/org/qbicc/graph/literal/LiteralFactory.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/LiteralFactory.java
@@ -14,6 +14,7 @@ import org.qbicc.type.CompoundType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.NullableType;
+import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
@@ -72,6 +73,8 @@ public interface LiteralFactory {
     Literal bitcastLiteral(Literal value, WordType toType);
 
     Literal valueConvertLiteral(Literal value, WordType toType);
+
+    Literal elementOfLiteral(Literal value, Literal index);
 
     static LiteralFactory create(TypeSystem typeSystem) {
         return new LiteralFactory() {
@@ -239,6 +242,18 @@ public interface LiteralFactory {
                 Assert.checkNotNullParam("value", value);
                 Assert.checkNotNullParam("toType", toType);
                 return value.convert(this, toType);
+            }
+
+            @Override
+            public Literal elementOfLiteral(Literal value, Literal index) {
+                Assert.checkNotNullParam("value", value);
+                Assert.checkNotNullParam("index", index);
+                ValueType inputType = value.getType();
+                if (inputType instanceof PointerType || inputType instanceof ArrayType) {
+                    return value.elementOf(this, index);
+                } else {
+                    throw new IllegalArgumentException("Invalid input type: " + inputType);
+                }
             }
         };
     }

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -105,6 +105,10 @@ public class TestClassContext implements ClassContext {
             return null;
         }
 
+        public ProgramModule getProgramModule(final DefinedTypeDefinition type) {
+            return null;
+        }
+
         public ProgramModule getOrAddProgramModule(final DefinedTypeDefinition type) {
             return null;
         }

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -113,6 +113,10 @@ public class TestClassContext implements ClassContext {
             return null;
         }
 
+        public DefinedTypeDefinition getDefaultTypeDefinition() {
+            return null;
+        }
+
         public Section getImplicitSection(ExecutableElement element) {
             return null;  // TODO: Customise this generated block
         }

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -286,6 +286,10 @@ final class CompilationContextImpl implements CompilationContext {
         }
     }
 
+    public ProgramModule getProgramModule(final DefinedTypeDefinition type) {
+        return programModules.get(type);
+    }
+
     public ProgramModule getOrAddProgramModule(final DefinedTypeDefinition type) {
         return programModules.computeIfAbsent(type, t -> new ProgramModule(t, typeSystem, literalFactory));
     }

--- a/driver/src/main/java/org/qbicc/driver/Driver.java
+++ b/driver/src/main/java/org/qbicc/driver/Driver.java
@@ -544,7 +544,7 @@ public class Driver implements Closeable {
             try {
                 hook.accept(compilationContext);
             } catch (Exception e) {
-                log.error("An exception was thrown in a post-generate hook", e);
+                log.error("An exception was thrown in a post-generate hook " + hook.getClass().getName(), e);
                 compilationContext.error("Post-generate hook failed: %s", e);
             }
             if (compilationContext.errors() > 0) {

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/FunctionAttributes.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/FunctionAttributes.java
@@ -16,5 +16,9 @@ public final class FunctionAttributes {
     public static LLValue framePointer(String val) {
         return LLVM.valueAttribute("\"frame-pointer\"", LLVM.quoteString(val));
     }
+
+    public static LLValue statepointId(int id) {
+        return LLVM.valueAttribute("\"statepoint-id\"", LLVM.quoteString(String.valueOf(id)));
+    }
 }
 

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/Values.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/Values.java
@@ -22,6 +22,10 @@ public final class Values {
         return LLVM.bitcastConstant(value, fromType, toType);
     }
 
+    public static LLValue gepConstant(LLValue type, LLValue ptrType, LLValue pointer, LLValue ... args) {
+        return LLVM.gepConstant(type, ptrType, pointer, args);
+    }
+
     public static LLValue addrspacecastConstant(LLValue value, LLValue fromType, LLValue toType) {
         return LLVM.addrspacecastConstant(value, fromType, toType);
     }

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/GetElementPtrConstant.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/GetElementPtrConstant.java
@@ -1,0 +1,82 @@
+package org.qbicc.machine.llvm.impl;
+
+import io.smallrye.common.constraint.Assert;
+import org.qbicc.machine.llvm.LLValue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+
+final class GetElementPtrConstant extends AbstractValue {
+    private final LLValue type;
+    private final LLValue ptrType;
+    private final LLValue pointer;
+    ArgImpl lastArg;
+
+    GetElementPtrConstant(final LLValue type, final LLValue ptrType, final LLValue pointer, LLValue ... args) {
+        this.type = type;
+        this.ptrType = ptrType;
+        this.pointer = pointer;
+        Iterator<LLValue> iterator = Arrays.stream(args).iterator();
+        while (iterator.hasNext()) {
+            LLValue argType = iterator.next();
+            LLValue argIndex = iterator.next();
+            lastArg = new ArgImpl((AbstractValue)argType, (AbstractValue)argIndex, lastArg);
+        }
+    }
+
+    public GetElementPtrConstant arg(final boolean inRange, final LLValue type, final LLValue index) {
+        Assert.checkNotNullParam("type", type);
+        Assert.checkNotNullParam("index", index);
+        lastArg = new ArgImpl((AbstractValue) type, (AbstractValue) index, lastArg);
+        return this;
+    }
+
+    public Appendable appendTo(final Appendable target) throws IOException {
+        target.append("getelementptr (");
+        target.append(' ');
+        ((AbstractValue)type).appendTo(target);
+        target.append(',');
+        target.append(' ');
+        ((AbstractValue)ptrType).appendTo(target);
+        target.append(' ');
+        ((AbstractValue)pointer).appendTo(target);
+        ArgImpl lastArg = this.lastArg;
+        if (lastArg != null) {
+            lastArg.appendTo(target);
+        }
+        target.append(")");
+        return target;
+    }
+
+    private static final class ArgImpl extends AbstractEmittable {
+        final boolean inRange;
+        final AbstractValue type;
+        final AbstractValue index;
+        final ArgImpl prev;
+
+        ArgImpl(final AbstractValue type, final AbstractValue index, final ArgImpl prev) {
+            this.inRange = false;
+            this.type = type;
+            this.index = index;
+            this.prev = prev;
+        }
+
+        public Appendable appendTo(final Appendable target) throws IOException {
+            ArgImpl prev = this.prev;
+            if (prev != null) {
+                prev.appendTo(target);
+            }
+            target.append(',');
+            target.append(' ');
+            if (inRange) {
+                target.append("inrange");
+                target.append(' ');
+            }
+            type.appendTo(target);
+            target.append(' ');
+            index.appendTo(target);
+            return target;
+        }
+    }
+}

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/LLVM.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/LLVM.java
@@ -2,6 +2,7 @@ package org.qbicc.machine.llvm.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.qbicc.machine.llvm.Array;
 import org.qbicc.machine.llvm.LLBasicBlock;
@@ -18,6 +19,8 @@ import org.qbicc.machine.llvm.debuginfo.DIExpression;
 public final class LLVM {
 
     private LLVM() {}
+
+    private static AtomicInteger statepointId = new AtomicInteger(0);
 
     public static Module newModule() {
         return new ModuleImpl();
@@ -152,5 +155,9 @@ public final class LLVM {
     public static LLValue valueAttribute(final String attribute, final String value) {
         // TODO Should we have a separate class for this?
         return new SingleWord(attribute + "=" + value);
+    }
+
+    public static int getNextStatepointId() {
+        return statepointId.getAndIncrement();
     }
 }

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/LLVM.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/LLVM.java
@@ -160,4 +160,8 @@ public final class LLVM {
     public static int getNextStatepointId() {
         return statepointId.getAndIncrement();
     }
+
+    public static LLValue gepConstant(LLValue type, LLValue ptrType, LLValue pointer, LLValue ... args) {
+        return new GetElementPtrConstant(type, ptrType, pointer, args);
+    }
 }

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -122,6 +122,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-methodinfo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-native</artifactId>
         </dependency>
         <dependency>

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -507,10 +507,14 @@ public class Main implements Callable<DiagnosticContext> {
         private boolean debugDevirt;
         @CommandLine.Option(names = "--gc", defaultValue = "none", description = "Type of GC to use. Valid values: ${COMPLETION-CANDIDATES}")
         private GCType gc;
+        @CommandLine.Option(names = "--method-data-stats")
+        private boolean methodDataStats;
         @CommandLine.Option(names = "--pie", negatable = true, defaultValue = "false", description = "[Disable|Enable] generation of position independent executable")
         private boolean isPie;
         @CommandLine.Option(names = "--platform", converter = PlatformConverter.class)
         private Platform platform;
+        @CommandLine.Option(names = "--string-pool-stats")
+        private boolean stringPoolStats;
 
         @CommandLine.Parameters(index="0", arity="1", description = "Application main class")
         private String mainClass;
@@ -579,6 +583,12 @@ public class Main implements Callable<DiagnosticContext> {
             }
             if (debugDevirt) {
                 Logger.getLogger("org.qbicc.plugin.dispatch.devirt").setLevel(Level.DEBUG);
+            }
+            if (methodDataStats) {
+                Logger.getLogger("org.qbicc.plugin.methodinfo.stats").setLevel(Level.DEBUG);
+            }
+            if (stringPoolStats) {
+                Logger.getLogger("org.qbicc.plugin.stringpool.stats").setLevel(Level.DEBUG);
             }
             if (outputPath == null) {
                 outputPath = Path.of(System.getProperty("java.io.tmpdir"), "qbicc-output-" + Integer.toHexString(ThreadLocalRandom.current().nextInt()));

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -50,6 +50,7 @@ import org.qbicc.plugin.instanceofcheckcast.SupersDisplayBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayEmitter;
 import org.qbicc.plugin.intrinsics.IntrinsicBasicBlockBuilder;
 import org.qbicc.plugin.intrinsics.core.CoreIntrinsics;
+import org.qbicc.plugin.llvm.LLVMDefaultModuleCompileStage;
 import org.qbicc.plugin.lowering.LocalVariableFindingBasicBlockBuilder;
 import org.qbicc.plugin.lowering.LocalVariableLoweringBasicBlockBuilder;
 import org.qbicc.plugin.layout.ObjectAccessLoweringBuilder;
@@ -88,6 +89,7 @@ import org.qbicc.plugin.opt.SimpleOptBasicBlockBuilder;
 import org.qbicc.plugin.reachability.RTAInfo;
 import org.qbicc.plugin.reachability.ReachabilityBlockBuilder;
 import org.qbicc.plugin.serialization.ObjectLiteralSerializingVisitor;
+import org.qbicc.plugin.stringpool.StringPoolEmitter;
 import org.qbicc.plugin.threadlocal.ThreadLocalBasicBlockBuilder;
 import org.qbicc.plugin.threadlocal.ThreadLocalTypeBuilder;
 import org.qbicc.plugin.trycatch.LocalThrowHandlingBasicBlockBuilder;
@@ -394,7 +396,9 @@ public class Main implements Callable<DiagnosticContext> {
 
                                 builder.addPostHook(Phase.GENERATE, new DotGenerator(Phase.GENERATE, graphGenConfig));
                                 builder.addPostHook(Phase.GENERATE, new LLVMCompileStage(isPie));
-                                builder.addPostHook(Phase.GENERATE, new MethodDataEmitter(isPie));
+                                builder.addPostHook(Phase.GENERATE, new MethodDataEmitter());
+                                builder.addPostHook(Phase.GENERATE, new StringPoolEmitter());
+                                builder.addPostHook(Phase.GENERATE, new LLVMDefaultModuleCompileStage(isPie));
                                 builder.addPostHook(Phase.GENERATE, new LinkStage(isPie));
 
                                 CompilationContext ctxt;

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -65,6 +65,7 @@ import org.qbicc.plugin.lowering.ThrowLoweringBasicBlockBuilder;
 import org.qbicc.plugin.lowering.VMHelpersSetupHook;
 import org.qbicc.plugin.main_method.AddMainClassHook;
 import org.qbicc.plugin.main_method.MainMethod;
+import org.qbicc.plugin.methodinfo.MethodDataEmitter;
 import org.qbicc.plugin.native_.ConstTypeResolver;
 import org.qbicc.plugin.native_.ConstantDefiningBasicBlockBuilder;
 import org.qbicc.plugin.native_.ExternExportTypeBuilder;
@@ -393,6 +394,7 @@ public class Main implements Callable<DiagnosticContext> {
 
                                 builder.addPostHook(Phase.GENERATE, new DotGenerator(Phase.GENERATE, graphGenConfig));
                                 builder.addPostHook(Phase.GENERATE, new LLVMCompileStage(isPie));
+                                builder.addPostHook(Phase.GENERATE, new MethodDataEmitter(isPie));
                                 builder.addPostHook(Phase.GENERATE, new LinkStage(isPie));
 
                                 CompilationContext ctxt;

--- a/main/src/main/resources/logging.properties
+++ b/main/src/main/resources/logging.properties
@@ -4,7 +4,9 @@ loggers=\
   org.qbicc.plugin.dispatch.tables,\
   org.qbicc.plugin.dispatch.stats,\
   org.qbicc.plugin.instanceofcheckcast.supers,\
-  org.qbicc.plugin.reachability.rta
+  org.qbicc.plugin.methodinfo.stats,\
+  org.qbicc.plugin.reachability.rta,\
+  org.qbicc.plugin.stringpool.stats
 
 # Root logger configuration
 logger.level=INFO
@@ -13,7 +15,9 @@ logger.handlers=CONSOLE
 logger.org.qbicc.plugin.dispatch.tables.level=INFO
 logger.org.qbicc.plugin.dispatch.stats.level=INFO
 logger.org.qbicc.plugin.instanceofcheckcast.supers.level=INFO
+logger.org.qbicc.plugin.methodinfo.stats.level=INFO
 logger.org.qbicc.plugin.reachability.rta.level=INFO
+logger.org.qbicc.plugin.stringpool.stats.level=INFO
 
 
 # A handler configuration

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCallSiteInfo.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCallSiteInfo.java
@@ -1,0 +1,36 @@
+package org.qbicc.plugin.llvm;
+
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.Node;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LLVMCallSiteInfo {
+    // This is a rough estimate based on number of callsites for an app with empty main().
+    // A better way would be to collect this stat during compilation and use it to initialize the list capacity.
+    private static final int INITIAL_LIST_SIZE = 100000;
+    private final ArrayList<Node> nodeList = new ArrayList<>(INITIAL_LIST_SIZE);
+    public static final AttachmentKey<LLVMCallSiteInfo> KEY = new AttachmentKey<>();
+
+    private LLVMCallSiteInfo() {}
+
+    public static LLVMCallSiteInfo get(CompilationContext ctxt) {
+        return ctxt.computeAttachmentIfAbsent(KEY, LLVMCallSiteInfo::new);
+    }
+
+    public void mapStatepointIdToNode(int statepointId, Node node) {
+        synchronized (nodeList) {
+            if (statepointId >= nodeList.size()) {
+                for (int i = nodeList.size(); i <= statepointId; i++) {
+                    nodeList.add(i, null);
+                }
+            }
+            nodeList.set(statepointId, node);
+        }
+    }
+
+    public Node getNodeForStatepointId(int id) { return nodeList.get(id); }
+}

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompileStage.java
@@ -1,102 +1,16 @@
 package org.qbicc.plugin.llvm;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
 import org.qbicc.context.CompilationContext;
-import org.qbicc.context.Location;
-import org.qbicc.driver.Driver;
-import org.qbicc.machine.tool.CCompilerInvoker;
-import org.qbicc.machine.tool.CToolChain;
-import org.qbicc.machine.tool.ToolMessageHandler;
-import org.qbicc.machine.tool.process.InputSource;
-import org.qbicc.machine.tool.process.OutputDestination;
-import org.qbicc.plugin.linker.Linker;
-import org.qbicc.tool.llvm.LlcInvoker;
-import org.qbicc.tool.llvm.LlvmToolChain;
-import org.qbicc.tool.llvm.OptInvoker;
-import org.qbicc.tool.llvm.OptPass;
-import org.qbicc.tool.llvm.OutputFormat;
-import org.qbicc.tool.llvm.RelocationModel;
 
 public class LLVMCompileStage implements Consumer<CompilationContext> {
     private final boolean isPie;
 
     public LLVMCompileStage(final boolean isPie) {
         this.isPie = isPie;
-    }
-
-    public void compileModule(final CompilationContext context, Path modulePath) {
-        LlcInvoker llcInvoker = createLlcInvoker(context);
-        OptInvoker optInvoker = createOptInvoker(context);
-        CCompilerInvoker ccInvoker = createCCompilerInvoker(context);
-
-        if (llcInvoker == null || optInvoker == null || ccInvoker == null) {
-            return;
-        }
-
-        compileModule(context, modulePath, llcInvoker, optInvoker, ccInvoker);
-    }
-
-    private void compileModule(final CompilationContext context, Path modulePath, LlcInvoker llcInvoker, OptInvoker optInvoker, CCompilerInvoker ccInvoker) {
-        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
-        if (cToolChain == null) {
-            context.error("No C tool chain is available");
-            return;
-        }
-
-        String moduleName = modulePath.getFileName().toString();
-        if (moduleName.endsWith(".ll")) {
-            String baseName = moduleName.substring(0, moduleName.length() - 3);
-            String optBitCodeName = baseName + "_opt.bc";
-            String assemblyName = baseName + ".s";
-            String objectName = baseName + "." + cToolChain.getPlatform().getObjectType().objectSuffix();
-
-            Path optBitCodePath = modulePath.resolveSibling(optBitCodeName);
-            Path assemblyPath = modulePath.resolveSibling(assemblyName);
-            Path objectPath = modulePath.resolveSibling(objectName);
-
-            optInvoker.setSource(InputSource.from(modulePath));
-            optInvoker.setDestination(OutputDestination.of(optBitCodePath));
-            int errCnt = context.errors();
-            try {
-                optInvoker.invoke();
-            } catch (IOException e) {
-                if (errCnt == context.errors()) {
-                    // whatever the problem was, it wasn't reported, so add an additional error here
-                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`opt` invocation has failed: %s", e.toString());
-                }
-                return;
-            }
-
-            llcInvoker.setSource(InputSource.from(optBitCodePath));
-            llcInvoker.setDestination(OutputDestination.of(assemblyPath));
-            errCnt = context.errors();
-            try {
-                llcInvoker.invoke();
-            } catch (IOException e) {
-                if (errCnt == context.errors()) {
-                    // whatever the problem was, it wasn't reported, so add an additional error here
-                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`llc` invocation has failed: %s", e.toString());
-                }
-                return;
-            }
-
-            // now compile it
-            ccInvoker.setSource(InputSource.from(assemblyPath));
-            ccInvoker.setOutputPath(objectPath);
-            try {
-                ccInvoker.invoke();
-            } catch (IOException e) {
-                context.error("Compiler invocation has failed for %s: %s", modulePath, e.toString());
-                return;
-            }
-            Linker.get(context).addObjectFilePath(objectPath);
-        } else {
-            context.warning("Ignoring unknown module file name \"%s\"", modulePath);
-        }
     }
 
     public void accept(final CompilationContext context) {
@@ -108,14 +22,7 @@ public class LLVMCompileStage implements Consumer<CompilationContext> {
 
         Iterator<Path> iterator = llvmState.getModulePaths().iterator();
         context.runParallelTask(ctxt -> {
-            LlcInvoker llcInvoker = createLlcInvoker(ctxt);
-            OptInvoker optInvoker = createOptInvoker(ctxt);
-            CCompilerInvoker ccInvoker = createCCompilerInvoker(ctxt);
-
-            if (llcInvoker == null || optInvoker == null || ccInvoker == null) {
-                return;
-            }
-
+            LLVMCompiler compiler = new LLVMCompiler(context, isPie);
             for (;;) {
                 Path modulePath;
                 synchronized (iterator) {
@@ -124,45 +31,8 @@ public class LLVMCompileStage implements Consumer<CompilationContext> {
                     }
                     modulePath = iterator.next();
                 }
-                compileModule(ctxt, modulePath, llcInvoker, optInvoker, ccInvoker);
+                compiler.compileModule(ctxt, modulePath);
             }
         });
-    }
-
-    private CCompilerInvoker createCCompilerInvoker(CompilationContext context) {
-        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
-        if (cToolChain == null) {
-            context.error("No C tool chain is available");
-            return null;
-        }
-        CCompilerInvoker ccInvoker = cToolChain.newCompilerInvoker();
-        ccInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
-        ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.ASM);
-        return ccInvoker;
-    }
-
-    private OptInvoker createOptInvoker(CompilationContext context) {
-        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
-        if (llvmToolChain == null) {
-            context.error("No LLVM tool chain is available");
-            return null;
-        }
-        OptInvoker optInvoker = llvmToolChain.newOptInvoker();
-        optInvoker.addOptimizationPass(OptPass.RewriteStatepointsForGc);
-        optInvoker.addOptimizationPass(OptPass.AlwaysInline);
-        return optInvoker;
-    }
-
-    private LlcInvoker createLlcInvoker(CompilationContext context) {
-        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
-        if (llvmToolChain == null) {
-            context.error("No LLVM tool chain is available");
-            return null;
-        }
-        LlcInvoker llcInvoker = llvmToolChain.newLlcInvoker();
-        llcInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
-        llcInvoker.setOutputFormat(OutputFormat.ASM);
-        llcInvoker.setRelocationModel(isPie ? RelocationModel.Pic : RelocationModel.Static);
-        return llcInvoker;
     }
 }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompiler.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompiler.java
@@ -1,0 +1,124 @@
+package org.qbicc.plugin.llvm;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.context.Location;
+import org.qbicc.driver.Driver;
+import org.qbicc.machine.tool.CCompilerInvoker;
+import org.qbicc.machine.tool.CToolChain;
+import org.qbicc.machine.tool.ToolMessageHandler;
+import org.qbicc.machine.tool.process.InputSource;
+import org.qbicc.machine.tool.process.OutputDestination;
+import org.qbicc.plugin.linker.Linker;
+import org.qbicc.tool.llvm.LlcInvoker;
+import org.qbicc.tool.llvm.LlvmToolChain;
+import org.qbicc.tool.llvm.OptInvoker;
+import org.qbicc.tool.llvm.OptPass;
+import org.qbicc.tool.llvm.OutputFormat;
+import org.qbicc.tool.llvm.RelocationModel;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class LLVMCompiler {
+    private final LlcInvoker llcInvoker;
+    private final OptInvoker optInvoker;
+    private final CCompilerInvoker ccInvoker;
+
+    public LLVMCompiler(CompilationContext context, boolean isPie) {
+        llcInvoker = createLlcInvoker(context, isPie);
+        optInvoker = createOptInvoker(context);
+        ccInvoker = createCCompilerInvoker(context);
+    }
+
+    public void compileModule(final CompilationContext context, Path modulePath) {
+        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
+
+        String moduleName = modulePath.getFileName().toString();
+        if (moduleName.endsWith(".ll")) {
+            String baseName = moduleName.substring(0, moduleName.length() - 3);
+            String optBitCodeName = baseName + "_opt.bc";
+            String assemblyName = baseName + ".s";
+            String objectName = baseName + "." + cToolChain.getPlatform().getObjectType().objectSuffix();
+
+            Path optBitCodePath = modulePath.resolveSibling(optBitCodeName);
+            Path assemblyPath = modulePath.resolveSibling(assemblyName);
+            Path objectPath = modulePath.resolveSibling(objectName);
+
+            optInvoker.setSource(InputSource.from(modulePath));
+            optInvoker.setDestination(OutputDestination.of(optBitCodePath));
+            int errCnt = context.errors();
+            try {
+                optInvoker.invoke();
+            } catch (IOException e) {
+                if (errCnt == context.errors()) {
+                    // whatever the problem was, it wasn't reported, so add an additional error here
+                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`opt` invocation has failed: %s", e.toString());
+                }
+                return;
+            }
+
+            llcInvoker.setSource(InputSource.from(optBitCodePath));
+            llcInvoker.setDestination(OutputDestination.of(assemblyPath));
+            errCnt = context.errors();
+            try {
+                llcInvoker.invoke();
+            } catch (IOException e) {
+                if (errCnt == context.errors()) {
+                    // whatever the problem was, it wasn't reported, so add an additional error here
+                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`llc` invocation has failed: %s", e.toString());
+                }
+                return;
+            }
+
+            // now compile it
+            ccInvoker.setSource(InputSource.from(assemblyPath));
+            ccInvoker.setOutputPath(objectPath);
+            try {
+                ccInvoker.invoke();
+            } catch (IOException e) {
+                context.error("Compiler invocation has failed for %s: %s", modulePath, e.toString());
+                return;
+            }
+            Linker.get(context).addObjectFilePath(objectPath);
+        } else {
+            context.warning("Ignoring unknown module file name \"%s\"", modulePath);
+        }
+    }
+
+    private static CCompilerInvoker createCCompilerInvoker(CompilationContext context) {
+        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
+        if (cToolChain == null) {
+            context.error("No C tool chain is available");
+            return null;
+        }
+        CCompilerInvoker ccInvoker = cToolChain.newCompilerInvoker();
+        ccInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.ASM);
+        return ccInvoker;
+    }
+
+    private static OptInvoker createOptInvoker(CompilationContext context) {
+        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
+        if (llvmToolChain == null) {
+            context.error("No LLVM tool chain is available");
+            return null;
+        }
+        OptInvoker optInvoker = llvmToolChain.newOptInvoker();
+        optInvoker.addOptimizationPass(OptPass.RewriteStatepointsForGc);
+        optInvoker.addOptimizationPass(OptPass.AlwaysInline);
+        return optInvoker;
+    }
+
+    private static LlcInvoker createLlcInvoker(CompilationContext context, boolean isPie) {
+        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
+        if (llvmToolChain == null) {
+            context.error("No LLVM tool chain is available");
+            return null;
+        }
+        LlcInvoker llcInvoker = llvmToolChain.newLlcInvoker();
+        llcInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        llcInvoker.setOutputFormat(OutputFormat.ASM);
+        llcInvoker.setRelocationModel(isPie ? RelocationModel.Pic : RelocationModel.Static);
+        return llcInvoker;
+    }
+}

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
@@ -1,0 +1,22 @@
+package org.qbicc.plugin.llvm;
+
+import org.qbicc.context.CompilationContext;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContext> {
+    private final boolean isPie;
+
+    public LLVMDefaultModuleCompileStage(boolean isPie) {
+        this.isPie = isPie;
+    }
+
+    @Override
+    public void accept(CompilationContext context) {
+        LLVMModuleGenerator generator = new LLVMModuleGenerator(context, isPie ? 2 : 0, isPie ? 2 : 0);
+        Path modulePath = generator.processProgramModule(context.getProgramModule(context.getDefaultTypeDefinition()));
+        LLVMCompiler compiler = new LLVMCompiler(context, isPie);
+        compiler.compileModule(context, modulePath);
+    }
+}

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
@@ -53,152 +53,8 @@ public class LLVMGenerator implements Consumer<CompilationContext>, ValueVisitor
         this.pieLevel = pieLevel;
     }
 
-    public Path processProgramModule(final CompilationContext ctxt, final ProgramModule programModule) {
-        DefinedTypeDefinition def = programModule.getTypeDefinition();
-        Path outputFile = ctxt.getOutputFile(def, "ll");
-        final Module module = Module.newModule();
-        final LLVMModuleNodeVisitor moduleVisitor = new LLVMModuleNodeVisitor(module, ctxt);
-        final LLVMModuleDebugInfo debugInfo = new LLVMModuleDebugInfo(module, ctxt);
-        final LLVMPseudoIntrinsics pseudoIntrinsics = new LLVMPseudoIntrinsics(module);
-
-        if (picLevel != 0) {
-            module.addFlag(ModuleFlagBehavior.Max, "PIC Level", Types.i32, Values.intConstant(picLevel));
-        }
-
-        if (pieLevel != 0) {
-            module.addFlag(ModuleFlagBehavior.Max, "PIE Level", Types.i32, Values.intConstant(pieLevel));
-        }
-
-        // declare debug function here
-        org.qbicc.machine.llvm.Function decl = module.declare("llvm.dbg.addr");
-        decl.returns(Types.void_);
-        decl.param(Types.metadata).param(Types.metadata).param(Types.metadata);
-
-        for (Section section : programModule.sections()) {
-            String sectionName = section.getName();
-            for (ProgramObject item : section.contents()) {
-                String name = item.getName();
-                Linkage linkage = map(item.getLinkage());
-                if (item instanceof Function) {
-                    ExecutableElement element = ((Function) item).getOriginalElement();
-                    MethodBody body = ((Function) item).getBody();
-                    boolean isExact = item == ctxt.getExactFunction(element);
-                    if (body == null) {
-                        ctxt.error("Function `%s` has no body", name);
-                        continue;
-                    }
-                    BasicBlock entryBlock = body.getEntryBlock();
-                    FunctionDefinition functionDefinition = module.define(name).linkage(linkage);
-                    LLValue topSubprogram = null;
-
-                    if (isExact) {
-                        topSubprogram = debugInfo.getDebugInfoForFunction(element).getSubprogram();
-                        functionDefinition.meta("dbg", topSubprogram);
-                    } else {
-                        topSubprogram = debugInfo.createThunkSubprogram((Function) item).asRef();
-                        functionDefinition.meta("dbg", topSubprogram);
-                    }
-                    functionDefinition.attribute(FunctionAttributes.framePointer("non-leaf"));
-                    functionDefinition.attribute(FunctionAttributes.uwtable);
-                    functionDefinition.gc("statepoint-example");
-
-                    LLVMNodeVisitor nodeVisitor = new LLVMNodeVisitor(ctxt, module, debugInfo, pseudoIntrinsics, topSubprogram, moduleVisitor, Schedule.forMethod(entryBlock), ((Function) item), functionDefinition);
-                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
-                        functionDefinition.section(sectionName);
-                    }
-
-                    nodeVisitor.execute();
-                } else if (item instanceof FunctionDeclaration) {
-                    FunctionDeclaration fn = (FunctionDeclaration) item;
-                    decl = module.declare(name).linkage(linkage);
-                    FunctionType fnType = fn.getType();
-                    decl.returns(moduleVisitor.map(fnType.getReturnType()));
-                    int cnt = fnType.getParameterCount();
-                    for (int i = 0; i < cnt; i++) {
-                        ValueType type = fnType.getParameterType(i);
-                        if (type instanceof VariadicType) {
-                            if (i < cnt - 1) {
-                                throw new IllegalStateException("Variadic type as non-final parameter type");
-                            }
-                            decl.variadic();
-                        } else {
-                            decl.param(moduleVisitor.map(type));
-                        }
-                    }
-                } else if (item instanceof DataDeclaration) {
-                    Global obj = module.global(moduleVisitor.map(item.getType())).linkage(Linkage.EXTERNAL);
-                    ThreadLocalMode tlm = item.getThreadLocalMode();
-                    if (tlm != null) {
-                        obj.threadLocal(map(tlm));
-                    }
-                    obj.asGlobal(item.getName());
-                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
-                        obj.section(sectionName);
-                    }
-                    if (item.getAddrspace() != 0) {
-                        obj.addressSpace(item.getAddrspace());
-                    }
-                } else if (item instanceof DataDeclaration) {
-                    Global obj = module.global(moduleVisitor.map(item.getType())).linkage(Linkage.EXTERNAL);
-                    ThreadLocalMode tlm = item.getThreadLocalMode();
-                    if (tlm != null) {
-                        obj.threadLocal(map(tlm));
-                    }
-                    obj.asGlobal(item.getName());
-                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
-                        obj.section(sectionName);
-                    }
-                    if (item.getAddrspace() != 0) {
-                        obj.addressSpace(item.getAddrspace());
-                    }
-                } else {
-                    assert item instanceof Data;
-                    Literal value = (Literal) ((Data) item).getValue();
-                    Global obj = module.global(moduleVisitor.map(item.getType()));
-                    if (value != null) {
-                        obj.value(moduleVisitor.map(value));
-                    } else {
-                        obj.value(Values.zeroinitializer);
-                    }
-                    obj.alignment(item.getType().getAlign());
-                    obj.linkage(linkage);
-                    ThreadLocalMode tlm = item.getThreadLocalMode();
-                    if (tlm != null) {
-                        obj.threadLocal(map(tlm));
-                    }
-                    if (((Data) item).isDsoLocal()) {
-                        obj.preemption(RuntimePreemption.LOCAL);
-                    }
-                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
-                        obj.section(sectionName);
-                    }
-                    if (item.getAddrspace() != 0) {
-                        obj.addressSpace(item.getAddrspace());
-                    }
-                    obj.asGlobal(item.getName());
-                }
-            }
-        }
-        try {
-            Path parent = outputFile.getParent();
-            if (! Files.exists(parent)) {
-                Files.createDirectories(parent);
-            }
-            try (BufferedWriter writer = Files.newBufferedWriter(outputFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
-                module.writeTo(writer);
-            }
-        } catch (IOException e) {
-            ctxt.error("Failed to write \"%s\": %s", outputFile, e.getMessage());
-            try {
-                Files.deleteIfExists(outputFile);
-            } catch (IOException e2) {
-                ctxt.warning("Failed to clean \"%s\": %s", outputFile, e.getMessage());
-            }
-        }
-        return outputFile;
-    }
-
     public void accept(final CompilationContext compilationContext) {
+        LLVMModuleGenerator generator = new LLVMModuleGenerator(compilationContext, picLevel, pieLevel);
         List<ProgramModule> allProgramModules = compilationContext.getAllProgramModules();
         Iterator<ProgramModule> iterator = allProgramModules.iterator();
         compilationContext.runParallelTask(ctxt -> {
@@ -210,31 +66,10 @@ public class LLVMGenerator implements Consumer<CompilationContext>, ValueVisitor
                     }
                     programModule = iterator.next();
                 }
-                Path outputFile = processProgramModule(compilationContext, programModule);
+                Path outputFile = generator.processProgramModule(programModule);
                 LLVMState llvmState = ctxt.computeAttachmentIfAbsent(LLVMState.KEY, LLVMState::new);
                 llvmState.addModulePath(outputFile);
             }
         });
-    }
-
-    Linkage map(org.qbicc.object.Linkage linkage) {
-        switch (linkage) {
-            case COMMON: return Linkage.COMMON;
-            case INTERNAL: return Linkage.INTERNAL;
-            case PRIVATE: return Linkage.PRIVATE;
-            case WEAK: return Linkage.EXTERN_WEAK;
-            case EXTERNAL: return Linkage.EXTERNAL;
-            default: throw Assert.impossibleSwitchCase(linkage);
-        }
-    }
-
-    ThreadLocalStorageModel map(ThreadLocalMode mode) {
-        switch (mode) {
-            case GENERAL_DYNAMIC: return ThreadLocalStorageModel.GENERAL_DYNAMIC;
-            case LOCAL_DYNAMIC: return ThreadLocalStorageModel.LOCAL_DYNAMIC;
-            case INITIAL_EXEC: return ThreadLocalStorageModel.INITIAL_EXEC;
-            case LOCAL_EXEC: return ThreadLocalStorageModel.LOCAL_EXEC;
-            default: throw Assert.impossibleSwitchCase(mode);
-        }
     }
 }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -1,0 +1,216 @@
+package org.qbicc.plugin.llvm;
+
+import io.smallrye.common.constraint.Assert;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.literal.Literal;
+import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.machine.llvm.FunctionAttributes;
+import org.qbicc.machine.llvm.FunctionDefinition;
+import org.qbicc.machine.llvm.Global;
+import org.qbicc.machine.llvm.LLValue;
+import org.qbicc.machine.llvm.Linkage;
+import org.qbicc.machine.llvm.Module;
+import org.qbicc.machine.llvm.ModuleFlagBehavior;
+import org.qbicc.machine.llvm.RuntimePreemption;
+import org.qbicc.machine.llvm.ThreadLocalStorageModel;
+import org.qbicc.machine.llvm.Types;
+import org.qbicc.machine.llvm.Values;
+import org.qbicc.object.Data;
+import org.qbicc.object.DataDeclaration;
+import org.qbicc.object.Function;
+import org.qbicc.object.FunctionDeclaration;
+import org.qbicc.object.ProgramModule;
+import org.qbicc.object.ProgramObject;
+import org.qbicc.object.Section;
+import org.qbicc.object.ThreadLocalMode;
+import org.qbicc.type.FunctionType;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.VariadicType;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+final class LLVMModuleGenerator {
+    private final CompilationContext context;
+    private final int picLevel;
+    private final int pieLevel;
+
+    LLVMModuleGenerator(final CompilationContext context, final int picLevel, final int pieLevel) {
+        this.context = context;
+        this.picLevel = picLevel;
+        this.pieLevel = pieLevel;
+    }
+
+    public Path processProgramModule(final ProgramModule programModule) {
+        DefinedTypeDefinition def = programModule.getTypeDefinition();
+        Path outputFile = context.getOutputFile(def, "ll");
+        final Module module = Module.newModule();
+        final LLVMModuleNodeVisitor moduleVisitor = new LLVMModuleNodeVisitor(module, context);
+        final LLVMModuleDebugInfo debugInfo = new LLVMModuleDebugInfo(module, context);
+        final LLVMPseudoIntrinsics pseudoIntrinsics = new LLVMPseudoIntrinsics(module);
+
+        if (picLevel != 0) {
+            module.addFlag(ModuleFlagBehavior.Max, "PIC Level", Types.i32, Values.intConstant(picLevel));
+        }
+
+        if (pieLevel != 0) {
+            module.addFlag(ModuleFlagBehavior.Max, "PIE Level", Types.i32, Values.intConstant(pieLevel));
+        }
+
+        // declare debug function here
+        org.qbicc.machine.llvm.Function decl = module.declare("llvm.dbg.addr");
+        decl.returns(Types.void_);
+        decl.param(Types.metadata).param(Types.metadata).param(Types.metadata);
+
+        for (Section section : programModule.sections()) {
+            String sectionName = section.getName();
+            for (ProgramObject item : section.contents()) {
+                String name = item.getName();
+                Linkage linkage = map(item.getLinkage());
+                if (item instanceof Function) {
+                    ExecutableElement element = ((Function) item).getOriginalElement();
+                    MethodBody body = ((Function) item).getBody();
+                    boolean isExact = item == context.getExactFunction(element);
+                    if (body == null) {
+                        context.error("Function `%s` has no body", name);
+                        continue;
+                    }
+                    BasicBlock entryBlock = body.getEntryBlock();
+                    FunctionDefinition functionDefinition = module.define(name).linkage(linkage);
+                    LLValue topSubprogram = null;
+
+                    if (isExact) {
+                        topSubprogram = debugInfo.getDebugInfoForFunction(element).getSubprogram();
+                        functionDefinition.meta("dbg", topSubprogram);
+                    } else {
+                        topSubprogram = debugInfo.createThunkSubprogram((Function) item).asRef();
+                        functionDefinition.meta("dbg", topSubprogram);
+                    }
+                    functionDefinition.attribute(FunctionAttributes.framePointer("non-leaf"));
+                    functionDefinition.attribute(FunctionAttributes.uwtable);
+                    functionDefinition.gc("statepoint-example");
+
+                    LLVMNodeVisitor nodeVisitor = new LLVMNodeVisitor(context, module, debugInfo, pseudoIntrinsics, topSubprogram, moduleVisitor, Schedule.forMethod(entryBlock), ((Function) item), functionDefinition);
+                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
+                        functionDefinition.section(sectionName);
+                    }
+
+                    nodeVisitor.execute();
+                } else if (item instanceof FunctionDeclaration) {
+                    FunctionDeclaration fn = (FunctionDeclaration) item;
+                    decl = module.declare(name).linkage(linkage);
+                    FunctionType fnType = fn.getType();
+                    decl.returns(moduleVisitor.map(fnType.getReturnType()));
+                    int cnt = fnType.getParameterCount();
+                    for (int i = 0; i < cnt; i++) {
+                        ValueType type = fnType.getParameterType(i);
+                        if (type instanceof VariadicType) {
+                            if (i < cnt - 1) {
+                                throw new IllegalStateException("Variadic type as non-final parameter type");
+                            }
+                            decl.variadic();
+                        } else {
+                            decl.param(moduleVisitor.map(type));
+                        }
+                    }
+                } else if (item instanceof DataDeclaration) {
+                    Global obj = module.global(moduleVisitor.map(item.getType())).linkage(Linkage.EXTERNAL);
+                    ThreadLocalMode tlm = item.getThreadLocalMode();
+                    if (tlm != null) {
+                        obj.threadLocal(map(tlm));
+                    }
+                    obj.asGlobal(item.getName());
+                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
+                        obj.section(sectionName);
+                    }
+                    if (item.getAddrspace() != 0) {
+                        obj.addressSpace(item.getAddrspace());
+                    }
+                } else if (item instanceof DataDeclaration) {
+                    Global obj = module.global(moduleVisitor.map(item.getType())).linkage(Linkage.EXTERNAL);
+                    ThreadLocalMode tlm = item.getThreadLocalMode();
+                    if (tlm != null) {
+                        obj.threadLocal(map(tlm));
+                    }
+                    obj.asGlobal(item.getName());
+                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
+                        obj.section(sectionName);
+                    }
+                    if (item.getAddrspace() != 0) {
+                        obj.addressSpace(item.getAddrspace());
+                    }
+                } else {
+                    assert item instanceof Data;
+                    Literal value = (Literal) ((Data) item).getValue();
+                    Global obj = module.global(moduleVisitor.map(item.getType()));
+                    if (value != null) {
+                        obj.value(moduleVisitor.map(value));
+                    } else {
+                        obj.value(Values.zeroinitializer);
+                    }
+                    obj.alignment(item.getType().getAlign());
+                    obj.linkage(linkage);
+                    ThreadLocalMode tlm = item.getThreadLocalMode();
+                    if (tlm != null) {
+                        obj.threadLocal(map(tlm));
+                    }
+                    if (((Data) item).isDsoLocal()) {
+                        obj.preemption(RuntimePreemption.LOCAL);
+                    }
+                    if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
+                        obj.section(sectionName);
+                    }
+                    if (item.getAddrspace() != 0) {
+                        obj.addressSpace(item.getAddrspace());
+                    }
+                    obj.asGlobal(item.getName());
+                }
+            }
+        }
+        try {
+            Path parent = outputFile.getParent();
+            if (! Files.exists(parent)) {
+                Files.createDirectories(parent);
+            }
+            try (BufferedWriter writer = Files.newBufferedWriter(outputFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+                module.writeTo(writer);
+            }
+        } catch (IOException e) {
+            context.error("Failed to write \"%s\": %s", outputFile, e.getMessage());
+            try {
+                Files.deleteIfExists(outputFile);
+            } catch (IOException e2) {
+                context.warning("Failed to clean \"%s\": %s", outputFile, e.getMessage());
+            }
+        }
+        return outputFile;
+    }
+
+    Linkage map(org.qbicc.object.Linkage linkage) {
+        switch (linkage) {
+            case COMMON: return Linkage.COMMON;
+            case INTERNAL: return Linkage.INTERNAL;
+            case PRIVATE: return Linkage.PRIVATE;
+            case WEAK: return Linkage.EXTERN_WEAK;
+            case EXTERNAL: return Linkage.EXTERNAL;
+            default: throw Assert.impossibleSwitchCase(linkage);
+        }
+    }
+
+    ThreadLocalStorageModel map(ThreadLocalMode mode) {
+        switch (mode) {
+            case GENERAL_DYNAMIC: return ThreadLocalStorageModel.GENERAL_DYNAMIC;
+            case LOCAL_DYNAMIC: return ThreadLocalStorageModel.LOCAL_DYNAMIC;
+            case INITIAL_EXEC: return ThreadLocalStorageModel.INITIAL_EXEC;
+            case LOCAL_EXEC: return ThreadLocalStorageModel.LOCAL_EXEC;
+            default: throw Assert.impossibleSwitchCase(mode);
+        }
+    }
+}

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -20,6 +20,7 @@ import org.qbicc.graph.literal.BitCastLiteral;
 import org.qbicc.graph.literal.BooleanLiteral;
 import org.qbicc.graph.literal.ByteArrayLiteral;
 import org.qbicc.graph.literal.CompoundLiteral;
+import org.qbicc.graph.literal.ElementOfLiteral;
 import org.qbicc.graph.literal.FloatLiteral;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.Literal;
@@ -311,6 +312,11 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue> {
             struct.item(array((int) (size - offs), i8), zeroinitializer);
         }
         return struct;
+    }
+
+    public LLValue visit(final Void param, final ElementOfLiteral node) {
+        PointerType pointerType = (PointerType) node.getType();
+        return Values.gepConstant(map(pointerType.getPointeeType()), map(pointerType), map(node.getValue()), map(node.getIndex().getType()), map(node.getIndex()));
     }
 
     public LLValue visit(final Void param, final FloatLiteral node) {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -847,7 +847,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail();
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
+        addStatepointId(call, node);
         return call.asLocal();
     }
 
@@ -864,7 +864,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail();
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
+        addStatepointId(call, node);
         return call.asLocal();
     }
 
@@ -882,7 +882,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail().attribute(FunctionAttributes.noreturn);
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
+        addStatepointId(call, node);
         builder.unreachable();
         return call;
     }
@@ -901,7 +901,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).tail(); // hint only
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
+        addStatepointId(call, node);
         ValueType returnType = node.getFunctionType().getReturnType();
         if (returnType instanceof VoidType) {
             return builder.ret();
@@ -945,6 +945,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
         addPersonalityIfNeeded();
+        addStatepointId(call, node);
         return call;
     }
 
@@ -972,6 +973,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
         addPersonalityIfNeeded();
+        addStatepointId(call, node);
         return call;
     }
 
@@ -1004,6 +1006,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
             LLVM.newBuilder(tailTarget).ret(map(returnType), call.asLocal());
         }
         addPersonalityIfNeeded();
+        addStatepointId(call, node);
         return call;
     }
 
@@ -1069,6 +1072,12 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
             func.personality(map(literal), map(literal.getType()));
             personalityAdded = true;
         }
+    }
+
+    private void addStatepointId(Call call, Node node) {
+        int statepointId = LLVM.getNextStatepointId();
+        call.attribute(FunctionAttributes.statepointId(statepointId));
+        LLVMCallSiteInfo.get(ctxt).mapStatepointIdToNode(statepointId, node);
     }
 
     // GEP

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -847,6 +847,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail();
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
+        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
         return call.asLocal();
     }
 
@@ -863,6 +864,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail();
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
+        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
         return call.asLocal();
     }
 
@@ -880,6 +882,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail().attribute(FunctionAttributes.noreturn);
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
+        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
         builder.unreachable();
         return call;
     }
@@ -898,6 +901,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).tail(); // hint only
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
+        call.attribute(FunctionAttributes.statepointId(LLVM.getNextStatepointId()));
         ValueType returnType = node.getFunctionType().getReturnType();
         if (returnType instanceof VoidType) {
             return builder.ret();

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMState.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMState.java
@@ -14,6 +14,7 @@ final class LLVMState {
     static final AttachmentKey<LLVMState> KEY = new AttachmentKey<>();
 
     private final List<Path> modulePaths = Collections.synchronizedList(new ArrayList<>());
+    private Path defaultModulePath;
 
     LLVMState() {}
 
@@ -21,9 +22,15 @@ final class LLVMState {
         modulePaths.add(path);
     }
 
+    void setDefaultModulePath(Path path) { defaultModulePath = path; }
+
     List<Path> getModulePaths() {
         synchronized (modulePaths) {
             return List.copyOf(modulePaths);
         }
+    }
+
+    Path getDefaultModulePath() {
+        return defaultModulePath;
     }
 }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMState.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMState.java
@@ -26,5 +26,4 @@ final class LLVMState {
             return List.copyOf(modulePaths);
         }
     }
-
 }

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -69,6 +69,7 @@ public class Lowering {
         if (appearing != null) {
             return appearing;
         }
+
         Section section = ctxt.getOrAddProgramModule(enclosingType).getOrAddSection(sectionName);
         Value initialValue = fieldElement.getInitialValue();
         Linkage linkage = Linkage.EXTERNAL;

--- a/plugins/methodinfo/pom.xml
+++ b/plugins/methodinfo/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>qbicc-plugin-parent</artifactId>
+        <groupId>org.qbicc</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>qbicc-plugin-methodinfo</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-linker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-llvm</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/InstructionMap.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/InstructionMap.java
@@ -1,0 +1,26 @@
+package org.qbicc.plugin.methodinfo;
+
+import org.qbicc.type.definition.element.ExecutableElement;
+
+final class InstructionMap {
+    private int offset;
+    private int sourceCodeIndex;
+    private ExecutableElement function;
+
+    InstructionMap(int offset, int sourceCodeIndex, ExecutableElement element) {
+        this.offset = offset;
+        this.sourceCodeIndex = sourceCodeIndex;
+        this.function = element;
+    }
+    public int getOffset() {
+        return offset;
+    }
+
+    public int getSourceCodeIndex() {
+        return sourceCodeIndex;
+    }
+
+    public ExecutableElement getFunction() {
+        return function;
+    }
+}

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodData.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodData.java
@@ -8,10 +8,6 @@ import java.util.Map;
 import java.util.Set;
 
 final class MethodData {
-    private final IndexableSet<String> fileNameSet = new IndexableSet<>();
-    private final IndexableSet<String> classNameSet = new IndexableSet<>();
-    private final IndexableSet<String> methodNameSet = new IndexableSet<>();
-    private final IndexableSet<String> methodDescSet = new IndexableSet<>();
     private final IndexableSet<MethodInfo> methodInfoSet = new IndexableSet<>();
     private final IndexableSet<SourceCodeInfo> sourceCodeInfoSet = new IndexableSet<>();
     private InstructionMap[] instructionMapList;
@@ -45,30 +41,6 @@ final class MethodData {
         System.arraycopy(instructionMapList, 0, map, 0, map.length);
         return map;
     }
-
-    int addFileName(String fileName) {
-        return fileNameSet.addIfAbsent(fileName);
-    }
-
-    String[] getFileNameList() { return fileNameSet.toArray(new String[0]); }
-
-    int addClassName(String className) {
-        return classNameSet.addIfAbsent(className);
-    }
-
-    String[] getClassNameList() { return classNameSet.toArray(new String[0]); }
-
-    int addMethodName(String methodName) {
-        return methodNameSet.addIfAbsent(methodName);
-    }
-
-    String[] getMethodNameList() { return methodNameSet.toArray(new String[0]); }
-
-    int addMethodDesc(String methodDesc) {
-        return methodDescSet.addIfAbsent(methodDesc);
-    }
-
-    String[] getMethodDescList() { return methodDescSet.toArray(new String[0]); }
 
     /**
      * A set implementation that allows to retrieve index of the items in the order they are added to the set.

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodData.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodData.java
@@ -1,0 +1,162 @@
+package org.qbicc.plugin.methodinfo;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+final class MethodData {
+    private final IndexableSet<String> fileNameSet = new IndexableSet<>();
+    private final IndexableSet<String> classNameSet = new IndexableSet<>();
+    private final IndexableSet<String> methodNameSet = new IndexableSet<>();
+    private final IndexableSet<String> methodDescSet = new IndexableSet<>();
+    private final IndexableSet<MethodInfo> methodInfoSet = new IndexableSet<>();
+    private final IndexableSet<SourceCodeInfo> sourceCodeInfoSet = new IndexableSet<>();
+    private InstructionMap[] instructionMapList;
+
+    MethodData(int instructionsCount) {
+        this.instructionMapList = new InstructionMap[instructionsCount];
+    }
+
+    int add(SourceCodeInfo sourceCodeInfo) {
+        return sourceCodeInfoSet.addIfAbsent(sourceCodeInfo);
+    }
+
+    int add(MethodInfo methodInfo) {
+        return methodInfoSet.addIfAbsent(methodInfo);
+    }
+
+    void add(int index, InstructionMap instructionMap) {
+        instructionMapList[index] = instructionMap;
+    }
+
+    MethodInfo[] getMethodInfoTable() {
+        return methodInfoSet.toArray(new MethodInfo[0]);
+    }
+
+    SourceCodeInfo[] getSourceCodeInfoTable() {
+        return sourceCodeInfoSet.toArray(new SourceCodeInfo[0]);
+    }
+
+    InstructionMap[] getInstructionMapList() {
+        InstructionMap[] map = new InstructionMap[instructionMapList.length];
+        System.arraycopy(instructionMapList, 0, map, 0, map.length);
+        return map;
+    }
+
+    int addFileName(String fileName) {
+        return fileNameSet.addIfAbsent(fileName);
+    }
+
+    String[] getFileNameList() { return fileNameSet.toArray(new String[0]); }
+
+    int addClassName(String className) {
+        return classNameSet.addIfAbsent(className);
+    }
+
+    String[] getClassNameList() { return classNameSet.toArray(new String[0]); }
+
+    int addMethodName(String methodName) {
+        return methodNameSet.addIfAbsent(methodName);
+    }
+
+    String[] getMethodNameList() { return methodNameSet.toArray(new String[0]); }
+
+    int addMethodDesc(String methodDesc) {
+        return methodDescSet.addIfAbsent(methodDesc);
+    }
+
+    String[] getMethodDescList() { return methodDescSet.toArray(new String[0]); }
+
+    /**
+     * A set implementation that allows to retrieve index of the items in the order they are added to the set.
+     * Note that user should synchronize on the set when traversing it via Iterator.
+     * @param <T>
+     */
+    private static final class IndexableSet<T> extends AbstractSet<T> implements Set<T> {
+        final Map<T, Integer> map;
+        int lastIndex;
+
+        IndexableSet() {
+            map = new LinkedHashMap<>();
+            lastIndex = -1;
+        }
+
+        @Override
+        public synchronized int size() {
+            return map.size();
+        }
+
+        @Override
+        public synchronized boolean isEmpty() {
+            return lastIndex == -1;
+        }
+
+        @Override
+        public synchronized Iterator iterator() {
+            return map.keySet().iterator();
+        }
+
+        @Override
+        public synchronized Object[] toArray() {
+            return map.keySet().toArray();
+        }
+
+        @Override
+        public synchronized <T> T[] toArray(T[] t) {
+            return super.toArray(t);
+        }
+
+        @Override
+        public synchronized boolean contains(Object o) {
+            return super.contains(o);
+        }
+
+        @Override
+        public synchronized boolean containsAll(Collection<?> c) {
+            return super.containsAll(c);
+        }
+
+        @Override
+        public synchronized boolean add(T t) {
+            if (map.containsKey(t)) {
+                return false;
+            } else {
+                map.put(t, lastIndex++);
+            }
+            return true;
+        }
+
+        public synchronized int addIfAbsent(T t) {
+            return map.computeIfAbsent(t, k -> ++lastIndex);
+        }
+
+        @Override
+        public boolean remove(Object obj) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public synchronized void clear() {
+            map.clear();
+            lastIndex = 0;
+        }
+
+        @Override
+        public synchronized String toString() {
+            return super.toString();
+        }
+    }
+}

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -286,8 +286,8 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
     }
 
     private void compileMethodDataModule(CompilationContext context, Path modulePath) {
-        LLVMCompileStage compileStage = new LLVMCompileStage(isPie);
-        compileStage.compileModule(context, modulePath);
+        LLVMCompiler compiler = new LLVMCompiler(context, isPie);
+        compiler.compileModule(context, modulePath);
     }
 
     @Override

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -1,0 +1,399 @@
+package org.qbicc.plugin.methodinfo;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.driver.Driver;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.literal.ArrayLiteral;
+import org.qbicc.graph.literal.Literal;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.graph.literal.SymbolLiteral;
+import org.qbicc.machine.llvm.stackmap.StackMap;
+import org.qbicc.machine.llvm.stackmap.StackMapVisitor;
+import org.qbicc.machine.object.ObjectFile;
+import org.qbicc.machine.object.ObjectFileProvider;
+import org.qbicc.object.Function;
+import org.qbicc.object.ProgramModule;
+import org.qbicc.object.Section;
+import org.qbicc.plugin.linker.Linker;
+import org.qbicc.plugin.llvm.LLVMCallSiteInfo;
+import org.qbicc.plugin.llvm.LLVMCompiler;
+import org.qbicc.plugin.llvm.LLVMGenerator;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.TypeSystem;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.element.ConstructorElement;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.FunctionElement;
+import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.definition.element.InitializerElement;
+import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.generic.BaseTypeSignature;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+public class MethodDataEmitter implements Consumer<CompilationContext> {
+    private final boolean isPie;
+    private final AtomicInteger stringIndex = new AtomicInteger();
+
+    private int createMethodInfo(MethodData methodData, ExecutableElement element) {
+        String methodName = "";
+        if (element instanceof ConstructorElement) {
+            methodName = "<init>";
+        } else if (element instanceof InitializerElement) {
+            methodName = "<clinit>";
+        } else if (element instanceof MethodElement) {
+            methodName = ((MethodElement)element).getName();
+        } else if (element instanceof FunctionElement) {
+            methodName = ((FunctionElement)element).getName();
+        }
+        String fileName = element.getSourceFileName();
+        String className = element.getEnclosingType().getInternalName();
+        String methodDesc = element.getDescriptor().toString();
+        int fileNameIndex = fileName != null ? methodData.addFileName(fileName) : -1;
+        int classNameIndex = className != null ? methodData.addClassName(className) : -1;
+        int methodNameIndex = methodName != null ? methodData.addMethodName(methodName) : -1;
+        int methodDescIndex = methodDesc != null ? methodData.addMethodDesc(methodDesc) : -1;
+        return methodData.add(new MethodInfo(fileNameIndex, classNameIndex, methodNameIndex, methodDescIndex));
+    }
+
+    private int createSourceCodeInfo(MethodData methodData, ExecutableElement element, int lineNumber, int bcIndex, int inlinedAtIndex) {
+        int minfoIndex = createMethodInfo(methodData, element);
+        return methodData.add(new SourceCodeInfo(minfoIndex, lineNumber, bcIndex, inlinedAtIndex));
+    }
+
+    private int createSourceCodeInfo(MethodData methodData, Node node) {
+        int sourceCodeIndex;
+        ExecutableElement element = node.getElement();
+        if (node.getCallSite() == null) {
+            sourceCodeIndex = createSourceCodeInfo(methodData, element, node.getSourceLine(), node.getBytecodeIndex(), -1);
+        } else {
+            int callerIndex = createSourceCodeInfo(methodData, node.getCallSite());
+            sourceCodeIndex = createSourceCodeInfo(methodData, element, node.getSourceLine(), node.getBytecodeIndex(), callerIndex);
+        }
+        return sourceCodeIndex;
+    }
+
+    /**
+     * Returns root method of the sequence of inlined methods starting from the
+     * method which contains {@code node}.
+     *
+     * @param node
+     * @return root method of the inlined method sequence
+     */
+    private ExecutableElement getRootMethodOfInlineSequence(Node node) {
+        if (node.getCallSite() == null) {
+            return node.getElement();
+        } else {
+            return getRootMethodOfInlineSequence(node.getCallSite());
+        }
+    }
+
+    public MethodData createMethodData(CompilationContext ctxt) {
+        List<StackMapRecord> stackMapRecords = new StackMapRecordCollector(ctxt).collect();
+        LLVMCallSiteInfo callSiteInfo = ctxt.getAttachment(LLVMCallSiteInfo.KEY);
+        MethodData methodData = new MethodData(stackMapRecords.size());
+        Iterator<StackMapRecord> recordIterator = stackMapRecords.iterator();
+        final int[] recordIndex = { 0 };
+
+        ctxt.runParallelTask(context -> {
+            StackMapRecord record;
+            int index;
+            for (;;) {
+                synchronized (recordIterator) {
+                    if (!recordIterator.hasNext()) {
+                        return;
+                    }
+                    record = recordIterator.next();
+                    index = recordIndex[0];
+                    recordIndex[0] += 1;
+                }
+
+                long spId = record.getStatepoindId();
+                int instructionOffset = record.getOffset();
+                Node node = callSiteInfo.getNodeForStatepointId((int)spId);
+                int scIndex = createSourceCodeInfo(methodData, node);
+                methodData.add(index, new InstructionMap(instructionOffset, scIndex, getRootMethodOfInlineSequence(node)));
+            }
+        });
+
+        return methodData;
+    }
+
+    Literal emitStringTable(CompilationContext ctxt, String[] strings) {
+        TypeSystem ts = ctxt.getTypeSystem();
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        Section section = ctxt.getImplicitSection(ctxt.getDefaultTypeDefinition());
+
+        // strings are represented using a compound type consisting of length and a pointer to character data
+        CompoundType stringType = CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc-md-string")
+            .setOverallAlignment(ts.getUnsignedInteger32Type().getAlign())
+            .addNextMember("len", ts.getUnsignedInteger32Type())
+            .addNextMember("data", ts.getUnsignedInteger8Type().getPointer())
+            .build();
+
+        Literal[] literals = Arrays.stream(strings)
+            .parallel()
+            .map(str -> {
+                // create a literal for the array of characters
+                byte[] chars = str.getBytes();
+                Literal literal = lf.literalOf(ts.getArrayType(ts.getUnsignedInteger8Type(), chars.length), chars);
+                SymbolLiteral symbol = lf.literalOfSymbol(".qbicc-md-string-data-" + stringIndex.getAndIncrement(), literal.getType().getPointer());
+                section.addData(null, symbol.getName(), literal);
+                Literal ptrLiteral = lf.bitcastLiteral(symbol, ts.getUnsignedInteger8Type().getPointer());
+
+                // now create a literal for the string consisting of length and the pointer to char array
+                HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
+                valueMap.put(stringType.getMember(0), lf.literalOf(chars.length));
+                valueMap.put(stringType.getMember(1), ptrLiteral);
+                return lf.literalOf(stringType, valueMap);
+            }).toArray(Literal[]::new);
+
+        return lf.literalOf(ts.getArrayType(literals[0].getType(), literals.length), List.of(literals));
+    }
+
+    Literal emitMethodInfoTable(CompilationContext ctxt, MethodInfo[] minfoList) {
+        TypeSystem ts = ctxt.getTypeSystem();
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        ValueType uint32Type = ts.getUnsignedInteger32Type();
+        CompoundType methodInfoType = CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc_method_info")
+            .setOverallAlignment(uint32Type.getAlign())
+            .addNextMember("fileNameIndex", uint32Type)
+            .addNextMember("classNameIndex", uint32Type)
+            .addNextMember("methodNameIndex", uint32Type)
+            .addNextMember("methodDescIndex", uint32Type)
+            .build();
+
+        Literal[] minfoLiterals = Arrays.stream(minfoList).parallel().map(minfo -> {
+                HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
+                valueMap.put(methodInfoType.getMember(0), lf.literalOf(minfo.getFileNameIndex()));
+                valueMap.put(methodInfoType.getMember(1), lf.literalOf(minfo.getClassNameIndex()));
+                valueMap.put(methodInfoType.getMember(2), lf.literalOf(minfo.getMethodNameIndex()));
+                valueMap.put(methodInfoType.getMember(3), lf.literalOf(minfo.getMethodDescIndex()));
+                return lf.literalOf(methodInfoType, valueMap);
+        }).toArray(Literal[]::new);
+
+        return lf.literalOf(ts.getArrayType(methodInfoType, minfoLiterals.length), List.of(minfoLiterals));
+    }
+
+    Literal emitSourceCodeInfoTable(CompilationContext ctxt, SourceCodeInfo[] scList) {
+        TypeSystem ts = ctxt.getTypeSystem();
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        ValueType uint32Type = ts.getUnsignedInteger32Type();
+        CompoundType sourceCodeInfoType = CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc_souce_code_info")
+            .setOverallAlignment(uint32Type.getAlign())
+            .addNextMember("methodInfoIndex", uint32Type)
+            .addNextMember("lineNumber", uint32Type)
+            .addNextMember("bcIndex", uint32Type)
+            .addNextMember("inlinedAtIndex", uint32Type)
+            .build();
+
+        Literal[] scInfoLiterals = Arrays.stream(scList).parallel().map(scInfo -> {
+            HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
+            valueMap.put(sourceCodeInfoType.getMember(0), lf.literalOf(scInfo.getMethodInfoIndex()));
+            valueMap.put(sourceCodeInfoType.getMember(1), lf.literalOf(scInfo.getLineNumber()));
+            valueMap.put(sourceCodeInfoType.getMember(2), lf.literalOf(scInfo.getBcIndex()));
+            valueMap.put(sourceCodeInfoType.getMember(3), lf.literalOf(scInfo.getInlinedAtIndex()));
+            return lf.literalOf(sourceCodeInfoType, valueMap);
+        }).toArray(Literal[]::new);
+
+        return lf.literalOf(ts.getArrayType(sourceCodeInfoType, scInfoLiterals.length), List.of(scInfoLiterals));
+    }
+
+    Literal emitInstructionMap(CompilationContext ctxt, InstructionMap[] imapList) {
+        TypeSystem ts = ctxt.getTypeSystem();
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        Section section = ctxt.getImplicitSection(ctxt.getDefaultTypeDefinition());
+        ValueType uint64Type = ts.getUnsignedInteger64Type();
+        ValueType uint32Type = ts.getUnsignedInteger32Type();
+
+        CompoundType imapType = CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc_instruction_map")
+            .setOverallAlignment(uint64Type.getAlign())
+            .addNextMember("instructionAddress", uint64Type)
+            .addNextMember("sourceCodeIndex", uint32Type)
+            .build();
+
+        Literal[] imapLiterals = IntStream.range(0, imapList.length)
+            .parallel()
+            .mapToObj(i -> {
+            HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
+            Function function = ctxt.getExactFunction(imapList[i].getFunction());
+            Literal functionCastLiteral = lf.bitcastLiteral(lf.literalOfSymbol(function.getName(), function.getType().getPointer()), ts.getUnsignedInteger8Type().getPointer());
+            Literal instructionAddrLiteral = lf.valueConvertLiteral(lf.elementOfLiteral(functionCastLiteral, lf.literalOf(imapList[i].getOffset())), ts.getUnsignedInteger64Type());
+            valueMap.put(imapType.getMember(0), instructionAddrLiteral);
+            valueMap.put(imapType.getMember(1), lf.literalOf(imapList[i].getSourceCodeIndex()));
+            section.declareFunction(null, function.getName(), function.getType());
+            return lf.literalOf(imapType, valueMap);
+        }).toArray(Literal[]::new);
+
+        return lf.literalOf(ts.getArrayType(imapType, imapLiterals.length), List.of(imapLiterals));
+    }
+
+    private void emitGlobalVariable(CompilationContext ctxt, String variableName, Literal value) {
+        Section section = ctxt.getImplicitSection(ctxt.getDefaultTypeDefinition());
+        section.addData(null, variableName, value);
+    }
+
+    public Path emitMethodData(CompilationContext ctxt, MethodData methodData) {
+        ArrayLiteral value;
+
+        value = (ArrayLiteral) emitStringTable(ctxt, methodData.getFileNameList());
+        emitGlobalVariable(ctxt, "qbicc_filename_table", value);
+
+        value = (ArrayLiteral) emitStringTable(ctxt, methodData.getClassNameList());
+        emitGlobalVariable(ctxt, "qbicc_classname_table", value);
+
+        value = (ArrayLiteral) emitStringTable(ctxt, methodData.getMethodNameList());
+        emitGlobalVariable(ctxt, "qbicc_methodname_table", value);
+
+        value = (ArrayLiteral) emitStringTable(ctxt, methodData.getMethodDescList());
+        emitGlobalVariable(ctxt, "qbicc_methoddesc_table", value);
+
+        value = (ArrayLiteral) emitMethodInfoTable(ctxt, methodData.getMethodInfoTable());
+        emitGlobalVariable(ctxt, "qbicc_method_info_table", value);
+
+        value = (ArrayLiteral) emitSourceCodeInfoTable(ctxt, methodData.getSourceCodeInfoTable());
+        emitGlobalVariable(ctxt, "qbicc_source_code_info_table", value);
+
+        value = (ArrayLiteral) emitInstructionMap(ctxt, methodData.getInstructionMapList());
+        emitGlobalVariable(ctxt, "qbicc_instruction_map_table", value);
+
+        ProgramModule programModule = ctxt.getProgramModule(ctxt.getDefaultTypeDefinition());
+        return new LLVMGenerator(isPie ? 2 : 0, isPie ? 2 : 0).processProgramModule(ctxt, programModule);
+    }
+
+    public MethodDataEmitter(boolean isPie) {
+        this.isPie = isPie;
+    }
+
+    private void compileMethodDataModule(CompilationContext context, Path modulePath) {
+        LLVMCompileStage compileStage = new LLVMCompileStage(isPie);
+        compileStage.compileModule(context, modulePath);
+    }
+
+    @Override
+    public void accept(CompilationContext context) {
+        MethodData methodData = createMethodData(context);
+        Path modulePath = emitMethodData(context, methodData);
+        if (modulePath != null) {
+            compileMethodDataModule(context, modulePath);
+        }
+    }
+
+    private static class StackMapRecord implements Comparable {
+        private final int objectFileIndex;
+        private final int offset;
+        private final long statepoindId;
+
+        StackMapRecord(final int objectFileIndex, final int offset, final long statepoindId) {
+            this.objectFileIndex = objectFileIndex;
+            this.offset = offset;
+            this.statepoindId = statepoindId;
+        }
+
+        long getStatepoindId() { return statepoindId; }
+        int getOffset() { return offset; }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(objectFileIndex, statepoindId, offset);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            return equals((StackMapRecord)o);
+        }
+
+        public boolean equals(StackMapRecord record) {
+            return objectFileIndex == record.objectFileIndex
+                && offset == record.offset;
+        }
+
+        @Override
+        public int compareTo(Object o) {
+            StackMapRecord other = (StackMapRecord) o;
+            if (equals(other)) {
+                return 0;
+            }
+            if (objectFileIndex < other.objectFileIndex) {
+                return -1;
+            } else if (objectFileIndex > other.objectFileIndex) {
+                return 1;
+            } else if (offset < other.offset) { // if same objectFileIndex then order by offset
+                return -1;
+            } else {
+                return 1;
+            }
+        }
+    }
+
+    private final class StackMapRecordCollector {
+        CompilationContext context;
+        StackMapRecordCollector(CompilationContext context) {
+            this.context = context;
+        }
+
+        public List<StackMapRecord> collect() {
+            Linker linker = Linker.get(context);
+            List<StackMapRecord> recordList = new ArrayList<>();
+            ObjectFileProvider objFileProvider = context.getAttachment(Driver.OBJ_PROVIDER_TOOL_KEY);
+            Iterator<Path> objFileIterator = linker.getObjectFilePaths().iterator();
+            final Integer[] index = { 0 };
+
+            context.runParallelTask(ctxt -> {
+                Path objFile;
+                for (;;) {
+                    Integer objFileIndex;
+                    synchronized (objFileIterator) {
+                        if (!objFileIterator.hasNext()) {
+                            return;
+                        }
+                        objFile = objFileIterator.next();
+                        objFileIndex = index[0];
+                        index[0] += 1;
+                    }
+                    try (ObjectFile objectFile = objFileProvider.openObjectFile(objFile)) {
+                        org.qbicc.machine.object.Section stackMapSection = objectFile.getSection(".llvm_stackmaps");
+                        if (stackMapSection != null) {
+                            ByteBuffer stackMapData = stackMapSection.getSectionContent();
+                            StackMap.parse(stackMapData, new StackMapVisitor() {
+                                public void startRecord(long recIndex, long patchPointId, long offset, int locCnt, int liveOutCnt) {
+                                    synchronized (recordList) {
+                                        recordList.add(new StackMapRecord(objFileIndex, (int) offset, patchPointId));
+                                    }
+                                }
+                            });
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+            // sort the list based on the object file index and the instruction offset
+            recordList.sort(StackMapRecord::compareTo);
+            return recordList;
+        }
+    }
+}

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
@@ -1,50 +1,52 @@
 package org.qbicc.plugin.methodinfo;
 
-final class MethodInfo {
-    private int fileNameIndex;
-    private int classNameIndex;
-    private int methodNameIndex;
-    private int methodDescIndex;
+import org.qbicc.plugin.stringpool.StringId;
 
-    MethodInfo(int fileIndex, int classIndex, int methodIndex, int methodDescIndex) {
-        this.fileNameIndex = fileIndex;
-        this.classNameIndex = classIndex;
-        this.methodNameIndex = methodIndex;
-        this.methodDescIndex = methodDescIndex;
+final class MethodInfo {
+    private StringId fileNameStringId;
+    private StringId classNameStringId;
+    private StringId methodNameStringId;
+    private StringId methodDescStringId;
+
+    MethodInfo(StringId fileStringId, StringId classStringId, StringId methodStringId, StringId methodDescStringId) {
+        this.fileNameStringId = fileStringId;
+        this.classNameStringId = classStringId;
+        this.methodNameStringId = methodStringId;
+        this.methodDescStringId = methodDescStringId;
     }
 
     public boolean equals(Object other) {
         if (this == other) return true;
         if (other == null || getClass() != other.getClass()) return false;
         MethodInfo that = (MethodInfo) other;
-        return fileNameIndex == that.fileNameIndex
-            && classNameIndex == that.classNameIndex
-            && methodNameIndex == that.methodNameIndex
-            && methodDescIndex == that.methodDescIndex;
+        return fileNameStringId == that.fileNameStringId
+            && classNameStringId == that.classNameStringId
+            && methodNameStringId == that.methodNameStringId
+            && methodDescStringId == that.methodDescStringId;
     }
 
-    int getFileNameIndex() {
-        return fileNameIndex;
+    StringId getFileNameStringId() {
+        return fileNameStringId;
     }
 
-    int getClassNameIndex() {
-        return classNameIndex;
+    StringId getClassNameStringId() {
+        return classNameStringId;
     }
 
-    int getMethodNameIndex() {
-        return methodNameIndex;
+    StringId getMethodNameStringId() {
+        return methodNameStringId;
     }
 
-    int getMethodDescIndex() {
-        return methodDescIndex;
+    StringId getMethodDescStringId() {
+        return methodDescStringId;
     }
 
     @Override
     public int hashCode() {
-        int result = fileNameIndex;
-        result = 31 * result + classNameIndex;
-        result = 31 * result + methodNameIndex;
-        result = 31 * result + methodDescIndex;
+        int result = fileNameStringId != null ? fileNameStringId.hashCode() : 0;
+        result = 31 * result + (classNameStringId != null ? classNameStringId.hashCode() : 0);
+        result = 31 * result + (methodNameStringId != null ? methodNameStringId.hashCode() : 0);
+        result = 31 * result + (methodDescStringId != null ? methodDescStringId.hashCode() : 0);
         return result;
     }
 }

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
@@ -1,0 +1,50 @@
+package org.qbicc.plugin.methodinfo;
+
+final class MethodInfo {
+    private int fileNameIndex;
+    private int classNameIndex;
+    private int methodNameIndex;
+    private int methodDescIndex;
+
+    MethodInfo(int fileIndex, int classIndex, int methodIndex, int methodDescIndex) {
+        this.fileNameIndex = fileIndex;
+        this.classNameIndex = classIndex;
+        this.methodNameIndex = methodIndex;
+        this.methodDescIndex = methodDescIndex;
+    }
+
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        MethodInfo that = (MethodInfo) other;
+        return fileNameIndex == that.fileNameIndex
+            && classNameIndex == that.classNameIndex
+            && methodNameIndex == that.methodNameIndex
+            && methodDescIndex == that.methodDescIndex;
+    }
+
+    int getFileNameIndex() {
+        return fileNameIndex;
+    }
+
+    int getClassNameIndex() {
+        return classNameIndex;
+    }
+
+    int getMethodNameIndex() {
+        return methodNameIndex;
+    }
+
+    int getMethodDescIndex() {
+        return methodDescIndex;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = fileNameIndex;
+        result = 31 * result + classNameIndex;
+        result = 31 * result + methodNameIndex;
+        result = 31 * result + methodDescIndex;
+        return result;
+    }
+}

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/SourceCodeInfo.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/SourceCodeInfo.java
@@ -1,0 +1,51 @@
+package org.qbicc.plugin.methodinfo;
+
+final class SourceCodeInfo {
+    private int minfoIndex;
+    private int lineNumber;
+    private int bcIndex;
+    private int inlinedAtIndex; // index of SourceCodeInfo in qbicc_source_code_info_table which has inlined this entry
+
+    SourceCodeInfo(int minfoIndex, int lineNumber, int bcIndex, int inlinedAtIndex) {
+        this.minfoIndex = minfoIndex;
+        this.lineNumber = lineNumber;
+        this.bcIndex = bcIndex;
+        this.inlinedAtIndex = inlinedAtIndex;
+    }
+
+    int getMethodInfoIndex() {
+        return minfoIndex;
+    }
+
+    int getLineNumber() {
+        return lineNumber;
+    }
+
+    int getBcIndex() {
+        return bcIndex;
+    }
+
+    int getInlinedAtIndex() {
+        return inlinedAtIndex;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        SourceCodeInfo that = (SourceCodeInfo) other;
+        return minfoIndex == that.minfoIndex
+            && lineNumber == that.lineNumber
+            && bcIndex == that.bcIndex
+            && inlinedAtIndex == that.inlinedAtIndex;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = minfoIndex;
+        result = 31 * result + lineNumber;
+        result = 31 * result + bcIndex;
+        result = 31 * result + inlinedAtIndex;
+        return result;
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -30,6 +30,7 @@
         <module>llvm</module>
         <module>lowering</module>
         <module>main</module>
+        <module>methodinfo</module>
         <module>metrics</module>
         <module>native</module>
         <module>objectmonitor</module>
@@ -40,6 +41,6 @@
         <module>verification</module>
         <module>unwind</module>
         <module>serialization</module>
-        <module>methodinfo</module>
+        <module>stringpool</module>
     </modules>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -40,5 +40,6 @@
         <module>verification</module>
         <module>unwind</module>
         <module>serialization</module>
+        <module>methodinfo</module>
     </modules>
 </project>

--- a/plugins/stringpool/pom.xml
+++ b/plugins/stringpool/pom.xml
@@ -9,21 +9,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>qbicc-plugin-methodinfo</artifactId>
+    <artifactId>qbicc-plugin-stringpool</artifactId>
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-linker</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-llvm</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.qbicc</groupId>
-            <artifactId>qbicc-plugin-stringpool</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-            <scope>compile</scope>
+            <artifactId>qbicc-compiler</artifactId>
         </dependency>
     </dependencies>
 

--- a/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/OffsetBasedStringPool.java
+++ b/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/OffsetBasedStringPool.java
@@ -1,0 +1,106 @@
+package org.qbicc.plugin.stringpool;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.literal.Literal;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.object.Data;
+import org.qbicc.object.Section;
+import org.qbicc.type.TypeSystem;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+/**
+ * This StringPool implementation stores strings in a single array with each string separated by a null character.
+ * First character is always null character and is used for empty strings.
+ * {@link StringId} is just an offset of the string in the array.
+ * @see OffsetBasedStringId
+ */
+public class OffsetBasedStringPool implements StringPool {
+    private final HashMap<String, StringId> stringToIdMap = new LinkedHashMap<>();
+    private final HashMap<StringId, String> idToStringMap = new HashMap<>();
+    private int nextOffset;
+
+    OffsetBasedStringPool() {
+        nextOffset = 1; // 0 is for null character to indicate empty pool
+    }
+
+    public StringId add(String str) {
+        if (str == null) {
+            return OffsetBasedStringId.NULL_STRING_ID;
+        } else if (str.equals("")) {
+            return OffsetBasedStringId.EMPTY_STRING_ID;
+        }
+        StringId id;
+        synchronized (this) {
+            id = stringToIdMap.computeIfAbsent(str, k -> {
+                StringId newId = new OffsetBasedStringId(nextOffset);
+                nextOffset += str.getBytes().length + 1; // +1 for null character
+                return newId;
+            });
+        }
+        idToStringMap.putIfAbsent(id, str);
+        return id;
+    }
+
+    @Override
+    public String findString(StringId id) {
+        if (id == OffsetBasedStringId.NULL_STRING_ID) {
+            return null;
+        } else if (id == OffsetBasedStringId.EMPTY_STRING_ID) {
+            return "";
+        } else {
+            return idToStringMap.get(id);
+        }
+    }
+
+
+    public Data emit(CompilationContext context) {
+        byte[] pool = new byte[nextOffset];
+        pool[0] = 0;
+        int cursor = 1;
+        for (String str: stringToIdMap.keySet()) {
+            byte[] chars = str.getBytes();
+            assert cursor == ((OffsetBasedStringId) stringToIdMap.get(str)).offset;
+            System.arraycopy(chars, 0, pool, cursor, chars.length);
+            cursor += chars.length;
+            pool[cursor] = 0;
+            cursor += 1;
+        }
+
+        TypeSystem ts = context.getTypeSystem();
+        LiteralFactory lf = context.getLiteralFactory();
+        Literal literal = lf.literalOf(ts.getArrayType(ts.getUnsignedInteger8Type(), pool.length), pool);
+        Section section = context.getImplicitSection(context.getDefaultTypeDefinition());
+        return section.addData(null, "qbicc_string_pool", literal);
+    }
+
+    private static final class OffsetBasedStringId implements StringId {
+        private static final StringId EMPTY_STRING_ID = new OffsetBasedStringId(0);
+        private static final StringId NULL_STRING_ID = new OffsetBasedStringId(-1);
+        int offset;
+
+        OffsetBasedStringId(int offset) {
+            this.offset = offset;
+        }
+
+        @Override
+        public Literal serialize(CompilationContext context) {
+            return context.getLiteralFactory().literalOf(offset);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            OffsetBasedStringId that = (OffsetBasedStringId) o;
+            return offset == that.offset;
+        }
+
+        @Override
+        public int hashCode() {
+            return offset;
+        }
+    }
+}

--- a/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/OffsetBasedStringPool.java
+++ b/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/OffsetBasedStringPool.java
@@ -35,7 +35,8 @@ public class OffsetBasedStringPool implements StringPool {
         synchronized (this) {
             id = stringToIdMap.computeIfAbsent(str, k -> {
                 StringId newId = new OffsetBasedStringId(nextOffset);
-                nextOffset += str.getBytes().length + 1; // +1 for null character
+                int numBytes = str.getBytes().length + 1; // +1 for null character
+                nextOffset += numBytes;
                 return newId;
             });
         }
@@ -73,6 +74,24 @@ public class OffsetBasedStringPool implements StringPool {
         Literal literal = lf.literalOf(ts.getArrayType(ts.getUnsignedInteger8Type(), pool.length), pool);
         Section section = context.getImplicitSection(context.getDefaultTypeDefinition());
         return section.addData(null, "qbicc_string_pool", literal);
+    }
+
+    @Override
+    public int count() {
+        return stringToIdMap.size();
+    }
+
+    @Override
+    public int size() {
+        return nextOffset;
+    }
+
+    @Override
+    public void displayStats() {
+        slog.debug("String pool stats");
+        slog.debug("-----------------");
+        slog.debugf("Number of strings: %d", count());
+        slog.debugf("Pool size in bytes: %d", size());
     }
 
     private static final class OffsetBasedStringId implements StringId {

--- a/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringId.java
+++ b/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringId.java
@@ -1,0 +1,11 @@
+package org.qbicc.plugin.stringpool;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.literal.Literal;
+
+/**
+ * Handle to uniquely identify a string in StringPool
+ */
+public interface StringId {
+    Literal serialize(CompilationContext context);
+}

--- a/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPool.java
+++ b/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPool.java
@@ -1,5 +1,6 @@
 package org.qbicc.plugin.stringpool;
 
+import org.jboss.logging.Logger;
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.object.Data;
@@ -11,6 +12,7 @@ import org.qbicc.object.Data;
  */
 public interface StringPool {
     AttachmentKey<StringPool> KEY = new AttachmentKey<>();
+    Logger slog = Logger.getLogger("org.qbicc.plugin.stringpool.stats");
 
     static StringPool get(final CompilationContext context) {
         StringPool stringPool = context.getAttachment(KEY);
@@ -38,8 +40,25 @@ public interface StringPool {
     String findString(StringId id);
 
     /**
-     * Emit the string pool
+     * Emits the string pool
      * @return
      */
     Data emit(CompilationContext context);
+
+    /**
+     * Returns number of strings in the pool
+     * @return
+     */
+    int count();
+
+    /**
+     * Returns size of the pool in bytes
+     * @return
+     */
+    int size();
+
+    /**
+     * Print string pool stats
+     */
+    void displayStats();
 }

--- a/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPool.java
+++ b/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPool.java
@@ -1,0 +1,45 @@
+package org.qbicc.plugin.stringpool;
+
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.object.Data;
+
+/**
+ * Represents a pool of strings to be stored in the final object file.
+ * Any string representing some sort of metadata can be put in this pool.
+ * Each string is identified uniquely using {@link StringId}.
+ */
+public interface StringPool {
+    AttachmentKey<StringPool> KEY = new AttachmentKey<>();
+
+    static StringPool get(final CompilationContext context) {
+        StringPool stringPool = context.getAttachment(KEY);
+        if (stringPool == null) {
+            StringPool appearing = context.putAttachmentIfAbsent(KEY, stringPool = new OffsetBasedStringPool());
+            if (appearing != null) {
+                stringPool = appearing;
+            }
+        }
+        return stringPool;
+    }
+
+    /**
+     * Add a string to the pool and return a unique identifier to it.
+     * @param str
+     * @return StringId
+     */
+    StringId add(String str);
+
+    /**
+     * Finds the string corresponding to the StringId
+     * @param id
+     * @return String corresponding to the StringId
+     */
+    String findString(StringId id);
+
+    /**
+     * Emit the string pool
+     * @return
+     */
+    Data emit(CompilationContext context);
+}

--- a/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPoolEmitter.java
+++ b/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPoolEmitter.java
@@ -9,5 +9,6 @@ public class StringPoolEmitter implements Consumer<CompilationContext> {
     public void accept(CompilationContext context) {
         StringPool stringPool = StringPool.get(context);
         stringPool.emit(context);
+        stringPool.displayStats();
     }
 }

--- a/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPoolEmitter.java
+++ b/plugins/stringpool/src/main/java/org/qbicc/plugin/stringpool/StringPoolEmitter.java
@@ -1,0 +1,13 @@
+package org.qbicc.plugin.stringpool;
+
+import org.qbicc.context.CompilationContext;
+
+import java.util.function.Consumer;
+
+public class StringPoolEmitter implements Consumer<CompilationContext> {
+    @Override
+    public void accept(CompilationContext context) {
+        StringPool stringPool = StringPool.get(context);
+        stringPool.emit(context);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,12 @@
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-plugin-methodinfo</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-plugin-native</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
This PR creates tables representing method data which can be used to map instruction addresses to the source code location at runtime.

To map instruction address to source code location, LLVM's statepoints are used. Statepoints are generated for every `call` or `invoke` instruction and are assigned a unique statepoint id. The `Node` representing the callsite is also recorded against the statepoint id for use during method data generation. The Node allows us to retrieve the method, line number and bytecode index.

Method data generation step is done after LLVM compilation stage as we need to access the statepoints data generated by LLVM in the StackMap section of the object files, but before linking is done.
StackMaps in the object file record the statepoint id and the offset of the instructions for the callsites corresponding to the statepoint id.
Combining this with the map of statepoint id to `Node` recorded earlier, we can easily associate the callsite instruction address to the source code location. 

All this information is recorded in the form of tables to avoid duplication of data.
Since these tables are not specific to any type, a default type `__qbicc-default-type__` is added to own such data. As such LLVM IR for these tables is generated in `__qbicc-default-type__.ll` file.

Following tables are generated to record the method data:

* A set of string tables representing the file names (`qbicc_filename_table`), class names (`qbicc_classname_table`), method names (`qbicc_methodname_table`) and method descriptors (`qbicc_methoddesc_table`).
Each entry in the string table consists of two fields:
	- len: length of the string
	- a pointer to a char array

* `qbicc_method_info_table` - this table contains information about the methods. Each entry corresponds to a method and contains following fields:
	- file name
	- class name
	- method name
	- method descriptor
All these fields are indices into their respective string tables. That is file name is an index into `qbicc_filename_table` and so on.

* `qbicc_source_code_info_table` - this table contains information about the bytecodes. Each entry corresponds to bytecode location and contains following fields:
	- method info index : index into `qbicc_method_info_table` - describes the method containing this bytecode
	- line number
	- bytecode index
	- inlinedAt index : if the method containing this bytecode is inlined, this field contains index into `qbicc_source_code_info_table` to identify the location in the caller that inlined this method

* `qbicc_instruction_map_table` - this table maps instruction address to source code location. Each entry contains following fields:
	- instruction address
	- source code table index : index into `qbicc_source_code_info_table`

Given an instruction address we can walk through these tables starting with `qbicc_instruction_map_table` to find the corresponding location in the source code.