### PR TITLE
Serialize interpreter heap

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/VmClass.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmClass.java
@@ -2,9 +2,11 @@ package org.qbicc.interpreter;
 
 import java.util.List;
 
+import org.qbicc.graph.literal.Literal;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.FieldElement;
 
 /**
  *
@@ -28,4 +30,6 @@ public interface VmClass extends VmObject {
     ObjectType getInstanceObjectType();
 
     ClassObjectType getInstanceObjectTypeId();
+
+    Literal getValueForStaticField(FieldElement field);
 }

--- a/compiler/src/main/java/org/qbicc/interpreter/VmPrimitiveClass.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmPrimitiveClass.java
@@ -1,0 +1,4 @@
+package org.qbicc.interpreter;
+
+public interface VmPrimitiveClass extends VmClass {
+}

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
@@ -3,6 +3,7 @@ package org.qbicc.type.definition;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import org.qbicc.graph.Value;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.InterfaceObjectType;
@@ -143,6 +144,18 @@ public interface LoadedTypeDefinition extends DefinedTypeDefinition {
     }
 
     void injectField(FieldElement field);
+
+    /**
+     * Return the initial value for the given static field.
+     * This value will be either derived from build-time interpretation of
+     * class initializers, or if build-time interpretation was not done for
+     * this class from any Constant attributes found in the classfile.
+     * If the field was not initialized in any of these ways this method will return null.
+     *
+     * @param field the static field whose initial value is desired.
+     * @return The initial value of the field, or null if there is no non-default initial value.
+     */
+    Value getInitialValue(FieldElement field);
 
     MethodElement getMethod(int index);
 

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import io.smallrye.common.constraint.Assert;
+import org.qbicc.graph.Value;
 import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.type.InterfaceObjectType;
@@ -172,6 +173,10 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
             throw new IllegalArgumentException("Injected fields must be unresolvable");
         }
         fields.add(field);
