### PR TITLE
Improve reachability analysis of interpreter heap

### DIFF
--- a/interpreter/pom.xml
+++ b/interpreter/pom.xml
@@ -32,11 +32,6 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-reachability</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-constraint</artifactId>
         </dependency>

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -130,7 +130,6 @@ import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmThrowable;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
-import org.qbicc.plugin.reachability.RTAInfo;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
@@ -1479,10 +1478,6 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         for (int i = 0; i < dimensions.length; i++) {
             dimensions[i] = unboxInt(dimList.get(i));
         }
-        if (node.getArrayType() instanceof ReferenceArrayObjectType) {
-            RTAInfo info = RTAInfo.get(node.getElement().getEnclosingType().getContext().getCompilationContext());
-            info.logBuildTimeInstantiatedArrayElement(((ReferenceArrayObjectType)node.getArrayType()).getLeafElementType());
-        }
         return multiNewArray(thread, node.getArrayType(), 0, dimensions);
     }
 
@@ -1503,17 +1498,11 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     public Object visit(VmThreadImpl thread, New node) {
         DefinedTypeDefinition enclosingType = node.getElement().getEnclosingType();
         VmClassLoaderImpl cl = thread.vm.getClassLoaderForContext(enclosingType.getContext());
-        RTAInfo info = RTAInfo.get(enclosingType.getContext().getCompilationContext());
-        info.logBuildTimeInstantiatedClass(node.getClassObjectType().getDefinition());
         return cl.loadClass(node.getClassObjectType().getDefinition().getInternalName()).newInstance();
     }
 
     @Override
     public Object visit(VmThreadImpl thread, NewArray node) {
-        if (node.getArrayType() instanceof ReferenceArrayObjectType) {
-            RTAInfo info = RTAInfo.get(node.getElement().getEnclosingType().getContext().getCompilationContext());
-            info.logBuildTimeInstantiatedArrayElement(((ReferenceArrayObjectType)node.getArrayType()).getLeafElementType());
-        }
         return newArray(thread, node.getArrayType(), unboxInt(node.getSize()));
     }
 

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -13,7 +13,6 @@ import org.qbicc.graph.literal.BooleanLiteral;
 import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.graph.literal.SymbolLiteral;
 import org.qbicc.graph.literal.ZeroInitializerLiteral;
-import org.qbicc.interpreter.Memory;
 import org.qbicc.object.Data;
 import org.qbicc.object.Linkage;
 import org.qbicc.object.Section;

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -1,0 +1,103 @@
+package org.qbicc.plugin.reachability;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmArray;
+import org.qbicc.interpreter.VmClass;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.VmString;
+import org.qbicc.plugin.coreclasses.CoreClasses;
+import org.qbicc.plugin.layout.Layout;
+import org.qbicc.type.ClassObjectType;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.PhysicalObjectType;
+import org.qbicc.type.ReferenceArrayObjectType;
+import org.qbicc.type.ReferenceType;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.FieldElement;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * This class supports reachability analysis by providing the capability of
+ * tracing the build-time instantiated heap starting from the static fields
+ * of a reachable LoadedTypeDefinition to identify reachable instantiated types.
+ * It internally tracks which objects have already been visited and avoids re-visiting
+ * them, since revisiting an object cannot make additional types reachable.
+ * It also does skips over instance fields that cannot add reachable types (primitives,
+ * java.lang.Class instances, and java.lang.String instances).
+ */
+class BuildtimeHeapAnalyzer {
+    private final Map<VmObject, Boolean> visited = Collections.synchronizedMap(new IdentityHashMap<>());
+
+    void clear() {
+        visited.clear();
+    }
+
+    /**
+     * Trace the build-time heap starting from the statics of the given type
+     * to identify instantiated types.
+     * @param ltd Type whose static fields are the roots for this trace
+     */
+    void traceHeap(CompilationContext ctxt, RTAInfo rtaInfo, LoadedTypeDefinition ltd) {
+        ArrayDeque<VmObject> worklist = new ArrayDeque<>();
+
+        int fieldCount = ltd.getFieldCount();
+        for (int i=0; i<fieldCount; i++) {
+            FieldElement f = ltd.getField(i);
+            if (f.isStatic() && f.getType() instanceof ReferenceType) {
+                Value v = ltd.getInitialValue(f);
+                if (v instanceof ObjectLiteral) {
+                    VmObject vo = ((ObjectLiteral) v).getValue();
+                    if (!visited.containsKey(vo)) {
+                        worklist.add(vo);
+                        visited.put(vo, Boolean.TRUE);
+                    }
+                }
+            }
+        }
+
+        Layout interpreterLayout = Layout.getForInterpreter(ctxt);
+        CoreClasses coreClasses = CoreClasses.get(ctxt);
+        while (!worklist.isEmpty()) {
+            VmObject cur = worklist.pop();
+
+            PhysicalObjectType ot = cur.getObjectType();
+            if (ot instanceof ClassObjectType && !(cur instanceof VmClass || cur instanceof VmString)) {
+                LoadedTypeDefinition concreteType = cur.getObjectType().getDefinition().load();
+                rtaInfo.processBuildtimeInstantiatedObjectType(concreteType, ltd);
+
+                Layout.LayoutInfo memLayout = interpreterLayout.getInstanceLayoutInfo(concreteType);
+                for (CompoundType.Member im : memLayout.getCompoundType().getMembers()) {
+                    if (im.getType() instanceof ReferenceType) {
+                        VmObject child = cur.getMemory().loadRef(im.getOffset(), MemoryAtomicityMode.UNORDERED);
+                        if (child != null && !visited.containsKey(child)) {
+                            worklist.add(child);
+                            visited.put(child, Boolean.TRUE);
+                        }
+                    }
+                }
+            } else if (ot instanceof ReferenceArrayObjectType) {
+                rtaInfo.processArrayElementType(((ReferenceArrayObjectType) ot).getLeafElementType());
+
+                FieldElement contentsField = coreClasses.getRefArrayContentField();
+                Layout.LayoutInfo info = interpreterLayout.getInstanceLayoutInfo(contentsField.getEnclosingType());
+                Memory memory = cur.getMemory();
+                int length = memory.load32(info.getMember(coreClasses.getArrayLengthField()).getOffset(), MemoryAtomicityMode.UNORDERED);
+                for (int i=0; i<length; i++) {
+                    VmObject e = memory.loadRef(((VmArray) cur).getArrayElementOffset(i), MemoryAtomicityMode.UNORDERED);
+                    if (e != null && !visited.containsKey(e)) {
+                        worklist.add(e);
+                        visited.put(e, Boolean.TRUE);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replace the conservative assumption that all types that were instantiated in the interpreter's heap are reachable with the proper optimistic algorithm that instead traces the portions of the heap that can be reached from static fields as those static fields become reachable. We will inspect each object in the interpreter heap at most once during this analysis (once an object is reachable from one static, it doesn't matter if it is also reachable from other statics).

This PR builds on top of #667.   The results seem almost too good to be true, so I decided to not incorporate this change into #667 in case I messed something up and didn't see it at first...

