### PR TITLE
Avoid to add superType's methods when target is an interface

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
@@ -351,7 +351,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
 
         // Construct instanceMethods -- the ordered list of all instance methods inherited and directly implemented.
         ArrayList<MethodElement> instanceMethods = new ArrayList<>();
-        if (superType != null) {
+        if (superType != null && !isInterface()) {
             // (i) all instance methods of my superclass
             instanceMethods.addAll(List.of(superType.getInstanceMethods()));
         }


### PR DESCRIPTION
Each itable has entries derived from java.lang.Object because interfaces' super class is always java.lang.Object, but maybe these entries are not needed.