### PR TITLE
Display struct type's member names in the comments

### DIFF
--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/StructType.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/StructType.java
@@ -10,5 +10,5 @@ public interface StructType extends LLValue {
      * @param type the type to add
      * @return this struct type
      */
-    StructType member(LLValue type);
+    StructType member(LLValue type, String name);
 }

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/StructTypeImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/StructTypeImpl.java
@@ -10,24 +10,30 @@ import io.smallrye.common.constraint.Assert;
 
 final class StructTypeImpl extends AbstractValue implements StructType {
     final ArrayList<AbstractValue> members = new ArrayList<>();
+    final ArrayList<String> memberNames = new ArrayList<>();
 
-    public StructType member(final LLValue type) {
+    public StructType member(final LLValue type, final String name) {
         members.add((AbstractValue) Assert.checkNotNullParam("type", type));
+        memberNames.add(name);
         return this;
     }
 
     public Appendable appendTo(final Appendable target) throws IOException {
         target.append('{');
         final Iterator<AbstractValue> iterator = members.iterator();
+        final Iterator<String> nameIterator = memberNames.iterator();
         if (iterator.hasNext()) {
             target.append(' ');
-            iterator.next().appendTo(target);
+            iterator.next().appendTo(target).append(" ; " + nameIterator.next());
+
             while (iterator.hasNext()) {
+                target.append('\n').append('\t');
                 target.append(',');
                 target.append(' ');
-                iterator.next().appendTo(target);
+                iterator.next().appendTo(target).append(" ; " + nameIterator.next());
             }
         }
+        target.append('\n').append('\t');
         target.append(' ');
         target.append('}');
         return target;

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -169,12 +169,12 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue> {
                 if (memberOffset > offs) {
                     // we have to pad it out
                     int pad = (int) (memberOffset - offs);
-                    struct.member(array(pad, i8));
+                    struct.member(array(pad, i8), "padding");
                     offs += pad;
                     index ++;
                 }
                 ValueType memberType = member.getType();
-                struct.member(map(memberType));
+                struct.member(map(memberType), member.getName());
                 // todo: cache these ints
                 offsets.put(member, Values.intConstant(index));
                 index ++;
@@ -184,7 +184,7 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue> {
             long size = compoundType.getSize();
             if (offs < size) {
                 // yet more padding
-                struct.member(array((int) (size - offs), i8));
+                struct.member(array((int) (size - offs), i8), "padding");
             }
 
             identifiedType.type(struct);


### PR DESCRIPTION
Making struct types member names available in LLVM IR would make is much easier to read the IR. 
I tried to use `Commentable` interface to add comments to `members` of `StructTypeImpl`, but it proved to be too complicated without getting the desired result.
In the end I resorted to this much simpler change which just meets the purpose.

Now the struct types in LLVM IR look like this:

```
%T.java.lang.InstantiationException = type { i32 ; typeId
        , i32 ; depth
        , i8 addrspace(1)* ; backtrace
        , i8 addrspace(1)* ; detailMessage
        , i8 addrspace(1)* ; cause
        , i8 addrspace(1)* ; stackTrace
        , i8 addrspace(1)* ; suppressedExceptions
         }
```

And it shows you the padding bytes as well:

```
%T.java.util.StringJoiner = type { i32 ; typeId
        , i32 ; size
        , i8 addrspace(1)* ; prefix
        , i8 addrspace(1)* ; delimiter
        , i8 addrspace(1)* ; suffix
        , i8 addrspace(1)* ; elts
        , i32 ; len
        , [4 x i8] ; padding
        , i8 addrspace(1)* ; emptyValue
         }
```

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>