### PR TITLE
Improve handling of arrays of native types

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -291,6 +291,8 @@ public interface BasicBlockBuilder extends Locatable {
 
     ValueHandle referenceHandle(Value reference);
 
+    ValueHandle nativeArrayHandle(Value array);
+
     ValueHandle instanceFieldOf(ValueHandle instance, FieldElement field);
 
     ValueHandle instanceFieldOf(ValueHandle instance, TypeDescriptor owner, String name, TypeDescriptor type);

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -131,6 +131,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().referenceHandle(reference);
     }
 
+    public ValueHandle nativeArrayHandle(Value reference) {
+        return getDelegate().nativeArrayHandle(reference);
+    }
+
     public ValueHandle instanceFieldOf(ValueHandle instance, FieldElement field) {
         return getDelegate().instanceFieldOf(instance, field);
     }

--- a/compiler/src/main/java/org/qbicc/graph/Load.java
+++ b/compiler/src/main/java/org/qbicc/graph/Load.java
@@ -2,6 +2,7 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import io.smallrye.common.constraint.Assert;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -17,7 +18,7 @@ public class Load extends AbstractValue implements OrderedNode {
         super(callSite, element, line, bci);
         this.dependency = dependency;
         this.handle = handle;
-        this.mode = mode;
+        this.mode = Assert.checkNotNullParam("mode", mode);
         if (! handle.isReadable()) {
             throw new IllegalArgumentException("Handle is not readable");
         }

--- a/compiler/src/main/java/org/qbicc/graph/NativeArrayHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/NativeArrayHandle.java
@@ -1,0 +1,55 @@
+package org.qbicc.graph;
+
+import org.qbicc.type.ArrayType;
+import org.qbicc.type.PointerType;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+import java.lang.annotation.Native;
+
+public class NativeArrayHandle extends AbstractValueHandle {
+    private final Value value;
+
+    NativeArrayHandle(Node callSite, ExecutableElement element, int line, int bci, Value value) {
+        super(callSite, element, line, bci);
+        this.value = value;
+    }
+
+    @Override
+    int calcHashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof NativeArrayHandle && equals((NativeArrayHandle)other);
+    }
+
+    public boolean equals(NativeArrayHandle other) {
+        return other == this || other != null && other.value.equals(value);
+    }
+
+    @Override
+    public PointerType getPointerType() {
+        return getValueType().getPointer();
+    }
+
+    @Override
+    public ArrayType getValueType() {
+        return (ArrayType) value.getType();
+    }
+
+    public Value getArrayValue() {
+        return value;
+    }
+
+    @Override
+    public MemoryAtomicityMode getDetectedMode() {
+        return MemoryAtomicityMode.NONE;
+    }
+
+    @Override
+    public <T, R> R accept(ValueHandleVisitor<T, R> visitor, T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -795,6 +795,10 @@ public interface Node {
                 return param.getBlockBuilder().referenceHandle(param.copyValue(node.getReferenceValue()));
             }
 
+            public ValueHandle visit(Copier param, NativeArrayHandle node) {
+                return param.getBlockBuilder().nativeArrayHandle(param.copyValue(node.getArrayValue()));
+            }
+
             public Value visit(final Copier param, final Select node) {
                 return param.getBlockBuilder().select(param.copyValue(node.getCondition()), param.copyValue(node.getTrueValue()), param.copyValue(node.getFalseValue()));
             }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -401,6 +401,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return new ReferenceHandle(callSite, element, line, bci, reference);
     }
 
+    public ValueHandle nativeArrayHandle(Value array) {
+        return new NativeArrayHandle(callSite, element, line, bci, array);
+    }
+
     public ValueHandle instanceFieldOf(ValueHandle instance, FieldElement field) {
         return new InstanceFieldOf(element, line, bci, field, field.getType(), instance);
     }

--- a/compiler/src/main/java/org/qbicc/graph/Store.java
+++ b/compiler/src/main/java/org/qbicc/graph/Store.java
@@ -2,6 +2,7 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import io.smallrye.common.constraint.Assert;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
@@ -18,7 +19,7 @@ public class Store extends AbstractNode implements Action, OrderedNode {
         this.dependency = dependency;
         this.handle = handle;
         this.value = value;
-        this.mode = mode;
+        this.mode = Assert.checkNotNullParam("mode", mode);
         if (! handle.isWritable()) {
             throw new IllegalArgumentException("Handle is not writable");
         }

--- a/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitor.java
@@ -80,6 +80,10 @@ public interface ValueHandleVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, NativeArrayHandle node) {
+        return visitUnknown(param, node);
+    }
+
     interface Delegating<T, R> extends ValueHandleVisitor<T, R> {
         ValueHandleVisitor<T, R> getDelegateValueHandleVisitor();
 
@@ -175,6 +179,11 @@ public interface ValueHandleVisitor<T, R> {
 
         @Override
         default R visit(T param, ReferenceHandle node) {
+            return getDelegateValueHandleVisitor().visit(param, node);
+        }
+
+        @Override
+        default R visit(T param, NativeArrayHandle node) {
             return getDelegateValueHandleVisitor().visit(param, node);
         }
     }

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -636,7 +636,8 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_AALOAD: {
                         v2 = pop1();
                         v1 = pop1();
-                        v1 = gf.load(gf.elementOf(gf.referenceHandle(v1), v2), MemoryAtomicityMode.UNORDERED);
+                        ValueHandle handle = gf.referenceHandle(v1);
+                        v1 = gf.load(gf.elementOf(handle, v2), handle.getDetectedMode());
                         push1(v1);
                         break;
                     }
@@ -644,7 +645,8 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_LALOAD: {
                         v2 = pop1();
                         v1 = pop1();
-                        v1 = gf.load(gf.elementOf(gf.referenceHandle(v1), v2), MemoryAtomicityMode.UNORDERED);
+                        ValueHandle handle = gf.referenceHandle(v1);
+                        v1 = gf.load(gf.elementOf(handle, v2), handle.getDetectedMode());
                         push2(v1);
                         break;
                     }
@@ -655,7 +657,8 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_CALOAD: {
                         v2 = pop1();
                         v1 = pop1();
-                        v1 = promote(gf.load(gf.elementOf(gf.referenceHandle(v1), v2), MemoryAtomicityMode.UNORDERED));
+                        ValueHandle handle = gf.referenceHandle(v1);
+                        v1 = promote(gf.load(gf.elementOf(handle, v2), handle.getDetectedMode()));
                         push1(v1);
                         break;
                     }
@@ -700,37 +703,47 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                         break;
                     case OP_IASTORE:
                     case OP_FASTORE:
-                    case OP_AASTORE:
+                    case OP_AASTORE: {
                         v3 = pop1();
                         v2 = pop1();
                         v1 = pop1();
-                        gf.store(gf.elementOf(gf.referenceHandle(v1), v2), v3, MemoryAtomicityMode.UNORDERED);
+                        ValueHandle handle = gf.elementOf(gf.referenceHandle(v1), v2);
+                        gf.store(handle, v3, handle.getDetectedMode());
                         break;
-                    case OP_BASTORE:
+                    }
+                    case OP_BASTORE: {
                         v3 = pop1();
                         v2 = pop1();
                         v1 = pop1();
-                        gf.store(gf.elementOf(gf.referenceHandle(v1), v2), gf.truncate(v3, ts.getSignedInteger8Type()), MemoryAtomicityMode.UNORDERED);
+                        ValueHandle handle = gf.elementOf(gf.referenceHandle(v1), v2);
+                        gf.store(handle, gf.truncate(v3, ts.getSignedInteger8Type()), handle.getDetectedMode());
                         break;
-                    case OP_SASTORE:
+                    }
+                    case OP_SASTORE: {
                         v3 = pop1();
                         v2 = pop1();
                         v1 = pop1();
-                        gf.store(gf.elementOf(gf.referenceHandle(v1), v2), gf.truncate(v3, ts.getSignedInteger16Type()), MemoryAtomicityMode.UNORDERED);
+                        ValueHandle handle = gf.elementOf(gf.referenceHandle(v1), v2);
+                        gf.store(handle, gf.truncate(v3, ts.getSignedInteger16Type()), handle.getDetectedMode());
                         break;
-                    case OP_CASTORE:
+                    }
+                    case OP_CASTORE: {
                         v3 = pop1();
                         v2 = pop1();
                         v1 = pop1();
-                        gf.store(gf.elementOf(gf.referenceHandle(v1), v2), gf.truncate(v3, ts.getUnsignedInteger16Type()), MemoryAtomicityMode.UNORDERED);
+                        ValueHandle handle = gf.elementOf(gf.referenceHandle(v1), v2);
+                        gf.store(handle, gf.truncate(v3, ts.getUnsignedInteger16Type()), handle.getDetectedMode());
                         break;
+                    }
                     case OP_LASTORE:
-                    case OP_DASTORE:
+                    case OP_DASTORE: {
                         v3 = pop2();
                         v2 = pop1();
                         v1 = pop1();
-                        gf.store(gf.elementOf(gf.referenceHandle(v1), v2), v3, MemoryAtomicityMode.UNORDERED);
+                        ValueHandle handle = gf.elementOf(gf.referenceHandle(v1), v2);
+                        gf.store(handle, v3, handle.getDetectedMode());
                         break;
+                    }
                     case OP_POP:
                         pop1();
                         break;

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -70,6 +70,7 @@ import org.qbicc.plugin.native_.ConstantDefiningBasicBlockBuilder;
 import org.qbicc.plugin.native_.ExternExportTypeBuilder;
 import org.qbicc.plugin.native_.FunctionTypeResolver;
 import org.qbicc.plugin.native_.InternalNativeTypeResolver;
+import org.qbicc.plugin.native_.NativeArrayBasicBlockBuilder;
 import org.qbicc.plugin.native_.NativeBasicBlockBuilder;
 import org.qbicc.plugin.native_.NativeBindingBasicBlockBuilder;
 import org.qbicc.plugin.native_.NativeBindingTypeBuilder;
@@ -310,6 +311,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, MemberResolvingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NativeBindingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, StructMemberAccessBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NativeArrayBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, PointerBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ThreadLocalBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ClassInitializingBasicBlockBuilder::new);

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -78,6 +78,7 @@ import org.qbicc.graph.MonitorExit;
 import org.qbicc.graph.MultiNewArray;
 import org.qbicc.graph.Multiply;
 import org.qbicc.graph.CheckCast;
+import org.qbicc.graph.NativeArrayHandle;
 import org.qbicc.graph.Neg;
 import org.qbicc.graph.New;
 import org.qbicc.graph.NewArray;
@@ -324,6 +325,15 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
         attr(param, "label", "ref");
         nl(param);
         addEdge(param, node, node.getReferenceValue(), EdgeType.VALUE_DEPENDENCY);
+        return name;
+    }
+
+    public String visit(final Appendable param, final NativeArrayHandle node) {
+        String name = register(node);
+        appendTo(param, name);
+        attr(param, "label", "array");
+        nl(param);
+        addEdge(param, node, node.getArrayValue(), EdgeType.VALUE_DEPENDENCY);
         return name;
     }
 

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -57,6 +57,7 @@ import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Mod;
 import org.qbicc.graph.Multiply;
 import org.qbicc.graph.CheckCast;
