### PR TITLE
Process generic types for functional interface

### DIFF
--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/FunctionTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/FunctionTypeResolver.java
@@ -92,7 +92,8 @@ public class FunctionTypeResolver implements DescriptorTypeResolver.Delegating {
                                     functionType = ts.getFunctionType(ts.getVoidType());
                                 } else {
                                     if (definedType.isInterface()) {
-                                        return NativeInfo.get(ctxt).getTypeOfFunctionalInterface(definedType);
+                                        List<TypeArgument> functionalInterfaceArguments = ((ClassTypeSignature)bound.getBound()).getTypeArguments();
+                                        return NativeInfo.get(ctxt).getTypeOfFunctionalInterface(definedType, functionalInterfaceArguments);
                                     } else {
                                         ctxt.error("Function interface type \"%s\" is not an interface", name);
                                         functionType = ts.getFunctionType(ts.getVoidType());


### PR DESCRIPTION
Return function interface type with correct generics. For example: function_ptr<UnaryOperator<void_ptr>>

Signed-off-by: Theresa Mammarella <tmammare@redhat.com>