### PR TITLE
Search all sections in getSection() for named one

### DIFF
--- a/machine/file/macho/src/main/java/org/qbicc/machine/file/macho/MachOObjectFile.java
+++ b/machine/file/macho/src/main/java/org/qbicc/machine/file/macho/MachOObjectFile.java
@@ -219,7 +219,7 @@ public final class MachOObjectFile implements ObjectFile {
 
     @Override
     public org.qbicc.machine.object.Section getSection(String name) {
-        final Section section = segmentsAndSections.getOrDefault(name, Map.of()).get(name);
+        final Section section = sections.stream().filter(s -> s.name.equals(name)).findFirst().orElse(null);
         if (section == null) {
             return null;
         }


### PR DESCRIPTION
The original implementation was using the Segment->Section mapping
and was trying to use the same name for both the segment and the
section.

This failed when looking up the `__llvm_stackmaps` section on macho
as the segment is named `__LLVM_STACKMAPS`.

New algorithm searches the segments list until it finds one of the
matching name and uses that to provide an org.qbicc.machine.object.Section
instances.

Co-authored-by: Ashutosh Mehra <asmehra@redhat.com>
Signed-off-by: Dan Heidinga <heidinga@redhat.com>