### PR TITLE
Use a proper map for getVirutalFunctions

### DIFF
--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -347,7 +347,7 @@ final class CompilationContextImpl implements CompilationContext {
         // look up the thread ID literal - todo: lazy cache?
         ClassObjectType threadType = bootstrapClassContext.findDefinedType("java/lang/Thread").load().getClassType();
         Section implicit = getImplicitSection(element);
-        return exactFunctions.computeIfAbsent(element, e -> {
+        return virtualFunctions.computeIfAbsent(element, e -> {
             FunctionType type = getFunctionTypeForElement(element, threadType);
             return implicit.addFunction(element, getVirtualNameForElement(element, type), type);
         });


### PR DESCRIPTION
This change uses the virtualFunctions map for the getVirtualFunctions().