### PR TITLE
Ensure 16 byte alignment of struct_UnwindException

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -24,6 +24,7 @@ public final class TypeSystem {
     private final int referenceAlign;
     private final int typeIdSize;
     private final int typeIdAlign;
+    private final int maxAlign;
     private final ByteOrder endianness;
     private final VariadicType variadicType = new VariadicType(this);
     private final PoisonType poisonType = new PoisonType(this);
@@ -50,6 +51,7 @@ public final class TypeSystem {
     TypeSystem(final Builder builder) {
         int byteBits = builder.getByteBits();
         this.byteBits = byteBits;
+        maxAlign = builder.getMaxAlignment();
         pointerSize = builder.getPointerSize();
         pointerAlign = builder.getPointerAlignment();
         funcAlign = builder.getPointerAlignment();
@@ -144,6 +146,15 @@ public final class TypeSystem {
      */
     public int getPointerAlignment() {
         return pointerAlign;
+    }
+
+    /**
+     * Get the maximal alignment for any type defined by this type system
+     *
+     * @return the maximal alignment for any type of this type system
+     */
+    public int getMaxAlignment() {
+        return maxAlign;
     }
 
     /**
@@ -425,6 +436,7 @@ public final class TypeSystem {
             int typeIdAlignment = 4;
             int referenceSize = 4;
             int referenceAlignment = 4;
+            int maxAlignment = 16;
             ByteOrder endianness = ByteOrder.nativeOrder();
 
             public int getByteBits() {
@@ -452,6 +464,15 @@ public final class TypeSystem {
             public void setPointerAlignment(final int pointerAlignment) {
                 TypeUtil.checkAlignmentParameter("pointerAlignment", pointerAlignment);
                 this.pointerAlignment = pointerAlignment;
+            }
+
+            public void setMaxAlignment(final int maxAlignment) {
+                TypeUtil.checkAlignmentParameter("maxAlignment", maxAlignment);
+                this.maxAlignment = maxAlignment;
+            }
+
+            public int getMaxAlignment() {
+                return maxAlignment;
             }
 
             public int getFunctionAlignment() {
@@ -654,6 +675,10 @@ public final class TypeSystem {
         int getPointerAlignment();
 
         void setPointerAlignment(int pointerAlignment);
+
+        int getMaxAlignment();
+
+        void setMaxAlignment(int maxAlignment);
 
         int getFunctionAlignment();
 

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -205,6 +205,9 @@ public class Main implements Callable<DiagnosticContext> {
                     probeBuilder.probeType(void_p);
                     // number of bits in char
                     probeBuilder.probeConstant("CHAR_BIT");
+                    // max alignment
+                    CProbe.Type max_align_t = CProbe.Type.builder().setName("max_align_t").build();
+                    probeBuilder.probeType(max_align_t);
                     // execute
                     CProbe probe = probeBuilder.build();
                     try {
@@ -234,6 +237,7 @@ public class Main implements Callable<DiagnosticContext> {
                             tsBuilder.setFloat64Alignment((int) probeResult.getTypeInfo(double_t).getAlign());
                             tsBuilder.setPointerSize((int) probeResult.getTypeInfo(void_p).getSize());
                             tsBuilder.setPointerAlignment((int) probeResult.getTypeInfo(void_p).getAlign());
+                            tsBuilder.setMaxAlignment((int) probeResult.getTypeInfo(max_align_t).getAlign());
                             // todo: function alignment probe
                             // for now, references == pointers
                             tsBuilder.setReferenceSize((int) probeResult.getTypeInfo(void_p).getSize());

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -1144,7 +1144,7 @@ public final class CNative {
 
     /**
      * Explicitly specify the exact alignment of an object.  The alignment will not be probed.  Different alignments can be specified
-     * for different platforms.
+     * for different platforms.  By convention, a value of Integer.MAX_VALUE encodes that the alignment should be max_align_t.
      */
     @Target({ ElementType.TYPE, ElementType.FIELD })
     @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/Unwind.java
+++ b/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/Unwind.java
@@ -73,6 +73,7 @@ public final class Unwind {
      * The header for a thrown exception.  The runtime is expected to create its own thrown structure which includes
      * this structure as a member.  The runtime is responsible for allocating and freeing instances.
      */
+    @align(Integer.MAX_VALUE) // Force to max_align_t; See https://github.com/qbicc/qbicc/pull/623 for discussion of problem with MacOS unwind.h
     public static final class struct__Unwind_Exception extends object {
         /**
          * "A language- and implementation-specific identifier of the kind of exception. It allows a personality routine


### PR DESCRIPTION
Fixes a GPF when throwing exceptions on BigSur because the unwindException struct element of the VMThread object was only being aligned to 8 bytes, not 16 as required by the libunwind specification.