### PR TITLE
invokeinterface: use searched itables

### DIFF
--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTableBuilder.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTableBuilder.java
@@ -20,12 +20,13 @@ public class DispatchTableBuilder implements Consumer<CompilationContext>  {
         DefinedTypeDefinition jloDef = classContext.findDefinedType("java/lang/Object");
         LoadedTypeDefinition jlo = jloDef.load();
         tables.buildFilteredVTable(jlo);
-        info.visitReachableSubclassesPreOrder(jlo, cls -> tables.buildFilteredVTable(cls));
+        info.visitReachableSubclassesPreOrder(jlo, tables::buildFilteredVTable);
 
-        // Synthesize GlobalVariable for vtables[]
+        // Synthesize GlobalVariable for vtables[] and itable_dict[]
         tables.buildVTablesGlobal(jlo);
+        tables.buildITablesGlobal(jlo);
 
         // Now build the interface dispatching structures for the reachable methods
-        info.visitReachableInterfaces(i -> tables.buildFilteredITableForInterface(i));
+        info.visitReachableInterfaces(tables::buildFilteredITableForInterface);
     }
 }

--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTableEmitter.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTableEmitter.java
@@ -20,12 +20,14 @@ public class DispatchTableEmitter implements Consumer<CompilationContext>  {
         DefinedTypeDefinition jloDef = classContext.findDefinedType("java/lang/Object");
         LoadedTypeDefinition jlo = jloDef.load();
         tables.emitVTable(jlo);
-        info.visitReachableSubclassesPreOrder(jlo, cls -> tables.emitVTable(cls));
+        info.visitReachableSubclassesPreOrder(jlo, tables::emitVTable);
 
-        // Emit the table of all program vtables in the object file for java.lang.Object
+        // Walk down the live class hierarchy and emit the itables for each class
+        tables.emitITables(jlo);
+        info.visitReachableSubclassesPreOrder(jlo, tables::emitITables);
+
+        // Emit the root tables of all program vtables and itables in the object file for java.lang.Object
         tables.emitVTableTable(jlo);
-
-        // Emit all interface dispatching tables
-        tables.emitInterfaceTables(info);
+        tables.emitITableTable(jlo);
     }
 }


### PR DESCRIPTION
Switch from directly indexed itables to searched itables to implement
invokeinterface.  This results in a slightly slower dispatch sequence,
but drops the data space consumed by interface dispatch data
structures from over 2MB to about 85KB for a trivial program.

Fixes #587.