### PR TITLE
Convert BuildTimeHeap to using VmObject

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/Vm.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Vm.java
@@ -175,6 +175,13 @@ public interface Vm {
     Memory allocate(int size);
 
     /**
+     * Intern a host JVM String as a VmString
+     * @param string the host string to intern
+     * @return the interned VmString
+     */
+    VmString intern(String string);
+
+    /**
      * Convenience method to get the actual (non-{@code null}) class loader for the given class context.
      *
      * @param classContext the class context (must not be {@code null})

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -349,7 +349,7 @@ public final class VmImpl implements Vm {
         return intern(vmString.getContent());
     }
 
-    VmStringImpl intern(String string) {
+    public VmStringImpl intern(String string) {
         VmStringImpl vmString = interned.get(string);
         if (vmString == null) {
             vmString = new VmStringImpl(this, stringClass, string);

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -1,6 +1,5 @@
 package org.qbicc.plugin.serialization;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -11,16 +10,26 @@ import java.util.function.Supplier;
 import io.smallrye.common.constraint.Assert;
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmArray;
+import org.qbicc.interpreter.VmObject;
 import org.qbicc.object.Data;
 import org.qbicc.object.Linkage;
 import org.qbicc.object.Section;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.type.ArrayType;
+import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.CompoundType;
+import org.qbicc.type.FloatType;
+import org.qbicc.type.IntegerType;
+import org.qbicc.type.PhysicalObjectType;
 import org.qbicc.type.Primitive;
+import org.qbicc.type.PrimitiveArrayObjectType;
+import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
@@ -28,7 +37,6 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
-import org.qbicc.type.descriptor.BaseTypeDescriptor;
 
 public class BuildtimeHeap {
     private static final AttachmentKey<BuildtimeHeap> KEY = new AttachmentKey<>();
@@ -36,17 +44,26 @@ public class BuildtimeHeap {
 
     private final CompilationContext ctxt;
     private final Layout layout;
-    /** For lazy definition of native array types for literals */
+    private final CoreClasses coreClasses;
+    /**
+     * For lazy definition of native array types for literals
+     */
     private final HashMap<String, CompoundType> arrayTypes = new HashMap<>();
-    /** For interning string literals */
-    private final HashMap<String, Data>  stringLiterals = new HashMap<>();
-    /** For interning java.lang.Class instances */
+    /**
+     * For interning java.lang.Class instances
+     */
     private final HashMap<LoadedTypeDefinition, Data> classObjects = new HashMap<>();
-    /** For interning objects */
-    private final IdentityHashMap<Object, Data> objects = new IdentityHashMap<>();
-    /** The initial heap */
+    /**
+     * For interning VmObjects
+     */
+    private final IdentityHashMap<VmObject, Data> vmObjects = new IdentityHashMap<>();
+    /**
+     * The initial heap
+     */
     private final Section heapSection;
-    /** The global array of java.lang.Class instances that is part of the serialized heap */
+    /**
+     * The global array of java.lang.Class instances that is part of the serialized heap
+     */
     private GlobalVariableElement classArrayGlobal;
 
     private int literalCounter = 0;
@@ -54,6 +71,7 @@ public class BuildtimeHeap {
     private BuildtimeHeap(CompilationContext ctxt) {
         this.ctxt = ctxt;
         this.layout = Layout.get(ctxt);
+        this.coreClasses = CoreClasses.get(ctxt);
 
         LoadedTypeDefinition ih = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/InitialHeap").load();
         this.heapSection = ctxt.getOrAddProgramModule(ih).getOrAddSection(ctxt.IMPLICIT_SECTION_NAME); // TODO: use ctxt.INITIAL_HEAP_SECTION_NAME
@@ -84,18 +102,25 @@ public class BuildtimeHeap {
         return classArrayGlobal;
     }
 
-    public synchronized Data serializeStringLiteral(String value) {
-        // String literals are interned via equals, not ==
-        if (stringLiterals.containsKey(value)) {
-            return stringLiterals.get(value);
+    public synchronized Data serializeVmObject(VmObject value) {
+        if (vmObjects.containsKey(value)) {
+            return vmObjects.get(value);
         }
-        LoadedTypeDefinition jls = ctxt.getBootstrapClassContext().findDefinedType("java/lang/String").load();
-        Data sl = serializeObject(jls, value);
-        stringLiterals.put(value, sl);
+        PhysicalObjectType ot = value.getObjectType();
+        Data sl;
+        if (ot instanceof ClassObjectType) {
+            // TODO: Right here we need to detect if value is a java.lang.Class instance and handle it specially by calling serializeClassObject!
+            sl = serializeVmObject((ClassObjectType) ot, value);
+        } else if (ot instanceof ReferenceArrayObjectType) {
+            sl = serializeRefArray((ReferenceArrayObjectType) ot, (VmArray)value);
+        } else {
+            sl = serializePrimArray((PrimitiveArrayObjectType) ot, (VmArray)value);
+        }
+        vmObjects.put(value, sl);
         return sl;
     }
 
-    public Data serializeClassObject(Primitive primitive) {
+    public synchronized Data serializeClassObject(Primitive primitive) {
         LoadedTypeDefinition jlc = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Class").load();
         Literal classLiteral = createClassObjectLiteral(jlc, primitive.getName(), primitive.getType());
         return defineData(nextLiteralName(), classLiteral);
@@ -112,48 +137,6 @@ public class BuildtimeHeap {
         return cl;
     }
 
-    public synchronized Data serializeObject(Object obj) {
-        if (objects.containsKey(obj)) {
-            return objects.get(obj);
-        }
-
-        Class<?> cls = obj.getClass();
-        // java.lang.Class instances are their own special thing; can't just reflectively write them.
-        if (obj instanceof Class<?>) {
-            LoadedTypeDefinition ltd = ctxt.getBootstrapClassContext().findDefinedType(cls.getName().replace('.', '/')).load();
-            return serializeClassObject(ltd);
-        }
-
-        Data data;
-        if (cls.isArray()) {
-            if (obj instanceof byte[]) {
-                data = serializeArray((byte[]) obj);
-            } else if (obj instanceof boolean[]) {
-                data = serializeArray((boolean[]) obj);
-            } else if (obj instanceof char[]) {
-                data =  serializeArray((char[]) obj);
-            } else if (obj instanceof short[]) {
-                data =  serializeArray((short[]) obj);
-            } else if (obj instanceof int[]) {
-                data = serializeArray((int[]) obj);
-            } else if (obj instanceof float[]) {
-                data = serializeArray((float[]) obj);
-            } else if (obj instanceof long[]) {
-                data = serializeArray((long[]) obj);
-            } else if (obj instanceof double[]) {
-                data = serializeArray((double[]) obj);
-            } else {
-                data = serializeArray((Object[]) obj);
-            }
-        } else {
-            LoadedTypeDefinition ltd = ctxt.getBootstrapClassContext().findDefinedType(cls.getName().replace('.', '/')).load();
-            data = serializeObject(ltd, obj);
-        }
-
-        objects.put(obj, data);
-        return data;
-    }
-
     private Literal createClassObjectLiteral(LoadedTypeDefinition jlc, String className, ValueType type) {
         LiteralFactory lf = ctxt.getLiteralFactory();
         Layout.LayoutInfo jlcLayout = layout.getInstanceLayoutInfo(jlc);
@@ -161,16 +144,16 @@ public class BuildtimeHeap {
         HashMap<CompoundType.Member, Literal> memberMap = new HashMap<>();
 
         // First default to a zero initializer for all the instance fields
-        for (CompoundType.Member m: jlcType.getMembers()) {
+        for (CompoundType.Member m : jlcType.getMembers()) {
             memberMap.put(m, lf.zeroInitializerLiteralOfType(m.getType()));
         }
 
         // Object header
-        memberMap.put(jlcLayout.getMember(layout.getObjectTypeIdField()), lf.literalOf(jlc.getTypeId()));
+        memberMap.put(jlcLayout.getMember(coreClasses.getObjectTypeIdField()), lf.literalOf(jlc.getTypeId()));
 
         // Next, initialize instance fields of the qbicc jlc type that we can/want to set at build time.
         CompoundType.Member name = jlcType.getMember("name");
-        memberMap.put(name, dataToLiteral(lf, serializeStringLiteral(className), (WordType)name.getType()));
+        memberMap.put(name, dataToLiteral(lf, serializeVmObject(ctxt.getVm().intern(className)), (WordType) name.getType()));
 
         CompoundType.Member id = jlcType.getMember("id");
         memberMap.put(id, lf.literalOfType(type));
@@ -192,69 +175,14 @@ public class BuildtimeHeap {
     }
 
     private String nextLiteralName() {
-        return prefix+(this.literalCounter++);
+        return prefix + (this.literalCounter++);
     }
 
     private Data defineData(String name, Literal value) {
-        Data d = heapSection.addData(null,name, value);
+        Data d = heapSection.addData(null, name, value);
         d.setLinkage(Linkage.EXTERNAL);
         d.setAddrspace(1);
         return d;
-    }
-
-    private Data serializeObject(LoadedTypeDefinition concreteType, Object instance) {
-        LiteralFactory lf = ctxt.getLiteralFactory();
-        Layout.LayoutInfo objLayout = layout.getInstanceLayoutInfo(concreteType);
-        CompoundType objType = objLayout.getCompoundType();
-        HashMap<CompoundType.Member, Literal> memberMap = new HashMap<>();
-
-        // Object header
-        memberMap.put(objLayout.getMember(layout.getObjectTypeIdField()), lf.literalOf(concreteType.getTypeId()));
-
-        // Instance fields
-        Class<?> jClass = instance.getClass();
-        LoadedTypeDefinition qClass = concreteType;
-        while (qClass.hasSuperClass()) {
-            for (Field jf : jClass.getDeclaredFields()) {
-                FieldElement qf = qClass.findField(jf.getName());
-                CompoundType.Member member = objLayout.getMember(qf);
-                jf.setAccessible(true);
-                if (qf != null && !qf.isStatic()) {
-                    try {
-                        if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.Z)) {
-                            memberMap.put(member, lf.literalOf(jf.getBoolean(instance)));
-                        } else if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.B)) {
-                            memberMap.put(member, lf.literalOf(jf.getByte(instance)));
-                        } else if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.S)) {
-                            memberMap.put(member, lf.literalOf(jf.getShort(instance)));
-                        } else if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.C)) {
-                            memberMap.put(member, lf.literalOf(jf.getChar(instance)));
-                        } else if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.I)) {
-                            memberMap.put(member, lf.literalOf(jf.getInt(instance)));
-                        } else if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.F)) {
-                            memberMap.put(member, lf.literalOf(jf.getFloat(instance)));
-                        } else if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.J)) {
-                            memberMap.put(member, lf.literalOf(jf.getLong(instance)));
-                        } else if (qf.getTypeDescriptor().equals(BaseTypeDescriptor.D)) {
-                            memberMap.put(member, lf.literalOf(jf.getDouble(instance)));
-                        } else {
-                            Object fieldContents = jf.get(instance);
-                            if (fieldContents == null) {
-                                memberMap.put(member, lf.zeroInitializerLiteralOfType(member.getType()));
-                            } else {
-                                memberMap.put(member, dataToLiteral(lf, serializeObject(fieldContents), (WordType)member.getType()));
-                            }
-                        }
-                    } catch (IllegalAccessException e) {
-                        ctxt.error("Heap Serialization: denied access to field %s of %s", jf.getName(), jClass);
-                    }
-                }
-            }
-            qClass = qClass.getSuperClass();
-            jClass = jClass.getSuperclass();
-        }
-
-        return defineData(nextLiteralName(), ctxt.getLiteralFactory().literalOf(objType, memberMap));
     }
 
     private Literal dataToLiteral(LiteralFactory lf, Data data, WordType toType) {
@@ -263,7 +191,7 @@ public class BuildtimeHeap {
 
     private CompoundType arrayLiteralType(FieldElement contents, int length) {
         LoadedTypeDefinition ltd = contents.getEnclosingType().load();
-        String typeName = ltd.getInternalName() + "_"+length;
+        String typeName = ltd.getInternalName() + "_" + length;
         CompoundType sizedArrayType = arrayTypes.get(typeName);
         if (sizedArrayType == null) {
             TypeSystem ts = ctxt.getTypeSystem();
@@ -271,136 +199,157 @@ public class BuildtimeHeap {
             CompoundType arrayCT = objLayout.getCompoundType();
 
             CompoundType.Member contentMem = objLayout.getMember(contents);
-            ArrayType sizedContentMem = ts.getArrayType(((ArrayType)contents.getType()).getElementType(), length);
+            ArrayType sizedContentMem = ts.getArrayType(((ArrayType) contents.getType()).getElementType(), length);
             CompoundType.Member realContentMem = ts.getCompoundTypeMember(contentMem.getName(), sizedContentMem, contentMem.getOffset(), contentMem.getAlign());
 
             Supplier<List<CompoundType.Member>> thunk;
-            if (contents.equals(CoreClasses.get(ctxt).getRefArrayContentField())) {
+            if (contents.equals(coreClasses.getRefArrayContentField())) {
                 thunk = () -> List.of(arrayCT.getMember(0), arrayCT.getMember(1), arrayCT.getMember(2), arrayCT.getMember(3), realContentMem);
             } else {
                 thunk = () -> List.of(arrayCT.getMember(0), arrayCT.getMember(1), realContentMem);
             }
 
-            sizedArrayType = ts.getCompoundType(CompoundType.Tag.STRUCT, typeName,arrayCT.getSize() + sizedContentMem.getSize(), arrayCT.getAlign(), thunk);
+            sizedArrayType = ts.getCompoundType(CompoundType.Tag.STRUCT, typeName, arrayCT.getSize() + sizedContentMem.getSize(), arrayCT.getAlign(), thunk);
             arrayTypes.put(typeName, sizedArrayType);
         }
         return sizedArrayType;
     }
 
-    private Literal javaPrimitiveArrayLiteral(FieldElement contentsField, int length, Literal data) {
+    private Data serializeVmObject(ClassObjectType ct, VmObject value) {
+        Memory memory = value.getMemory();
         LiteralFactory lf = ctxt.getLiteralFactory();
-        CompoundType literalCT = arrayLiteralType(contentsField, length);
-        return lf.literalOf(literalCT, Map.of(
-            literalCT.getMember(0), lf.literalOf(contentsField.getEnclosingType().load().getTypeId()),
-            literalCT.getMember(1), lf.literalOf(length),
-            literalCT.getMember(2), data
-        ));
-    }
+        LoadedTypeDefinition concreteType = ct.getDefinition().load();
+        Layout.LayoutInfo objLayout = layout.getInstanceLayoutInfo(concreteType);
+        CompoundType objType = objLayout.getCompoundType();
+        HashMap<CompoundType.Member, Literal> memberMap = new HashMap<>();
 
-    private Data serializeArray(byte[] array) {
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getByteArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getSignedInteger8Type(), array.length), array));
-        return defineData(nextLiteralName(), al);
-    }
-
-    private Data serializeArray(boolean[] array) {
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (boolean v: array) {
-            elements.add(ctxt.getLiteralFactory().literalOf(v));
+        // Iterate over instance fields and get their values from value's backing Memory
+        CompoundType.Member typeIdMember = objLayout.getMember(coreClasses.getObjectTypeIdField());
+        for (CompoundType.Member member : objType.getMembers()) {
+            if (member.equals(typeIdMember)) {
+                // Handle specially; not set by the interpreter because typeIds are assigned in postHook of Phase.ANALYZE.
+                memberMap.put(typeIdMember, lf.literalOf(concreteType.getTypeId()));
+            } else if (member.getType() instanceof IntegerType) {
+                IntegerType it = (IntegerType)member.getType();
+                if (it.getSize() == 8L) {
+                    memberMap.put(member, lf.literalOf(it, memory.load8(member.getOffset(), MemoryAtomicityMode.UNORDERED)));
+                } else if (it.getSize() == 16L) {
+                    memberMap.put(member, lf.literalOf(it, memory.load16(member.getOffset(), MemoryAtomicityMode.UNORDERED)));
+                } else if (it.getSize() == 32L) {
+                    memberMap.put(member, lf.literalOf(it, memory.load32(member.getOffset(), MemoryAtomicityMode.UNORDERED)));
+                } else {
+                    memberMap.put(member, lf.literalOf(it, memory.load64(member.getOffset(), MemoryAtomicityMode.UNORDERED)));
+                }
+            } else if (member.getType() instanceof FloatType) {
+                FloatType ft = (FloatType)member.getType();
+                if (ft.getSize() == 32L) {
+                    memberMap.put(member, lf.literalOf(ft, memory.loadFloat(member.getOffset(), MemoryAtomicityMode.UNORDERED)));
+                } else {
+                    memberMap.put(member, lf.literalOf(ft, memory.loadDouble(member.getOffset(), MemoryAtomicityMode.UNORDERED)));
+                }
+            } else {
+                VmObject contents = memory.loadRef(member.getOffset(), MemoryAtomicityMode.UNORDERED);
+                if (contents == null) {
+                    memberMap.put(member, lf.zeroInitializerLiteralOfType(member.getType()));
+                } else {
+                    memberMap.put(member, dataToLiteral(lf, serializeVmObject(contents), (WordType) member.getType()));
+                }
+            }
         }
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getBooleanArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getUnsignedInteger8Type(), array.length), elements));
-        return defineData(nextLiteralName(), al);
+
+        return defineData(nextLiteralName(), ctxt.getLiteralFactory().literalOf(objType, memberMap));
     }
 
