### PR TITLE
Introduce support for per-phase attachments

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/DiagnosticContext.java
+++ b/compiler/src/main/java/org/qbicc/context/DiagnosticContext.java
@@ -32,6 +32,39 @@ public interface DiagnosticContext {
 
     <T> T computeAttachment(AttachmentKey<T> key, Function<T, T> function);
 
+    <T> T getAttachment(PhaseAttachmentKey<T> key);
+
+    <T> T getAttachmentOrDefault(PhaseAttachmentKey<T> key, T defVal);
+
+    <T> T putAttachment(PhaseAttachmentKey<T> key, T value);
+
+    <T> T putAttachmentIfAbsent(PhaseAttachmentKey<T> key, T value);
+
+    <T> T removeAttachment(PhaseAttachmentKey<T> key);
+
+    <T> boolean removeAttachment(PhaseAttachmentKey<T> key, T expect);
+
+    <T> T replaceAttachment(PhaseAttachmentKey<T> key, T update);
+
+    <T> boolean replaceAttachment(PhaseAttachmentKey<T> key, T expect, T update);
+
+    <T> T computeAttachmentIfAbsent(PhaseAttachmentKey<T> key, Supplier<T> function);
+
+    <T> T computeAttachmentIfPresent(PhaseAttachmentKey<T> key, Function<T, T> function);
+
+    <T> T computeAttachment(PhaseAttachmentKey<T> key, Function<T, T> function);
+
+    void cyclePhaseAttachments();
+
+    /**
+     * Get an attachment from the previous phase.
+     *
+     * @param key the attachment key
+     * @param <T> the attachment type
+     * @return the attachment, or {@code null} if it was not created in the previous phase
+     */
+    <T> T getPreviousPhaseAttachment(final PhaseAttachmentKey<T> key);
+
     int errors();
 
     int warnings();

--- a/compiler/src/main/java/org/qbicc/context/PhaseAttachmentKey.java
+++ b/compiler/src/main/java/org/qbicc/context/PhaseAttachmentKey.java
@@ -1,0 +1,8 @@
+package org.qbicc.context;
+
+/**
+ * An attachment key for per-phase attachments.
+ */
+public final class PhaseAttachmentKey<T> {
+    public PhaseAttachmentKey() {}
+}

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -15,6 +15,7 @@ import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.context.Diagnostic;
 import org.qbicc.context.Location;
+import org.qbicc.context.PhaseAttachmentKey;
 import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.Node;
@@ -218,6 +219,70 @@ public class TestClassContext implements ClassContext {
 
         public <T> T computeAttachment(final AttachmentKey<T> key, final java.util.function.Function<T, T> function) {
             return (T) attachments.compute(key, (k, o) -> function.apply((T) o));
+        }
+
+        @Override
+        public <T> T getAttachment(PhaseAttachmentKey<T> key) {
+            return null;
+        }
+
+        @Override
+        public <T> T getAttachmentOrDefault(PhaseAttachmentKey<T> key, T defVal) {
+            return null;
+        }
+
+        @Override
+        public <T> T putAttachment(PhaseAttachmentKey<T> key, T value) {
+            return null;
+        }
+
+        @Override
+        public <T> T putAttachmentIfAbsent(PhaseAttachmentKey<T> key, T value) {
+            return null;
+        }
+
+        @Override
+        public <T> T removeAttachment(PhaseAttachmentKey<T> key) {
+            return null;
+        }
+
+        @Override
+        public <T> boolean removeAttachment(PhaseAttachmentKey<T> key, T expect) {
+            return false;
+        }
+
+        @Override
+        public <T> T replaceAttachment(PhaseAttachmentKey<T> key, T update) {
+            return null;
+        }
+
+        @Override
+        public <T> boolean replaceAttachment(PhaseAttachmentKey<T> key, T expect, T update) {
+            return false;
+        }
+
+        @Override
+        public <T> T computeAttachmentIfAbsent(PhaseAttachmentKey<T> key, Supplier<T> function) {
+            return null;
+        }
+
+        @Override
+        public <T> T computeAttachmentIfPresent(PhaseAttachmentKey<T> key, java.util.function.Function<T, T> function) {
+            return null;
+        }
+
+        @Override
+        public <T> T computeAttachment(PhaseAttachmentKey<T> key, java.util.function.Function<T, T> function) {
+            return null;
+        }
+
+        @Override
+        public <T> T getPreviousPhaseAttachment(PhaseAttachmentKey<T> key) {
+            return null;
+        }
+
+        @Override
+        public void cyclePhaseAttachments() {
         }
 
         public int errors() {

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -21,6 +21,7 @@ import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.context.Diagnostic;
 import org.qbicc.context.Location;
+import org.qbicc.context.PhaseAttachmentKey;
 import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.Node;
@@ -144,6 +145,71 @@ final class CompilationContextImpl implements CompilationContext {
 
     public <T> T computeAttachment(final AttachmentKey<T> key, final Function<T, T> function) {
         return baseDiagnosticContext.computeAttachment(key, function);
+    }
+
+    @Override
+    public <T> T getAttachment(PhaseAttachmentKey<T> key) {
+        return baseDiagnosticContext.getAttachment(key);
+    }
+
+    @Override
+    public <T> T getAttachmentOrDefault(PhaseAttachmentKey<T> key, T defVal) {
+        return baseDiagnosticContext.getAttachmentOrDefault(key, defVal);
+    }
+
+    @Override
+    public <T> T putAttachment(PhaseAttachmentKey<T> key, T value) {
+        return baseDiagnosticContext.putAttachment(key, value);
+    }
+
+    @Override
+    public <T> T putAttachmentIfAbsent(PhaseAttachmentKey<T> key, T value) {
+        return baseDiagnosticContext.putAttachmentIfAbsent(key, value);
+    }
+
+    @Override
+    public <T> T removeAttachment(PhaseAttachmentKey<T> key) {
+        return baseDiagnosticContext.removeAttachment(key);
+    }
+
+    @Override
+    public <T> boolean removeAttachment(PhaseAttachmentKey<T> key, T expect) {
+        return baseDiagnosticContext.removeAttachment(key, expect);
+    }
+
+    @Override
+    public <T> T replaceAttachment(PhaseAttachmentKey<T> key, T update) {
+        return baseDiagnosticContext.replaceAttachment(key, update);
+    }
+
+    @Override
+    public <T> boolean replaceAttachment(PhaseAttachmentKey<T> key, T expect, T update) {
+        return baseDiagnosticContext.replaceAttachment(key, expect, update);
+    }
+
+    @Override
+    public <T> T computeAttachmentIfAbsent(PhaseAttachmentKey<T> key, Supplier<T> function) {
+        return baseDiagnosticContext.computeAttachmentIfAbsent(key, function);
+    }
+
+    @Override
+    public <T> T computeAttachmentIfPresent(PhaseAttachmentKey<T> key, Function<T, T> function) {
+        return baseDiagnosticContext.computeAttachmentIfPresent(key, function);
+    }
+
+    @Override
+    public <T> T computeAttachment(PhaseAttachmentKey<T> key, Function<T, T> function) {
+        return baseDiagnosticContext.computeAttachment(key, function);
+    }
+
+    @Override
+    public void cyclePhaseAttachments() {
+        baseDiagnosticContext.cyclePhaseAttachments();
+    }
+
+    @Override
+    public <T> T getPreviousPhaseAttachment(PhaseAttachmentKey<T> key) {
+        return baseDiagnosticContext.getPreviousPhaseAttachment(key);
     }
 
     public int errors() {

--- a/driver/src/main/java/org/qbicc/driver/Driver.java
+++ b/driver/src/main/java/org/qbicc/driver/Driver.java
@@ -420,6 +420,7 @@ public class Driver implements Closeable {
         }
 
         compilationContext.clearEnqueuedSet();
+        compilationContext.cyclePhaseAttachments();
 
         // ANALYZE phase
 
@@ -484,6 +485,7 @@ public class Driver implements Closeable {
         }
 
         compilationContext.clearEnqueuedSet();
+        compilationContext.cyclePhaseAttachments();
 
         // LOWER phase
 
@@ -546,6 +548,8 @@ public class Driver implements Closeable {
                 return false;
             }
         }
+
+        compilationContext.cyclePhaseAttachments();
 
         // GENERATE phase
 


### PR DESCRIPTION
This will allow us to repeat certain data collection operations in each phase, for example tracking read & written fields or assembling an overall call graph.