### PR TITLE
Get an entry at requires_version_index

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/ModuleDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/ModuleDefinitionImpl.java
@@ -159,7 +159,7 @@ final class ModuleDefinitionImpl implements ModuleDefinition {
                         requiresModifiers[j] = buffer.getShort() & 0xffff;
                         int reqVerIdx = buffer.getShort() & 0xffff;
                         if (reqVerIdx != 0) {
-                            requiresVersions[j] = ClassFileUtil.getUtf8Entry(buffer, reqIdx, cpOffsets, strCache, b);
+                            requiresVersions[j] = ClassFileUtil.getUtf8Entry(buffer, reqVerIdx, cpOffsets, strCache, b);
                         }
                     }
                 }


### PR DESCRIPTION
This fix uses the requires_version_index in the requires table of the module attribute to get the version of the specified module.