-    private Data serializeArray(char[] array) {
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (char v: array) {
-            elements.add(ctxt.getLiteralFactory().literalOf(v));
-        }
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getCharArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getUnsignedInteger16Type(), array.length), elements));
-        return defineData(nextLiteralName(), al);
-    }
-
-    private Data serializeArray(short[] array) {
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (short v: array) {
-            elements.add(ctxt.getLiteralFactory().literalOf(v));
-        }
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getShortArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getSignedInteger16Type(), array.length), elements));
-        return defineData(nextLiteralName(), al);
-    }
-
-    private Data serializeArray(int[] array) {
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (int v: array) {
-            elements.add(ctxt.getLiteralFactory().literalOf(v));
-        }
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getIntArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getSignedInteger32Type(), array.length), elements));
-        return defineData(nextLiteralName(), al);
-    }
-
-    private Data serializeArray(float[] array) {
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (float v: array) {
-            elements.add(ctxt.getLiteralFactory().literalOf(v));
-        }
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getFloatArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getFloat32Type(), array.length), elements));
-        return defineData(nextLiteralName(), al);
-    }
-
-    private Data serializeArray(long[] array) {
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (long v: array) {
-            elements.add(ctxt.getLiteralFactory().literalOf(v));
-        }
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getLongArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getSignedInteger64Type(), array.length), elements));
-        return defineData(nextLiteralName(), al);
-    }
-
-    private Data serializeArray(double[] array) {
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (double v: array) {
-            elements.add(ctxt.getLiteralFactory().literalOf(v));
-        }
-        Literal al = javaPrimitiveArrayLiteral(CoreClasses.get(ctxt).getDoubleArrayContentField(), array.length,
-            ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(ctxt.getTypeSystem().getFloat64Type(), array.length), elements));
-        return defineData(nextLiteralName(), al);
-    }
-
-    private Data serializeArray(Object[] array) {
+    private Data serializeRefArray(ReferenceArrayObjectType at, VmArray value) {
         LoadedTypeDefinition jlo = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Object").load();
-        Class<?> cls = array.getClass();
-        int dimensions = 0;
-        Class<?> leafElementClass = cls.getComponentType();
-        while (leafElementClass.isArray()) {
-            dimensions += 1;
-            leafElementClass = leafElementClass.getComponentType();
-        }
-        LoadedTypeDefinition leafLTD = ctxt.getBootstrapClassContext().findDefinedType(leafElementClass.getName().replace('.', '/')).load();
-
         LiteralFactory lf = ctxt.getLiteralFactory();
-        List<Literal> elements = new ArrayList<>(array.length);
-        for (Object o: array) {
-            Data elem = serializeObject(o);
-            elements.add(lf.bitcastLiteral(lf.literalOfSymbol(elem.getName(), elem.getType().getPointer().asCollected()), jlo.getClassType().getReference()));
-        }
-        FieldElement contentsField = CoreClasses.get(ctxt).getRefArrayContentField();
+        FieldElement contentsField = coreClasses.getRefArrayContentField();
+        Layout.LayoutInfo info = layout.getInstanceLayoutInfo(contentsField.getEnclosingType());
 
-        CompoundType literalCT = arrayLiteralType(contentsField, array.length);
+        Memory memory = value.getMemory();
+        int length = memory.load32(info.getMember(coreClasses.getArrayLengthField()).getOffset(), MemoryAtomicityMode.UNORDERED);
+        CompoundType literalCT = arrayLiteralType(contentsField, length);
+
+        List<Literal> elements = new ArrayList<>(length);
+        for (int i=0; i<length; i++) {
+            VmObject e = memory.loadRef(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED);
+            if (e == null) {
+                elements.add(lf.zeroInitializerLiteralOfType(at.getElementType()));
+            } else {
+                Data elem = serializeVmObject(e);
+                elements.add(lf.bitcastLiteral(lf.literalOfSymbol(elem.getName(), elem.getType().getPointer().asCollected()), jlo.getClassType().getReference()));
+            }
+        }
+
         Literal al = lf.literalOf(literalCT, Map.of(
             literalCT.getMember(0), lf.literalOf(contentsField.getEnclosingType().load().getTypeId()),
-            literalCT.getMember(1), lf.literalOf(array.length),
-            literalCT.getMember(2), lf.literalOf(ctxt.getTypeSystem().getUnsignedInteger8Type(), dimensions),
-            literalCT.getMember(3), lf.literalOf(leafLTD.getTypeId()),
-            literalCT.getMember(4), ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(jlo.getClassType().getReference(), array.length), elements)
+            literalCT.getMember(1), lf.literalOf(length),
+            literalCT.getMember(2), lf.literalOf(ctxt.getTypeSystem().getUnsignedInteger8Type(), at.getDimensionCount()),
+            literalCT.getMember(3), lf.literalOf(at.getLeafElementType().getDefinition().load().getTypeId()),
+            literalCT.getMember(4), ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getArrayType(jlo.getClassType().getReference(), length), elements)
         ));
 
         return defineData(nextLiteralName(), al);
