### PR TITLE
Serialization of java.lang.Class instances

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -88,6 +88,7 @@ import org.qbicc.plugin.opt.PhiOptimizerVisitor;
 import org.qbicc.plugin.opt.SimpleOptBasicBlockBuilder;
 import org.qbicc.plugin.reachability.RTAInfo;
 import org.qbicc.plugin.reachability.ReachabilityBlockBuilder;
+import org.qbicc.plugin.serialization.ClassObjectSerializer;
 import org.qbicc.plugin.serialization.ObjectLiteralSerializingVisitor;
 import org.qbicc.plugin.stringpool.StringPoolEmitter;
 import org.qbicc.plugin.threadlocal.ThreadLocalBasicBlockBuilder;
@@ -360,6 +361,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
                                 builder.addPostHook(Phase.ANALYZE, new DispatchTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
+                                builder.addPostHook(Phase.ANALYZE, new ClassObjectSerializer());
 
                                 builder.addElementHandler(Phase.LOWER, new FunctionLoweringElementHandler());
                                 builder.addElementHandler(Phase.LOWER, new ElementVisitorAdapter(new DotGenerator(Phase.LOWER, graphGenConfig)));

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/InstanceOfCheckCastBasicBlockBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/InstanceOfCheckCastBasicBlockBuilder.java
@@ -197,7 +197,6 @@ public class InstanceOfCheckCastBasicBlockBuilder extends DelegatingBasicBlockBu
             }
         }
 
-        ctxt.warning(getLocation(), "Lowering classOf to incomplete VMHelper stub");
         List<Value> args = List.of(typeId);
         return notNull(getFirstBuilder().call(getFirstBuilder().staticMethod(methodElement), args));
     }

--- a/plugins/intrinsics/pom.xml
+++ b/plugins/intrinsics/pom.xml
@@ -33,6 +33,10 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-instanceof-checkcast</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-serialization</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/plugins/serialization/pom.xml
+++ b/plugins/serialization/pom.xml
@@ -19,11 +19,19 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-instanceof-checkcast</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-layout</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-gc-nogc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-reachability</artifactId>
         </dependency>
     </dependencies>
 

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
@@ -1,0 +1,59 @@
+package org.qbicc.plugin.serialization;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.literal.Literal;
+import org.qbicc.graph.literal.SymbolLiteral;
+import org.qbicc.object.Data;
+import org.qbicc.object.Section;
+import org.qbicc.plugin.instanceofcheckcast.SupersDisplayTables;
+import org.qbicc.plugin.reachability.RTAInfo;
+import org.qbicc.type.ArrayType;
+import org.qbicc.type.ReferenceType;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.descriptor.ArrayTypeDescriptor;
+import org.qbicc.type.generic.TypeSignature;
+
+/**
+ * Constructs and emits an array of java.lang.Class references indexed by typeId.
+ */
+public class ClassObjectSerializer implements Consumer<CompilationContext> {
+    @Override
+    public void accept(CompilationContext ctxt) {
+        BuildtimeHeap bth = BuildtimeHeap.get(ctxt);
+        SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
+        RTAInfo rtaInfo = RTAInfo.get(ctxt);
+        LoadedTypeDefinition jlc = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Class").load();
+        Section section = ctxt.getImplicitSection(jlc);
+        ReferenceType jlcRef = jlc.getType().getReference();
+        ArrayType rootArrayType = ctxt.getTypeSystem().getArrayType(jlcRef, tables.get_number_of_typeids());
+
+        // create the GlobalVariable for shared access to the Class array
+        ArrayTypeDescriptor desc = ArrayTypeDescriptor.of(ctxt.getBootstrapClassContext(), jlc.getDescriptor());
+        GlobalVariableElement.Builder builder = GlobalVariableElement.builder();
+        builder.setName("qbicc_jlc_lookup_table");
+        builder.setType(rootArrayType);
+        builder.setEnclosingType(jlc);
+        builder.setDescriptor(desc);
+        builder.setSignature(TypeSignature.synthesize(ctxt.getBootstrapClassContext(), desc));
+        GlobalVariableElement classArrayGlobal = builder.build();
+        bth.setClassArrayGlobal(classArrayGlobal);
+
+        // initialize the Class array by serializing java.lang.Class instances for all initialized types
+        Literal[] rootTable = new Literal[tables.get_number_of_typeids()];
+        Arrays.fill(rootTable, ctxt.getLiteralFactory().zeroInitializerLiteralOfType(jlcRef));
+        rtaInfo.visitInitializedTypes( ltd -> {
+            Data cls = bth.serializeClassObject(ltd);
+            section.declareData(null, cls.getName(), cls.getType()).setAddrspace(1);
+            SymbolLiteral refToClass = ctxt.getLiteralFactory().literalOfSymbol(cls.getName(), cls.getType().getPointer().asCollected());
+            rootTable[ltd.getTypeId()] = ctxt.getLiteralFactory().bitcastLiteral(refToClass, jlcRef);
+        });
+
+        // Add the final data value for the constructed Class array
+        section.addData(null, classArrayGlobal.getName(), ctxt.getLiteralFactory().literalOf(rootArrayType, List.of(rootTable)));
+    }
+}

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -26,6 +26,11 @@ public class ObjectModel {
     public static native CNative.type_id get_type_id_from_class(Class<?> cls);
 
     /**
+     * Get the java.lang.Class instance for the type ID.
+     */
+    public static native Class<?> get_class_from_type_id(CNative.type_id typeId);
+
+    /**
      * Get the concrete type ID value from the referenced object.  Note that all reference arrays will have the same
      * type ID, which does not reflect the element type.
      *
@@ -127,7 +132,7 @@ public class ObjectModel {
      * 4 - has default methods
      * See SupersDisplayTables.calculateTypeIdFlags() for definitive list.
      * 
-     * @param typeID the class to read the flags for
+     * @param typeId the class to read the flags for
      * @return the flags value
      */
     public static native int get_typeid_flags(CNative.type_id typeId);
@@ -146,7 +151,7 @@ public class ObjectModel {
 
     /** 
      * Fetch the superclass `type_id` from the current `type_id`
-     * @param an existing type_id, don't call this on Object's typeid
+     * @param typeId an existing type_id, don't call this on Object's typeid
      * @return superclass's type_id
      */
     public static native CNative.type_id get_superclass_typeid(CNative.type_id typeId);

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -96,8 +96,10 @@ public final class VMHelpers {
     // TODO: mark this with a "NoInline" annotation
     @NoSideEffects
     static Class<?> classof_from_typeid(type_id typeId) {
-        // Load the java.lang.Class object from an array of them indexed by typeId.
-        return null; // TODO: Implement this! (or perhaps implement it inline; it should take less code than a call).
+        if (ObjectModel.is_reference_array(typeId)) {
+            throw new UnsupportedOperationException("Attempted to get java.lang.Class instance for the [ref typeId");
+        }
+        return ObjectModel.get_class_from_type_id(typeId);
     }
 
     @NoSideEffects


### PR DESCRIPTION
Initial steps; should be enough for executing static synchronized methods using the nativeObjectMonitor field of the appropriate class object.
- Emit the array of j.l.C instances indexed by typeId
- Implement VM_Helpers.classof_from_typeid
- Add compiler pass to "serialize" j.l.C instances for all initialized types
- Initialize a couple of the instance fields (name, id); leave the rest zero initialized.