+import org.qbicc.graph.NativeArrayHandle;
 import org.qbicc.graph.Neg;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.NodeVisitor;
@@ -1116,6 +1117,11 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
     @Override
     public GetElementPtr visit(Void param, ReferenceHandle node) {
         return gep(map(node.getReferenceValue()), node).arg(false, i32, ZERO);
+    }
+
+    @Override
+    public GetElementPtr visit(Void param, NativeArrayHandle node) {
+        return gep(map(node.getArrayValue()), node).arg(false, i32, ZERO);
     }
 
     GetElementPtr gep(LLValue ptr, ValueHandle handle) {

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
@@ -3,10 +3,12 @@ package org.qbicc.plugin.native_;
 import java.util.List;
 
 import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.literal.SymbolLiteral;
 import org.qbicc.object.Data;
 import org.qbicc.object.Linkage;
 import org.qbicc.object.Section;
 import org.qbicc.object.ThreadLocalMode;
+import org.qbicc.type.ArrayType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
@@ -117,10 +119,16 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
 
             private void addExtern(final NativeInfo nativeInfo, final FieldElement resolved, final String name) {
                 ValueType fieldType = resolved.getType();
+                SymbolLiteral literal;
+                if (fieldType instanceof ArrayType) {
+                    literal = ctxt.getLiteralFactory().literalOfSymbol(name, fieldType);
+                } else {
+                    literal = ctxt.getLiteralFactory().literalOfSymbol(name, fieldType.getPointer());
+                }
                 nativeInfo.registerFieldInfo(
                     resolved.getEnclosingType().getDescriptor(),
                     resolved.getName(),
-                    new NativeDataInfo(resolved, false, fieldType, ctxt.getLiteralFactory().literalOfSymbol(name, fieldType.getPointer()))
+                    new NativeDataInfo(resolved, false, fieldType, literal)
                 );
             }
 

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeArrayBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeArrayBasicBlockBuilder.java
@@ -1,0 +1,40 @@
+package org.qbicc.plugin.native_;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.ElementOf;
+import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.NativeArrayHandle;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.PointerHandle;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.ValueHandleVisitor;
+import org.qbicc.type.ArrayType;
+import org.qbicc.type.PointerType;
+
+public class NativeArrayBasicBlockBuilder extends DelegatingBasicBlockBuilder implements ValueHandleVisitor<Void, ValueHandle> {
+    private final CompilationContext ctxt;
+
+    public NativeArrayBasicBlockBuilder(CompilationContext context, BasicBlockBuilder delegate) {
+        super(delegate);
+        this.ctxt = context;
+    }
+
+    @Override
+    public Value load(ValueHandle handle, MemoryAtomicityMode mode) {
+        if (handle instanceof NativeArrayHandle) {
+            return ((NativeArrayHandle) handle).getArrayValue();
+        }
+        return super.load(handle, mode);
+    }
+
+    @Override
+    public ValueHandle referenceHandle(Value reference) {
+        if (reference.getType() instanceof ArrayType) {
+            return nativeArrayHandle(reference);
+        }
+        return super.referenceHandle(reference);
+    }
+}

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBasicBlockBuilder.java
@@ -20,6 +20,7 @@ import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Linkage;
 import org.qbicc.object.Section;
 import org.qbicc.object.ThreadLocalMode;
+import org.qbicc.type.ArrayType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
@@ -155,7 +156,12 @@ public class NativeBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         NativeDataInfo fieldInfo = nativeInfo.getFieldInfo(owner, name);
         if (fieldInfo != null) {
             // todo: convert to GlobalVariable
-            return pointerHandle(getAndDeclareSymbolLiteral(fieldInfo));
+            SymbolLiteral sym = getAndDeclareSymbolLiteral(fieldInfo);
+            if (sym.getType() instanceof ArrayType) {
+                return nativeArrayHandle(sym);
+            } else {
+                return pointerHandle(getAndDeclareSymbolLiteral(fieldInfo));
+            }
         }
         return super.staticField(owner, name, type);
     }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/PointerTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/PointerTypeResolver.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.qbicc.context.CompilationContext;
 import org.qbicc.type.ArrayType;
