### PR TITLE
CompareAndSwap lowering

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
+++ b/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
@@ -41,10 +41,33 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
         if (! target.isReadable()) {
             throw new IllegalArgumentException("Handle is not readable");
         }
+
+        /* expected and update value must have the same type, target must be a pointer to that type. */
+        if (!expectedValue.getType().equals(updateValue.getType())
+             || !expectedValue.getType().equals(target.getPointerType().getPointeeType())
+        ) {
+            throw new IllegalArgumentException("The target, expected and new value types must agree.");
+        };
+
+        /* ordering params must be at least MONOTONIC */
+        if ((0 > successAtomicityMode.compareTo(MemoryAtomicityMode.MONOTONIC))
+            || (0 > failureAtomicityMode.compareTo(MemoryAtomicityMode.MONOTONIC))
+        ) {
+            throw new IllegalArgumentException("Mode must be at least monotonic");
+        }
+        /* volatile does not map to an ordering constraint */
+        if (successAtomicityMode.equals(MemoryAtomicityMode.VOLATILE) || failureAtomicityMode.equals(MemoryAtomicityMode.VOLATILE)) {
+            throw new IllegalArgumentException("volatile does not map to a LLVM ordering constraint");
+        }
+        /* failure ordering must not be RELEASE or ACQUIRE_RELEASE */
+        if (failureAtomicityMode.equals(MemoryAtomicityMode.RELEASE) || failureAtomicityMode.equals(MemoryAtomicityMode.ACQUIRE_RELEASE)) {
+            throw new IllegalArgumentException("Failure mode cannot be release or acquire_release");
+        }
+
     }
 
     int calcHashCode() {
-        return Objects.hash(CmpAndSwap.class, dependency, target, expectedValue, updateValue, successAtomicityMode, failureAtomicityMode);
+        return Objects.hash(CmpAndSwap.class, dependency, target, expectedValue, updateValue, resultType, successAtomicityMode, failureAtomicityMode);
     }
 
     public CompoundType getType() {
@@ -86,7 +109,8 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
     public boolean equals(final CmpAndSwap other) {
         return this == other || other != null && dependency.equals(other.dependency) && target.equals(other.target)
             && expectedValue.equals(other.expectedValue) && updateValue.equals(other.updateValue)
-            && successAtomicityMode == other.successAtomicityMode && failureAtomicityMode == other.failureAtomicityMode;
+            && resultType.equals(other.resultType) && successAtomicityMode == other.successAtomicityMode
+            && failureAtomicityMode == other.failureAtomicityMode;
     }
 
     public int getValueDependencyCount() {
@@ -120,5 +144,21 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
             }
         }
         return compoundType;
+    }
+
+    /**
+     * Original value found in the CAS target
+     * @return value found in CAS target
+     */
+    public CompoundType.Member getResultValueType() {
+        return this.resultType.getMember(0);
+    }
+
+    /**
+     * Result flag where true indicates success, if the operation is marked as strong (default).
+     * @return result flag
+     */
+    public CompoundType.Member getResultFlagType() {
+        return this.resultType.getMember(1);
     }
 }

