### PR TITLE
Bug fix in conversion of invokes to linktime errors

### DIFF
--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
@@ -284,6 +284,18 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
                 return visit(node);
             }
 
+            private Value visit(VirtualMethodElementHandle node) {
+                MethodElement target = node.getExecutable();
+                // Elides check for native method because we don't know the exact target (could be overridden).
+                if (target.isStatic()) {
+                    throwIncompatibleClassChangeError();
+                    throw Assert.unreachableCode();
+                }
+                nullCheck(node.getInstance());
+                // return value unused in this case
+                return null;
+            }
+
             private Value visit(InstanceMethodElementHandle node) {
                 MethodElement target = node.getExecutable();
                 if (target.hasAllModifiersOf(ClassFile.ACC_NATIVE) &&

--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
@@ -262,9 +262,9 @@ public class DispatchTables {
                     cSection.declareFunction(ameStub, ameImpl.getName(), ameImpl.getType());
                     valueMap.put(itableInfo.getType().getMember(i), lf.bitcastLiteral(ameLiteral, implType.getPointer()));
                 } else {
-                    Function impl = ctxt.getExactFunctionIfExists(methImpl);
+                    Function impl = methImpl.isNative() ? null : ctxt.getExactFunctionIfExists(methImpl);
                     if (impl == null) {
-                        if (RTAInfo.get(ctxt).isInvokableMethod(methImpl)) {
+                        if (!methImpl.isNative() && RTAInfo.get(ctxt).isInvokableMethod(methImpl)) {
                             ctxt.error(methImpl, "Missing method implementation for vtable of %s", cls.getInternalName());
                         } else {
                             MethodElement uleStub = ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError");


### PR DESCRIPTION
An invokevirtual whose target is a native method cannot be converted
to an unconditional throw of an UnsatisfiedLinkError because the
virtual method may be overriden. Tested against the class library
at 8311cc4b2 (before the addition of a non-native Object.toString())
and verified that with this fix I see the same 4MB growth in final
executable size that I saw when defining a non-native Object.toString.