### PR TITLE
Use StackMap section name specific to objectfile format

### DIFF
--- a/machine/file/elf/src/main/java/org/qbicc/machine/file/elf/ElfObjectFileProvider.java
+++ b/machine/file/elf/src/main/java/org/qbicc/machine/file/elf/ElfObjectFileProvider.java
@@ -146,6 +146,11 @@ public class ElfObjectFileProvider implements ObjectFileProvider {
                 return reloSymbol.getName();
             }
 
+            @Override
+            public String getStackMapSectionName() {
+                return ".llvm_stackmaps";
+            }
+
             private ElfSymbolTableEntry findSymbol(final String name) {
                 final ElfSymbolTableEntry symbol = elfHeader.findSymbol(name);
                 if (symbol == null) {

--- a/machine/file/macho/src/main/java/org/qbicc/machine/file/macho/MachOObjectFile.java
+++ b/machine/file/macho/src/main/java/org/qbicc/machine/file/macho/MachOObjectFile.java
@@ -241,6 +241,11 @@ public final class MachOObjectFile implements ObjectFile {
         return null;
     }
 
+    @Override
+    public String getStackMapSectionName() {
+        return "__llvm_stackmaps";
+    }
+
     public void close() {
         buffer.close();
     }

--- a/machine/file/object/src/main/java/org/qbicc/machine/object/ObjectFile.java
+++ b/machine/file/object/src/main/java/org/qbicc/machine/object/ObjectFile.java
@@ -31,4 +31,6 @@ public interface ObjectFile extends Closeable {
     Section getSection(String name);
 
     String getRelocationSymbolForSymbolValue(String symbol);
+
+    String getStackMapSectionName();
 }

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -348,7 +348,7 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
                         index[0] += 1;
                     }
                     try (ObjectFile objectFile = objFileProvider.openObjectFile(objFile)) {
-                        org.qbicc.machine.object.Section stackMapSection = objectFile.getSection(".llvm_stackmaps");
+                        org.qbicc.machine.object.Section stackMapSection = objectFile.getSection(objectFile.getStackMapSectionName());
                         if (stackMapSection != null) {
                             ByteBuffer stackMapData = stackMapSection.getSectionContent();
                             StackMap.parse(stackMapData, new StackMapVisitor() {


### PR DESCRIPTION
https://llvm.org/docs/StackMaps.html#stack-map-section states Stack Map section name is different for ELF and MachO file formats. This PR makes changes to use the correct name for the Stack Map section based on the file format.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>