+    }
+
+    private Data serializePrimArray(PrimitiveArrayObjectType at, VmArray value) {
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        TypeSystem ts = ctxt.getTypeSystem();
+        FieldElement contentsField = coreClasses.getArrayContentField(at);
+        Layout.LayoutInfo info = layout.getInstanceLayoutInfo(contentsField.getEnclosingType());
+
+        Memory memory = value.getMemory();
+        int length = memory.load32(info.getMember(coreClasses.getArrayLengthField()).getOffset(), MemoryAtomicityMode.UNORDERED);
+        CompoundType literalCT = arrayLiteralType(contentsField, length);
+
+        Literal arrayContentsLiteral;
+        if (contentsField.equals(coreClasses.getByteArrayContentField())) {
+            byte[] contents = new byte[length];
+            for (int i=0; i<length; i++) {
+                contents[i] = (byte)memory.load8(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED);
+            }
+            arrayContentsLiteral = lf.literalOf(ctxt.getTypeSystem().getArrayType(at.getElementType(), length), contents);
+        } else {
+            List<Literal> elements = new ArrayList<>(length);
+            if (contentsField.equals(coreClasses.getBooleanArrayContentField())) {
+                for (int i=0; i<length; i++) {
+                    elements.add(lf.literalOf(memory.load8(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED) > 0));
+                }
+            } else if (contentsField.equals(coreClasses.getShortArrayContentField())) {
+                for (int i=0; i<length; i++) {
+                    elements.add(lf.literalOf(ts.getSignedInteger16Type(), memory.load16(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED)));
+                }
+            } else if (contentsField.equals(coreClasses.getCharArrayContentField())) {
+                for (int i=0; i<length; i++) {
+                    elements.add(lf.literalOf(ts.getUnsignedInteger16Type(), memory.load16(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED)));
+                }
+            } else if (contentsField.equals(coreClasses.getIntArrayContentField())) {
+                for (int i=0; i<length; i++) {
+                    elements.add(lf.literalOf(ts.getSignedInteger32Type(), memory.load32(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED)));
+                }
+            } else if (contentsField.equals(coreClasses.getLongArrayContentField())) {
+                for (int i=0; i<length; i++) {
+                    elements.add(lf.literalOf(ts.getSignedInteger64Type(), memory.load64(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED)));
+                }
+            } else if (contentsField.equals(coreClasses.getFloatArrayContentField())) {
+                for (int i=0; i<length; i++) {
+                    elements.add(lf.literalOf(ts.getFloat32Type(), memory.loadFloat(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED)));
+                }
+            } else {
+                Assert.assertTrue((contentsField.equals(coreClasses.getDoubleArrayContentField())));
+                for (int i=0; i<length; i++) {
+                    elements.add(lf.literalOf(ts.getFloat64Type(), memory.loadDouble(value.getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED)));
+                }
+            }
+            arrayContentsLiteral = lf.literalOf(ctxt.getTypeSystem().getArrayType(at.getElementType(), length), elements);
+        }
+
+        Literal arrayLiteral = lf.literalOf(literalCT, Map.of(
+            literalCT.getMember(0), lf.literalOf(contentsField.getEnclosingType().load().getTypeId()),
+            literalCT.getMember(1), lf.literalOf(length),
+            literalCT.getMember(2), arrayContentsLiteral
+        ));
+
+        return defineData(nextLiteralName(), arrayLiteral);
     }
 }

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
@@ -6,6 +6,7 @@ import org.qbicc.graph.Node;
 import org.qbicc.graph.NodeVisitor;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.SymbolLiteral;
 import org.qbicc.interpreter.Vm;