+    }
+
+    public Value getInitialValue(FieldElement field) {
+        return vmClass == null ? field.getInitialValue() : vmClass.getValueForStaticField(field);
     }
 
     public int getMethodCount() {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -140,7 +140,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
             FieldElement field = typeDefinition.getField(i);
             if (field.isStatic()) {
                 Literal initValue = field.getInitialValue();
-                if (initValue instanceof ZeroInitializerLiteral) {
+                if (initValue == null || initValue instanceof ZeroInitializerLiteral) {
                     // Nothing to do;  memory starts zeroed.
                     continue;
                 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -11,22 +11,31 @@ import io.smallrye.common.constraint.Assert;
 import org.qbicc.context.ClassContext;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.literal.FloatLiteral;
+import org.qbicc.graph.literal.IntegerLiteral;
+import org.qbicc.graph.literal.Literal;
+import org.qbicc.graph.literal.StringLiteral;
+import org.qbicc.graph.literal.ZeroInitializerLiteral;
 import org.qbicc.interpreter.Thrown;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmClassLoader;
 import org.qbicc.interpreter.VmInvokable;
 import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.VmString;
 import org.qbicc.interpreter.VmThrowable;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.type.ClassObjectType;
+import org.qbicc.type.CompoundType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 import org.qbicc.type.descriptor.MethodDescriptor;
+import org.qbicc.type.descriptor.TypeDescriptor;
 
 class VmClassImpl extends VmObjectImpl implements VmClass {
     private static final VarHandle interfacesHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "interfaces", VarHandle.class, VmClassImpl.class, List.class);
@@ -93,6 +102,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         layoutInfo = typeDefinition.isInterface() ? null : Layout.getForInterpreter(ctxt).getInstanceLayoutInfo(typeDefinition);
         staticLayoutInfo = Layout.getForInterpreter(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
         staticMemory = staticLayoutInfo == null ? vmImpl.allocate(0) : vmImpl.allocate((int) staticLayoutInfo.getCompoundType().getSize());
+        initializeConstantStaticFields();
     }
 
     VmClassImpl(VmImpl vmImpl, VmClassClassImpl classClass, @SuppressWarnings("unused") int primitivesOnly) {
@@ -121,6 +131,49 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         staticLayoutInfo = Layout.getForInterpreter(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
         staticMemory = staticLayoutInfo == null ? vm.allocate(0) : vm.allocate((int) staticLayoutInfo.getCompoundType().getSize());
         superClass = new VmClassImpl(vm, (VmClassClassImpl) this, classContext.findDefinedType("java/lang/Object").load(), null);
+        initializeConstantStaticFields();
+    }
+
+    void initializeConstantStaticFields() {
+        int cnt = typeDefinition.getFieldCount();
+        for (int i = 0; i < cnt; i ++) {
+            FieldElement field = typeDefinition.getField(i);
+            if (field.isStatic()) {
+                Literal initValue = field.getInitialValue();
+                if (initValue instanceof ZeroInitializerLiteral) {
+                    // Nothing to do;  memory starts zeroed.
+                    continue;
+                }
+                CompoundType.Member member = staticLayoutInfo.getMember(field);
+                if (initValue instanceof IntegerLiteral) {
+                    IntegerLiteral val = (IntegerLiteral) initValue;
+                    if (val.getType().getSize() == 1) {
+                        staticMemory.store8(member.getOffset(), val.byteValue(), MemoryAtomicityMode.UNORDERED);
+                    } else if (val.getType().getSize() == 2) {
+                        staticMemory.store16(member.getOffset(), val.shortValue(), MemoryAtomicityMode.UNORDERED);
+                    } else if (val.getType().getSize() == 4) {
+                        staticMemory.store32(member.getOffset(), val.intValue(), MemoryAtomicityMode.UNORDERED);
+                    } else {
+                        staticMemory.store64(member.getOffset(), val.longValue(), MemoryAtomicityMode.UNORDERED);
+                    }
+                } else if (initValue instanceof FloatLiteral) {
+                    FloatLiteral val = (FloatLiteral) initValue;
+                    if (val.getType().getSize() == 4) {
+                        staticMemory.store32(member.getOffset(), val.floatValue(), MemoryAtomicityMode.UNORDERED);
+                    } else {
+                        staticMemory.store64(member.getOffset(), val.doubleValue(), MemoryAtomicityMode.UNORDERED);
+                    }
+                } else if (initValue instanceof StringLiteral) {
+                    if (vm.bootstrapComplete) {
+                        VmString sv = vm.intern(((StringLiteral) initValue).getValue());
+                        staticMemory.storeRef(member.getOffset(), sv, MemoryAtomicityMode.UNORDERED);
+                    }
+                } else {
+                    // CONSTANT_Class, CONSTANT_MethodHandle, CONSTANT_MethodType
+                    vm.getCompilationContext().warning("Did not properly initialize interpreter memory for constant static field "+field);
+                }
+            }
+        }
     }
 
     VmArrayClassImpl getArrayClass() {
@@ -242,6 +295,42 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
 
     Layout.LayoutInfo getLayoutInfo() {
         return layoutInfo;
+    }
+
+    public Literal getValueForStaticField(FieldElement field) {
+        if (staticLayoutInfo == null || staticLayoutInfo.getMember(field) == null) {
+            // TODO: This should become a hard error at some point, but make it a warning while we are bringing interpreter online.
+            //       It seems to mostly be happening with callsites associated with invokedynamic.
+            vm.getCompilationContext().warning("No interpreter layout for static "+field+". Using zero initializer as value");
+            return vm.getCompilationContext().getLiteralFactory().zeroInitializerLiteralOfType(field.getType());
+        }
+        int offset = staticLayoutInfo.getMember(field).getOffset();
+        TypeDescriptor desc = field.getTypeDescriptor();
+        if (desc.equals(BaseTypeDescriptor.Z)) {
+            int val = staticMemory.load8(offset, MemoryAtomicityMode.UNORDERED);
+            return vm.getCompilationContext().getLiteralFactory().literalOf(val != 0);
+        } else if (desc.equals(BaseTypeDescriptor.B)) {
+            return vm.getCompilationContext().getLiteralFactory().literalOf((byte) staticMemory.load8(offset, MemoryAtomicityMode.UNORDERED));
+        } else if (desc.equals(BaseTypeDescriptor.S)) {
+            return vm.getCompilationContext().getLiteralFactory().literalOf((short) staticMemory.load16(offset, MemoryAtomicityMode.UNORDERED));
+        } else if (desc.equals(BaseTypeDescriptor.C)) {
+            return vm.getCompilationContext().getLiteralFactory().literalOf((char) staticMemory.load16(offset, MemoryAtomicityMode.UNORDERED));
+        } else if (desc.equals(BaseTypeDescriptor.I)) {
+            return vm.getCompilationContext().getLiteralFactory().literalOf(staticMemory.load32(offset, MemoryAtomicityMode.UNORDERED));
+        } else if (desc.equals(BaseTypeDescriptor.F)) {
+            return vm.getCompilationContext().getLiteralFactory().literalOf(staticMemory.loadFloat(offset, MemoryAtomicityMode.UNORDERED));
+        } else if (desc.equals(BaseTypeDescriptor.J)) {
+            return vm.getCompilationContext().getLiteralFactory().literalOf(staticMemory.load64(offset, MemoryAtomicityMode.UNORDERED));
+        } else if (desc.equals(BaseTypeDescriptor.D)) {
+            return vm.getCompilationContext().getLiteralFactory().literalOf(staticMemory.loadDouble(offset, MemoryAtomicityMode.UNORDERED));
+        } else {
+            VmObject value = staticMemory.loadRef(offset, MemoryAtomicityMode.UNORDERED);
+            if (value == null) {
+                return vm.getCompilationContext().getLiteralFactory().zeroInitializerLiteralOfType(field.getType());
+            } else {
+                return vm.getCompilationContext().getLiteralFactory().literalOf(value);
+            }
+        }
     }
 
     void initialize(VmThreadImpl thread) throws Thrown {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -37,6 +37,8 @@ public final class VmImpl implements Vm {
     final boolean wideRefs;
     final MemoryImpl emptyMemory;
 
+    boolean bootstrapComplete;
+
     // core classes
     final VmClassImpl objectClass;
     final VmClassClassImpl classClass;
@@ -94,6 +96,7 @@ public final class VmImpl implements Vm {
 
     VmImpl(final CompilationContext ctxt) {
         this.ctxt = ctxt;
+        bootstrapComplete = false;
         // force all fields to be populated so the injections are visible to us
         CoreClasses coreClasses = CoreClasses.get(ctxt);
         ctxt.getExceptionField();
@@ -266,6 +269,9 @@ public final class VmImpl implements Vm {
             }
             return clazz;
         });
+
+        bootstrapComplete = true;
+        throwableClass.initializeConstantStaticFields(); // Has constant String fields that can't be initialized when we first process the class
     }
 
     VmClassLoaderImpl getBootstrapClassLoader() {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmPrimitiveClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmPrimitiveClassImpl.java
@@ -1,12 +1,13 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.VmPrimitiveClass;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 
 /**
  *
  */
-class VmPrimitiveClassImpl extends VmClassImpl {
+class VmPrimitiveClassImpl extends VmClassImpl implements VmPrimitiveClass {
     private final LoadedTypeDefinition arrayTypeDefinition;
     private final String simpleName;
 

--- a/plugins/lowering/pom.xml
+++ b/plugins/lowering/pom.xml
@@ -33,6 +33,10 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-layout</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-serialization</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -106,7 +106,7 @@ public class Lowering {
             }
         }
         if (initialValue instanceof ObjectLiteral) {
-            Data objLit = BuildtimeHeap.get(ctxt).serializeVmObject(((ObjectLiteral) initialValue).getValue());
+            SymbolLiteral objLit = BuildtimeHeap.get(ctxt).serializeVmObject(((ObjectLiteral) initialValue).getValue());
             section.declareData(null, objLit.getName(), objLit.getType()).setAddrspace(1);
             SymbolLiteral refToLiteral = ctxt.getLiteralFactory().literalOfSymbol(objLit.getName(), objLit.getType().getPointer().asCollected());
             initialValue = ctxt.getLiteralFactory().bitcastLiteral(refToLiteral, ((ObjectLiteral) initialValue).getType());

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -10,12 +10,16 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.OffsetOfField;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.BooleanLiteral;
+import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.graph.literal.SymbolLiteral;
 import org.qbicc.graph.literal.ZeroInitializerLiteral;
+import org.qbicc.interpreter.Memory;
 import org.qbicc.object.Data;
 import org.qbicc.object.Linkage;
 import org.qbicc.object.Section;
 import org.qbicc.plugin.constants.Constants;
 import org.qbicc.plugin.layout.Layout;
+import org.qbicc.plugin.serialization.BuildtimeHeap;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.ReferenceType;
@@ -61,7 +65,7 @@ public class Lowering {
         builder.setEnclosingType(enclosingType);
         final String sectionName;
         if (fieldElement.getType() instanceof ReferenceType) {
-            sectionName = GLOBAL_REFERENCES;
+            sectionName = CompilationContext.IMPLICIT_SECTION_NAME; // TODO: GLOBAL_REFERENCES;
         } else {
             sectionName = CompilationContext.IMPLICIT_SECTION_NAME;
         }
@@ -73,20 +77,12 @@ public class Lowering {
         }
 
         Section section = ctxt.getOrAddProgramModule(enclosingType).getOrAddSection(sectionName);
-        Value initialValue = fieldElement.getInitialValue();
-        Linkage linkage = Linkage.EXTERNAL;
-        if (fieldType instanceof ReferenceType) {
-            // Reference-typed field values must always be deserialized.
-            linkage = Linkage.COMMON;
+        Value initialValue = enclosingType.load().getInitialValue(fieldElement);
+        if (initialValue == null) {
+            initialValue = Constants.get(ctxt).getConstantValue(fieldElement);
+        }
+        if (initialValue == null) {
             initialValue = ctxt.getLiteralFactory().zeroInitializerLiteralOfType(varType);
-        } else {
-            if (initialValue == null || initialValue instanceof ZeroInitializerLiteral) {
-                initialValue = Constants.get(ctxt).getConstantValue(fieldElement);
-                if (initialValue == null || initialValue instanceof ZeroInitializerLiteral) {
-                    linkage = Linkage.COMMON;
-                    initialValue = ctxt.getLiteralFactory().zeroInitializerLiteralOfType(varType);
-                }
-            }
         }
         if (initialValue instanceof OffsetOfField) {
             // special case: the field holds an offset which is really an integer
@@ -109,8 +105,15 @@ public class Lowering {
                 throw new IllegalArgumentException("Cannot initialize boolean field");
             }
         }
+        if (initialValue instanceof ObjectLiteral) {
+            Data objLit = BuildtimeHeap.get(ctxt).serializeVmObject(((ObjectLiteral) initialValue).getValue());
+            section.declareData(null, objLit.getName(), objLit.getType()).setAddrspace(1);
+            SymbolLiteral refToLiteral = ctxt.getLiteralFactory().literalOfSymbol(objLit.getName(), objLit.getType().getPointer().asCollected());
+            initialValue = ctxt.getLiteralFactory().bitcastLiteral(refToLiteral, ((ObjectLiteral) initialValue).getType());
+        }
+
         final Data data = section.addData(fieldElement, itemName, initialValue);
-        data.setLinkage(linkage);
+        data.setLinkage(initialValue instanceof ZeroInitializerLiteral ? Linkage.COMMON : Linkage.EXTERNAL);
         data.setDsoLocal();
         return global;
     }

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
@@ -48,14 +48,14 @@ public class ClassObjectSerializer implements Consumer<CompilationContext> {
         Literal[] rootTable = new Literal[tables.get_number_of_typeids()];
         Arrays.fill(rootTable, ctxt.getLiteralFactory().zeroInitializerLiteralOfType(jlcRef));
         rtaInfo.visitInitializedTypes( ltd -> {
-            Data cls = bth.serializeClassObject(ltd);
+            SymbolLiteral cls = bth.serializeClassObject(ltd);
             section.declareData(null, cls.getName(), cls.getType()).setAddrspace(1);
             SymbolLiteral refToClass = ctxt.getLiteralFactory().literalOfSymbol(cls.getName(), cls.getType().getPointer().asCollected());
             rootTable[ltd.getTypeId()] = ctxt.getLiteralFactory().bitcastLiteral(refToClass, jlcRef);
         });
 
         Primitive.forEach(type -> {
-            Data cls = bth.serializeClassObject(type);
+            SymbolLiteral cls = bth.serializeClassObject(type);
             section.declareData(null, cls.getName(), cls.getType()).setAddrspace(1);
             SymbolLiteral refToClass = ctxt.getLiteralFactory().literalOfSymbol(cls.getName(), cls.getType().getPointer().asCollected());
             rootTable[type.getTypeId()] = ctxt.getLiteralFactory().bitcastLiteral(refToClass, jlcRef);

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
@@ -34,7 +34,7 @@ public class ObjectLiteralSerializingVisitor implements NodeVisitor.Delegating<N
 
     public Value visit(final Node.Copier param, final StringLiteral node) {
         VmString vString = ctxt.getVm().intern(node.getValue());
-        Data literal = BuildtimeHeap.get(ctxt).serializeVmObject(vString);
+        SymbolLiteral literal = BuildtimeHeap.get(ctxt).serializeVmObject(vString);
 
         Section section = ctxt.getImplicitSection(param.getBlockBuilder().getRootElement());
         section.declareData(null, literal.getName(), literal.getType()).setAddrspace(1);
@@ -44,7 +44,7 @@ public class ObjectLiteralSerializingVisitor implements NodeVisitor.Delegating<N
     }
 
     public Value visit(final Node.Copier param, final ObjectLiteral node) {
-        Data literal = BuildtimeHeap.get(ctxt).serializeVmObject(node.getValue());
+        SymbolLiteral literal = BuildtimeHeap.get(ctxt).serializeVmObject(node.getValue());
 
         Section section = ctxt.getImplicitSection(param.getBlockBuilder().getRootElement());
         section.declareData(null, literal.getName(), literal.getType()).setAddrspace(1);


### PR DESCRIPTION
Serialize the values that the interpreter has computed for static fields.
Fix several bugs in VMBuildTimeHeap exposed by actually serializing interesting object graphs.
