### PR TITLE
Lower literal structs for extractvalue

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
+++ b/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
@@ -113,7 +113,13 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
         CompoundType compoundType = map.get(valueType);
         if (compoundType == null) {
             TypeSystem ts = ctxt.getTypeSystem();
-            compoundType = ts.getCompoundType(CompoundType.Tag.NONE, null, -1, -1, () -> List.of(ts.getCompoundTypeMember(null, valueType, -1, -1), ts.getCompoundTypeMember(null, ts.getBooleanType(), -1, -1)));
+            compoundType = CompoundType.builder(ts)
+                .setTag(CompoundType.Tag.INLINE)
+                .setName(null)
+                .addNextMember(valueType)
+                .addNextMember(ts.getBooleanType())
+                .setOverallAlignment(valueType.getAlign())
+                .build();
             CompoundType appearing = map.putIfAbsent(valueType, compoundType);
             if (appearing != null) {
                 compoundType = appearing;

--- a/compiler/src/main/java/org/qbicc/type/CompoundType.java
+++ b/compiler/src/main/java/org/qbicc/type/CompoundType.java
@@ -200,6 +200,7 @@ public final class CompoundType extends ValueType {
         NONE("untagged"),
         STRUCT("struct"),
         UNION("union"),
+        INLINE("inline"), /* LLVM literal structure type */
         ;
         private final String string;
 
@@ -254,6 +255,10 @@ public final class CompoundType extends ValueType {
             }
             overallAlign = align;
             return this;
+        }
+
+        public Builder addNextMember(final ValueType type) {
+            return addNextMember("", type, type.getAlign());
         }
 
         public Builder addNextMember(final String name, final ValueType type) {

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/ExtractValueImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/ExtractValueImpl.java
@@ -41,11 +41,8 @@ final class ExtractValueImpl extends AbstractYieldingInstruction implements Extr
         aggregateType.appendTo(target);
         target.append(' ');
         aggregate.appendTo(target);
-        ArgImpl lastArg = this.lastArg;
-        if (lastArg != null) {
-            lastArg.appendTo(target);
-        }
-        return target;
+        lastArg.appendTo(target);
+        return appendTrailer(target);
     }
 
     static final class ArgImpl extends AbstractEmittable {


### PR DESCRIPTION
LLVM literal and identified structure types are not interchangeable. A literal type is needed to correctly interpret the return value of cmpxchg.

change relates to: https://github.com/qbicc/qbicc/pull/619