@@ -34,6 +35,16 @@ public class ObjectLiteralSerializingVisitor implements NodeVisitor.Delegating<N
     public Value visit(final Node.Copier param, final StringLiteral node) {
         VmString vString = ctxt.getVm().intern(node.getValue());
         Data literal = BuildtimeHeap.get(ctxt).serializeVmObject(vString);
+
+        Section section = ctxt.getImplicitSection(param.getBlockBuilder().getRootElement());
+        section.declareData(null, literal.getName(), literal.getType()).setAddrspace(1);
+
+        SymbolLiteral refToLiteral = ctxt.getLiteralFactory().literalOfSymbol(literal.getName(), literal.getType().getPointer().asCollected());
+        return param.getBlockBuilder().notNull(ctxt.getLiteralFactory().bitcastLiteral(refToLiteral, node.getType()));
+    }
+
+    public Value visit(final Node.Copier param, final ObjectLiteral node) {
+        Data literal = BuildtimeHeap.get(ctxt).serializeVmObject(node.getValue());
 
         Section section = ctxt.getImplicitSection(param.getBlockBuilder().getRootElement());
         section.declareData(null, literal.getName(), literal.getType()).setAddrspace(1);

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
@@ -8,6 +8,8 @@ import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.SymbolLiteral;
+import org.qbicc.interpreter.Vm;
+import org.qbicc.interpreter.VmString;
 import org.qbicc.object.Data;
 import org.qbicc.object.Section;
 
@@ -30,7 +32,8 @@ public class ObjectLiteralSerializingVisitor implements NodeVisitor.Delegating<N
     }
 
     public Value visit(final Node.Copier param, final StringLiteral node) {
-        Data literal = BuildtimeHeap.get(ctxt).serializeStringLiteral(node.getValue());
+        VmString vString = ctxt.getVm().intern(node.getValue());
+        Data literal = BuildtimeHeap.get(ctxt).serializeVmObject(vString);
 
         Section section = ctxt.getImplicitSection(param.getBlockBuilder().getRootElement());
         section.declareData(null, literal.getName(), literal.getType()).setAddrspace(1);


### PR DESCRIPTION
Support serialization of VmObject instances to the initial heap.
Currently being used to serialize String literals and java.lang.Class
instances.  Should support arbitrary VmObject graphs as soon as
we manage to get them all the way to the backend.