### PR TITLE
Make class initialization failure a warning... for now

### DIFF
--- a/driver/src/main/java/org/qbicc/driver/ElementInitializer.java
+++ b/driver/src/main/java/org/qbicc/driver/ElementInitializer.java
@@ -31,9 +31,9 @@ public class ElementInitializer implements Consumer<ExecutableElement> {
                     String message = throwable.getMessage();
                     CompilationContext ctxt = vm.getCompilationContext();
                     if (message != null) {
-                        ctxt.error("Failed to initialize %s: %s: %s", vmClass.getName(), className, message);
+                        ctxt.warning("Failed to initialize %s: %s: %s", vmClass.getName(), className, message);
                     } else {
-                        ctxt.error("Failed to initialize %s: %s", vmClass.getName(), className);
+                        ctxt.warning("Failed to initialize %s: %s", vmClass.getName(), className);
                     }
                 }
             }

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -373,7 +373,9 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, LocalVariableFindingBasicBlockBuilder::new);
                                 builder.addPostHook(Phase.ANALYZE, RTAInfo::reportStats);
-                                builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
+                                if (! initBuildTime) {
+                                    builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
+                                }
                                 builder.addPostHook(Phase.ANALYZE, new DispatchTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new ClassObjectSerializer());
@@ -401,7 +403,9 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, StaticFieldLoweringBasicBlockBuilder::new);
                                 // InstanceOfCheckCastBB must come before ObjectAccessLoweringBuilder or typeIdOf won't be lowered correctly
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, InstanceOfCheckCastBasicBlockBuilder::new);
-                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LowerClassInitCheckBlockBuilder::new);
+                                if (! initBuildTime) {
+                                    builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LowerClassInitCheckBlockBuilder::new);
+                                }
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectAccessLoweringBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectMonitorBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LLVMCompatibleBasicBlockBuilder::new);

--- a/plugins/conversion/src/main/java/org/qbicc/plugin/conversion/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/conversion/src/main/java/org/qbicc/plugin/conversion/LLVMCompatibleBasicBlockBuilder.java
@@ -22,6 +22,7 @@ import org.qbicc.type.FloatType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.NumericType;
+import org.qbicc.type.ObjectType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.UnsignedIntegerType;
@@ -137,6 +138,12 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         } else {
             return super.store(handle, value, mode);
         }
+    }
+
+    @Override
+    public Node classInitCheck(ObjectType objectType) {
+        // either this is handled by an earlier BBB, or else init was 100% build time
+        return nop();
     }
 
     @Override


### PR DESCRIPTION
Allowing compilation to complete even with failing class init will allow us to move more quickly with getting something working.  The most expedient way to make this work is to disable run time init when build time init is enabled, but this is not strictly correct.  If a class fails to initialize during build, then any class init check should be replaced with a throw of an exception-in-initializer error (which will result in pruning much of the program graph).

The next step would be to determine how the build and run time init modes could mix - if they can at all.