--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -218,7 +218,6 @@ public final class TypeSystem {
 
     public CompoundType getCompoundType(final CompoundType.Tag tag, String name, long size, int align, Supplier<List<CompoundType.Member>> memberResolver) {
         Assert.checkNotNullParam("tag", tag);
-        Assert.checkNotNullParam("name", name);
         Assert.checkMinimumParameter("size", 0, size);
         TypeUtil.checkAlignmentParameter("align", align);
         return new CompoundType(this, tag, name, memberResolver, size, align);

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/LLBuilder.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/LLBuilder.java
@@ -7,6 +7,7 @@ import org.qbicc.machine.llvm.op.AtomicRmwInstruction;
 import org.qbicc.machine.llvm.op.Binary;
 import org.qbicc.machine.llvm.op.Branch;
 import org.qbicc.machine.llvm.op.Call;
+import org.qbicc.machine.llvm.op.CmpAndSwap;
 import org.qbicc.machine.llvm.op.ExactBinary;
 import org.qbicc.machine.llvm.op.ExtractValue;
 import org.qbicc.machine.llvm.op.FastMathBinary;
@@ -145,6 +146,9 @@ public interface LLBuilder {
     ExtractValue insertvalue(LLValue aggregateType, LLValue aggregate, LLValue insertType, LLValue insert);
 
     Alloca alloca(LLValue type);
+
+    CmpAndSwap cmpAndSwap(final LLValue pointerType, final LLValue type, final LLValue pointer, final LLValue expect, final LLValue update,
+                          final OrderingConstraint successOrdering, final OrderingConstraint failureOrdering);
 
     static LLBuilder newBuilder(LLBasicBlock block) {
         return LLVM.newBuilder(block);

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/BuilderImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/BuilderImpl.java
@@ -12,6 +12,7 @@ import org.qbicc.machine.llvm.op.AtomicRmwInstruction;
 import org.qbicc.machine.llvm.op.Binary;
 import org.qbicc.machine.llvm.op.Branch;
 import org.qbicc.machine.llvm.op.Call;
+import org.qbicc.machine.llvm.op.CmpAndSwap;
 import org.qbicc.machine.llvm.op.ExactBinary;
 import org.qbicc.machine.llvm.op.ExtractValue;
 import org.qbicc.machine.llvm.op.FastMathBinary;
@@ -444,5 +445,18 @@ final class BuilderImpl implements LLBuilder {
     public Alloca alloca(final LLValue type) {
         Assert.checkNotNullParam("type", type);
         return append(new AllocaImpl(block, (AbstractValue) type));
+    }
+
+    public CmpAndSwap cmpAndSwap(final LLValue pointerType, final LLValue  type, final LLValue pointer, final LLValue expect,
+                                 final LLValue update, final OrderingConstraint successOrdering, final OrderingConstraint failureOrdering) {
+        Assert.checkNotNullParam("pointerType", pointerType);
+        Assert.checkNotNullParam("type", type);
+        Assert.checkNotNullParam("pointer", pointer);
+        Assert.checkNotNullParam("expect", expect);
+        Assert.checkNotNullParam("update", update);
+        Assert.checkNotNullParam("successOrdering", successOrdering);
+        Assert.checkNotNullParam("failureOrdering", failureOrdering);
+        return append(new CmpAndSwapImpl(block, (AbstractValue) pointerType, (AbstractValue)type, (AbstractValue)pointer,
+            (AbstractValue)expect, (AbstractValue)update, successOrdering, failureOrdering));
     }
 }

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/CmpAndSwapImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/CmpAndSwapImpl.java
@@ -1,0 +1,117 @@
+package org.qbicc.machine.llvm.impl;
+
+import io.smallrye.common.constraint.Assert;
+import org.qbicc.machine.llvm.LLValue;
+import org.qbicc.machine.llvm.op.CmpAndSwap;
+import org.qbicc.machine.llvm.op.OrderingConstraint;
+
+import java.io.IOException;
+
+final class CmpAndSwapImpl extends AbstractYieldingInstruction implements CmpAndSwap {
+    private final AbstractValue pointerType;
+    private final AbstractValue type;
+    private final AbstractValue pointer;
+    private final AbstractValue expect;
+    private final AbstractValue update;
+    private final OrderingConstraint successOrdering;
+    private final OrderingConstraint failureOrdering;
+    /* optional arguments */
+    private boolean weak;   /* not mapped from add phase */
+    private boolean isVolatile; /* not mapped from add phase */
+    private String syncScope;   /* not mapped from add phase */
+    private int alignment;  /* not mapped from add phase */
+
+    public CmpAndSwapImpl(BasicBlockImpl block, AbstractValue pointerType, AbstractValue type, AbstractValue pointer,
+                          AbstractValue expect, AbstractValue update, OrderingConstraint successOrdering,
+                          OrderingConstraint failureOrdering) {
+        super(block);
+        this.pointerType = pointerType;
+        this.type = type;
+        this.pointer = pointer;
+        this.expect = expect;
+        this.update = update;
+        this.successOrdering = successOrdering;
+        this.failureOrdering = failureOrdering;
+        this.isVolatile = true; /* default for Java */
+    }
+
+    public CmpAndSwap comment(final String comment) {
+        return (CmpAndSwap)super.comment(comment);
+    }
+
+    public CmpAndSwap meta(final String name, final LLValue data) {
+        return (CmpAndSwap)super.meta(name, data);
+    }
+
+    public Appendable appendTo(final Appendable target) throws IOException {
+        super.appendTo(target);
+        target.append("cmpxchg");
+
+        /* weak */
+        if (weak) {
+            space(target);
+            target.append("weak");
+        }
+
+        /* volatile */
+        if (isVolatile) {
+            space(target);
+            target.append("volatile");
+        }
+
+        /* pointer */
+        space(target);
+        pointerType.appendTo(target);
+        space(target);
+        pointer.appendTo(target);
+        target.append(',');
+
+        /* cmp */
+        space(target);
+        type.appendTo(target);
+        space(target);
+        expect.appendTo(target);
+        target.append(',');
+
+        /* new */
+        space(target);
+        type.appendTo(target);
+        space(target);
+        update.appendTo(target);
+
+        /* syncscope */
+        final String syncScope = this.syncScope;
+        if (syncScope != null) {
+            space(target);
+            target.append("syncscope");
+            target.append('(');
+            target.append('"');
+            target.append(syncScope);
+            target.append('"');
+            target.append(')');
+        }
+
+        /* success ordering */
+        space(target);
+        target.append(successOrdering.name());
+
+        /* failure ordering */
+        space(target);
+        target.append(failureOrdering.name());
+
+        /* align */
+        if (alignment != 0) {
+            target.append(',');
+            space(target);
+            target.append("align");
+            space(target);
+            target.append(Integer.toString(alignment));
+        }
+
+        return appendTrailer(target);
+    }
+
+    private void space(Appendable target) throws IOException {
+        target.append(' ');
+    }
+}

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/op/CmpAndSwap.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/op/CmpAndSwap.java
@@ -1,0 +1,8 @@
+package org.qbicc.machine.llvm.op;
+
+import org.qbicc.machine.llvm.LLValue;
+
+public interface CmpAndSwap extends YieldingInstruction {
+    CmpAndSwap comment(String comment);
+    CmpAndSwap meta(String name, LLValue data);
+}


### PR DESCRIPTION
Lowers the CmpAndSwap value to the LLVM IR cmpxchg instruction. 

cmpxchg returns a "literal" structure type and I believe only "identified" llvm structure types are currently supported. The next step will be to correctly lower `extractvalue` to use a literal structure so the result of cmpxchg can be accessed. 
update: https://github.com/qbicc/qbicc/pull/620

Signed-off-by: Theresa Mammarella <tmammare@redhat.com>