### PR TITLE
Convert internal native structs to CompoundType

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -63,6 +63,7 @@ import org.qbicc.plugin.native_.ConstTypeResolver;
 import org.qbicc.plugin.native_.ConstantDefiningBasicBlockBuilder;
 import org.qbicc.plugin.native_.ExternExportTypeBuilder;
 import org.qbicc.plugin.native_.FunctionTypeResolver;
+import org.qbicc.plugin.native_.InternalNativeTypeResolver;
 import org.qbicc.plugin.native_.NativeBasicBlockBuilder;
 import org.qbicc.plugin.native_.NativeBindingBasicBlockBuilder;
 import org.qbicc.plugin.native_.NativeBindingTypeBuilder;
@@ -70,6 +71,7 @@ import org.qbicc.plugin.native_.NativeTypeBuilder;
 import org.qbicc.plugin.native_.NativeTypeResolver;
 import org.qbicc.plugin.native_.PointerBasicBlockBuilder;
 import org.qbicc.plugin.native_.PointerTypeResolver;
+import org.qbicc.plugin.native_.StructMemberAccessBasicBlockBuilder;
 import org.qbicc.plugin.objectmonitor.ObjectMonitorBasicBlockBuilder;
 import org.qbicc.plugin.opt.GotoRemovingVisitor;
 import org.qbicc.plugin.opt.LocalMemoryTrackingBasicBlockBuilder;
@@ -280,6 +282,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addResolverFactory(ConstTypeResolver::new);
                                 builder.addResolverFactory(FunctionTypeResolver::new);
                                 builder.addResolverFactory(PointerTypeResolver::new);
+                                builder.addResolverFactory(InternalNativeTypeResolver::new);
                                 builder.addResolverFactory(NativeTypeResolver::new);
 
                                 builder.addPreHook(Phase.ADD, CoreIntrinsics::register);
