### PR TITLE
add an UnsafeHandle for ref+offset handles

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -290,6 +290,8 @@ public interface BasicBlockBuilder extends Locatable {
 
     ValueHandle elementOf(ValueHandle array, Value index);
 
+    ValueHandle unsafeHandle(ValueHandle base, Value offset, ValueType outputType);
+
     ValueHandle pointerHandle(Value pointer);
 
     ValueHandle referenceHandle(Value reference);

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -123,6 +123,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().elementOf(array, index);
     }
 
+    public ValueHandle unsafeHandle(final ValueHandle base, final Value offset, final ValueType outputType) {
+        return getDelegate().unsafeHandle(base, offset, outputType);
+    }
+
     public ValueHandle pointerHandle(Value pointer) {
         return getDelegate().pointerHandle(pointer);
     }

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -861,6 +861,10 @@ public interface Node {
                 return node;
             }
 
+            public ValueHandle visit(final Copier param, final UnsafeHandle node) {
+                return param.getBlockBuilder().unsafeHandle(param.copyValueHandle(node.getBase()), param.copyValue(node.getOffset()), node.getOutputType());
+            }
+
             public Value visit(final Copier param, final Xor node) {
                 return param.getBlockBuilder().xor(param.copyValue(node.getLeftInput()), param.copyValue(node.getRightInput()));
             }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -390,6 +390,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return new ElementOf(callSite, element, line, bci, array, index);
     }
 
+    public ValueHandle unsafeHandle(ValueHandle base, Value offset, ValueType outputType) {
+        return new UnsafeHandle(callSite, element, line, bci, base, offset, outputType);
+    }
+
     public ValueHandle pointerHandle(Value pointer) {
         return new PointerHandle(callSite, element, line, bci, pointer);
     }