+import org.qbicc.type.CompoundType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
@@ -134,7 +135,9 @@ public class PointerTypeResolver implements DescriptorTypeResolver.Delegating {
             if (elemType instanceof ArrayType) {
                 // it's an array of arrays, make it into a native array instead of a reference array
                 return ctxt.getTypeSystem().getArrayType(elemType, detectArraySize(visibleAnnotations));
-            } else if (! (elemType instanceof ReferenceType) && elemType instanceof WordType && elemDesc instanceof ClassTypeDescriptor) {
+            } else if (! (elemType instanceof ReferenceType)
+                && (elemType instanceof WordType || elemType instanceof CompoundType)
+                && elemDesc instanceof ClassTypeDescriptor) {
                 // this means it's an array of native type (wrapped as ref type) and should be transformed to a "real" array type
                 return ctxt.getTypeSystem().getArrayType(elemType, detectArraySize(visibleAnnotations));
             }


### PR DESCRIPTION
This PR adds a `NativeArrayHandle` as a value handle for arrays of native types and a BBB to transform load operation on `NativeArrayHandle`.
With these changes we can write code using arrays of native types, eg:

```
    @extern
   public static uint32_t[] table;

    @export
    public static int testArray(int index, int value) {
        table[index] = word(value);
        return table[index].intValue();
    }
```

gets translated to:

```
@table = external global [0 x i32]
...
define i32 @testArray(i32 %p0, i32 %p1) "frame-pointer"="non-leaf" uwtable gc "statepoint-example" !dbg !119 {
B0:
  %L0 = alloca i32, i32 1, align 4
  call void @llvm.dbg.addr(metadata i32* %L0, metadata !123, metadata !DIExpression()), !dbg !121 ; Unwind.java:214 bci@0
  %L1 = alloca i32, i32 1, align 4
  call void @llvm.dbg.addr(metadata i32* %L1, metadata !124, metadata !DIExpression()), !dbg !121 ; Unwind.java:214 bci@0
  store i32 %p0, i32* %L0, align 4, !dbg !122 ; Unwind.java:0 bci@-1
  store i32 %p1, i32* %L1, align 4, !dbg !122 ; Unwind.java:0 bci@-1
  %L2 = load i32, i32* %L0, align 4, !dbg !121 ; Unwind.java:214 bci@3
  %L3 = load i32, i32* %L1, align 4, !dbg !121 ; Unwind.java:214 bci@4
    ; Unwind.java:214 bci@8
  %L4 = getelementptr [0 x i32], [0 x i32]* @table, i32 0, i32 %L2, !dbg !121
  store i32 %L3, i32* %L4, align 4, !dbg !121 ; Unwind.java:214 bci@11
  %L5 = load i32, i32* %L0, align 4, !dbg !120 ; Unwind.java:215 bci@15
  %L6 = getelementptr [0 x i32], [0 x i32]* @table, i32 0, i32 %L5, !dbg !120
  %L7 = load i32, i32* %L6, align 4, !dbg !120 ; Unwind.java:215 bci@16
    ; Unwind.java:215 bci@17
  ret i32 %L7, !dbg !120 ; Unwind.java:215 bci@20
}
```

Main use-case for adding this support is to be able to access method data tables added in https://github.com/qbicc/qbicc/pull/594 at runtime using C-like syntax.