@@ -299,6 +302,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NativeBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, MemberResolvingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NativeBindingBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, StructMemberAccessBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, PointerBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ThreadLocalBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ClassInitializingBasicBlockBuilder::new);

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
@@ -141,6 +141,14 @@ public final class Layout {
     }
 
     public LayoutInfo getInstanceLayoutInfo(DefinedTypeDefinition type) {
+        return getInstanceLayoutInfoHelper(type, false);
+    }
+
+    public LayoutInfo getInstanceLayoutInfoForNativeType(DefinedTypeDefinition type) {
+        return getInstanceLayoutInfoHelper(type, true);
+    }
+
+    private LayoutInfo getInstanceLayoutInfoHelper(DefinedTypeDefinition type, boolean isNativeType) {
         if (type.isInterface()) {
             throw new IllegalArgumentException("Interfaces have no instance layout");
         }
@@ -149,7 +157,8 @@ public final class Layout {
         if (layoutInfo != null) {
             return layoutInfo;
         }
-        LoadedTypeDefinition superClass = validated.getSuperClass();
+        // ignore super class layout for native types
+        LoadedTypeDefinition superClass = isNativeType ? null : validated.getSuperClass();
         LayoutInfo superLayout;
         int minAlignment;
         if (superClass != null) {

--- a/plugins/native/pom.xml
+++ b/plugins/native/pom.xml
@@ -38,5 +38,9 @@
             <groupId>org.qbicc</groupId>
             <artifactId>qbicc-plugin-linker</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.qbicc</groupId>
+            <artifactId>qbicc-plugin-layout</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/InternalNativeTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/InternalNativeTypeResolver.java
@@ -1,0 +1,35 @@
+package org.qbicc.plugin.native_;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.DescriptorTypeResolver;
+
+public class InternalNativeTypeResolver implements DescriptorTypeResolver.Delegating {
+    private final ClassContext classCtxt;
+    private final CompilationContext ctxt;
+    private final DescriptorTypeResolver delegate;
+
+   public InternalNativeTypeResolver(ClassContext classCtxt, DescriptorTypeResolver delegate) {
+        this.classCtxt = classCtxt;
+        this.ctxt = classCtxt.getCompilationContext();
+        this.delegate = delegate;
+    }
+
+    @Override
+    public DescriptorTypeResolver getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public ValueType resolveTypeFromClassName(String packageName, String internalName) {
+        DefinedTypeDefinition definedType = classCtxt.findDefinedType(packageName + "/" + internalName);
+        if (definedType == null) {
+            return delegate.resolveTypeFromClassName(packageName, internalName);
+        }
+        NativeInfo nativeInfo = NativeInfo.get(ctxt);
+        ValueType valueType = nativeInfo.resolveInternalNativeType(definedType);
+        return valueType == null ? delegate.resolveTypeFromClassName(packageName, internalName) : valueType;
+    }
+}

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
@@ -21,6 +21,7 @@ final class Native {
     static final String ANN_INCLUDE = className(include.class);
     static final String ANN_INCLUDE_LIST = className(include.List.class);
     static final String ANN_INCOMPLETE = className(incomplete.class);
+    static final String ANN_INTERNAL = className(internal.class);
     static final String ANN_LIB = className(lib.class);
     static final String ANN_LIB_LIST = className(lib.List.class);
     static final String ANN_NAME = className(name.class);

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeBuilder.java
@@ -1,11 +1,14 @@
 package org.qbicc.plugin.native_;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.qbicc.context.CompilationContext;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.definition.ConstructorResolver;
 import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
  *
@@ -15,6 +18,7 @@ public class NativeTypeBuilder implements DefinedTypeDefinition.Builder.Delegati
     private final CompilationContext ctxt;
     private final DefinedTypeDefinition.Builder delegate;
     private boolean isNative;
+    private boolean isInternalNative;
 
     public NativeTypeBuilder(final ClassContext classCtxt, final DefinedTypeDefinition.Builder delegate) {
         this.classCtxt = classCtxt;
@@ -43,10 +47,27 @@ public class NativeTypeBuilder implements DefinedTypeDefinition.Builder.Delegati
         }
     }
 
+    public void setVisibleAnnotations(final List<Annotation> annotations) {
+        for (Annotation annotation : annotations) {
+            ClassTypeDescriptor desc = annotation.getDescriptor();
+            if (desc.getPackageName().equals(Native.NATIVE_PKG)) {
+                String annClassName = desc.getClassName();
+                if (annClassName.equals(Native.ANN_INTERNAL)) {
+                    isInternalNative = true;
+                    break;
+                }
+            }
+        }
+        getDelegate().setVisibleAnnotations(annotations);
+    }
+
+
     public DefinedTypeDefinition build() {
         // wrap up
         DefinedTypeDefinition builtType = getDelegate().build();
-        if (isNative && ! builtType.isAbstract()) {
+        if (isInternalNative) {
+            NativeInfo.get(ctxt).internalNativeTypes.put(builtType, new AtomicReference<>());
+        } else if (isNative && ! builtType.isAbstract()) {
             NativeInfo.get(ctxt).nativeTypes.put(builtType, new AtomicReference<>());
         }
         return builtType;

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/StructMemberAccessBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/StructMemberAccessBasicBlockBuilder.java
@@ -1,0 +1,34 @@
+package org.qbicc.plugin.native_;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.plugin.layout.Layout;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.definition.element.FieldElement;
+
+public class StructMemberAccessBasicBlockBuilder extends DelegatingBasicBlockBuilder {
+    private final CompilationContext ctxt;
+
+    public StructMemberAccessBasicBlockBuilder(CompilationContext context, BasicBlockBuilder delegate) {
+        super(delegate);
+        ctxt = context;
+    }
+
+    public ValueHandle referenceHandle(Value reference) {
+        if (reference.getType() instanceof CompoundType) {
+            return reference.getValueHandle();
+        }
+        return super.referenceHandle(reference);
+    }
+
+    public ValueHandle instanceFieldOf(ValueHandle instance, FieldElement field) {
+        if (instance.getValueType() instanceof CompoundType) {
+            Layout layout = Layout.get(ctxt);
+            return memberOf(instance, layout.getInstanceLayoutInfo(field.getEnclosingType()).getMember(field));
+        }
+        return super.instanceFieldOf(instance, field);
+    }
+}


### PR DESCRIPTION
Added a type resolver that converts internal native type (a type that
is annotated with @internal) to CompoundType.
Also added a basic block builder that transforms access to native type's
fields.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>