--- a/compiler/src/main/java/org/qbicc/graph/UnsafeHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/UnsafeHandle.java
@@ -1,0 +1,95 @@
+package org.qbicc.graph;
+
+import org.qbicc.type.PointerType;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+import java.util.Objects;
+
+/**
+ * A base + offset to be used in an Unsafe memory access.
+ */
+public class UnsafeHandle extends AbstractValueHandle {
+    private final ValueHandle base;
+    private final Value offset;
+    private final ValueType outputType;
+
+    UnsafeHandle(Node callSite, ExecutableElement element, int line, int bci, ValueHandle base, Value offset, ValueType outputType) {
+        super(callSite, element, line, bci);
+        this.base = base;
+        this.offset = offset;
+        this.outputType = outputType;
+    }
+
+    @Override
+    public boolean hasValueHandleDependency() {
+        return true;
+    }
+
+    @Override
+    public ValueHandle getValueHandle() {
+        return base;
+    }
+
+    @Override
+    public int getValueDependencyCount() {
+        return 1;
+    }
+
+    @Override
+    public Value getValueDependency(int index) throws IndexOutOfBoundsException {
+        return index == 0 ? this.offset : Util.throwIndexOutOfBounds(index);
+    }
+
+    @Override
+    public PointerType getPointerType() {
+        return outputType.getPointer();
+    }
+
+    @Override
+    public boolean isConstantLocation() {
+            return offset.isConstant() && base.isConstantLocation();
+    }
+
+    @Override
+    public boolean isValueConstant() {
+        return offset.isConstant() && base.isValueConstant();
+    }
+
+    @Override
+    public MemoryAtomicityMode getDetectedMode() {
+        return base.getDetectedMode();
+    }
+
+    public ValueHandle getBase() {
+        return base;
+    }
+
+    public Value getOffset() {
+        return offset;
+    }
+
+    public ValueType getOutputType() {
+        return outputType;
+    }
+
+    int calcHashCode() {
+        return Objects.hash(base, offset, outputType);
+    }
+
+    public boolean equals(final Object other) {
+        return other instanceof UnsafeHandle && equals((UnsafeHandle) other);
+    }
+
+    public boolean equals(final UnsafeHandle other) {
+        return this == other || other != null && base.equals(other.base) && offset.equals(other.offset) && outputType.equals(other.offset);
+    }
+
+    public <T, R> R accept(final ValueHandleVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+
+    public <T> long accept(final ValueHandleVisitorLong<T> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitor.java
@@ -72,6 +72,10 @@ public interface ValueHandleVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, UnsafeHandle node) {
+        return visitUnknown(param, node);
+    }
+
     default R visit(T param, PointerHandle node) {
         return visitUnknown(param, node);
     }
@@ -165,6 +169,11 @@ public interface ValueHandleVisitor<T, R> {
 
         @Override
         default R visit(T param, StaticMethodElementHandle node) {
+            return getDelegateValueHandleVisitor().visit(param, node);
+        }
+
+        @Override
+        default R visit(T param, UnsafeHandle node) {
             return getDelegateValueHandleVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitorLong.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitorLong.java
@@ -72,6 +72,10 @@ public interface ValueHandleVisitorLong<T> {
         return visitUnknown(param, node);
     }
 
+    default long visit(T param, UnsafeHandle node) {
+        return visitUnknown(param, node);
+    }
+
     default long visit(T param, PointerHandle node) {
         return visitUnknown(param, node);
     }
@@ -165,6 +169,11 @@ public interface ValueHandleVisitorLong<T> {
 
         @Override
         default long visit(T param, StaticMethodElementHandle node) {
+            return getDelegateValueHandleVisitor().visit(param, node);
+        }
+
+        @Override
+        default long visit(T param, UnsafeHandle node) {
             return getDelegateValueHandleVisitor().visit(param, node);
         }
 

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -117,6 +117,7 @@ import org.qbicc.graph.Truncate;
 import org.qbicc.graph.TypeIdOf;
 import org.qbicc.graph.UnaryValue;
 import org.qbicc.graph.Unreachable;
+import org.qbicc.graph.UnsafeHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueReturn;
@@ -435,6 +436,17 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
         nl(param);
         attr(param, "label", "method (static)\\n" + node.getExecutable());
         nl(param);
+        return name;
+    }
+
+    public String visit(final Appendable param, final UnsafeHandle node) {
+        String name = register(node);
+        appendTo(param, name);
+        attr(param, "label", "unsafeHandle");
+        attr(param, "fixedsize", "shape");
+        nl(param);
+        addEdge(param, node, node.getValueHandle(), EdgeType.VALUE_DEPENDENCY);
+        addEdge(param, node, node.getOffset(), EdgeType.VALUE_DEPENDENCY);
         return name;
     }
 

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
@@ -9,6 +9,7 @@ import org.qbicc.graph.InstanceFieldOf;
 import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.ReferenceHandle;
+import org.qbicc.graph.UnsafeHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueHandleVisitor;
@@ -17,6 +18,7 @@ import org.qbicc.type.ObjectType;
 import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
+import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.FieldElement;
 
@@ -158,6 +160,13 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder imp
         Layout layout = Layout.get(ctxt);
         FieldElement element = node.getVariableElement();
         return memberOf(transform(node.getValueHandle()), layout.getInstanceLayoutInfo(element.getEnclosingType()).getMember(element));
+    }
+
+    @Override
+    public ValueHandle visit(Void param, UnsafeHandle node) {
+        UnsignedIntegerType u8 = ctxt.getTypeSystem().getUnsignedInteger8Type();
+        ValueHandle valueHandle = elementOf(pointerHandle(bitCast(addressOf(node.getBase()), u8.getPointer())), node.getOffset());
+        return pointerHandle(bitCast(addressOf(valueHandle), node.getOutputType().getPointer()));
     }
 
     @Override


### PR DESCRIPTION
Keep a high-level representation of the ref+offset pointers introduced
by Unsafe during the ADD/ANALYZE phases to simplify analysis and
build-time interpretation.