### PR TITLE
disable rol/ror intrinsics for now; LLVM backend doesn't understand them

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -570,6 +570,7 @@ public final class CoreIntrinsics {
         intrinsics.registerIntrinsic(integerDesc, "remainderUnsigned", binaryIntDesc, remainderUnsigned);
         intrinsics.registerIntrinsic(longDesc, "remainderUnsigned", binaryLongDesc, remainderUnsigned);
 
+        /* LLVM backend doesn't understand ror and rol, so avoid generating them
         StaticIntrinsic ror = (builder, target, arguments) ->
             builder.ror(arguments.get(0), arguments.get(1));
 
@@ -581,6 +582,7 @@ public final class CoreIntrinsics {
 
         intrinsics.registerIntrinsic(integerDesc, "rotateLeft", binaryIntDesc, rol);
         intrinsics.registerIntrinsic(longDesc, "rotateLeft", longIntDesc, rol);
+        */
 
         StaticIntrinsic compare = (builder, target, arguments) ->
             builder.cmp(arguments.get(0), arguments.get(1));


### PR DESCRIPTION
Not sure what the intent of these intrinsics was, but they aren't implemented in the LLVM backend and a little quick googling seemed to indicate that they aren't LLVM instructions, so it wasn't obvious what to do with them.  We actually hit these with --init-build-time now; one of the hashcode methods uses Integer.rol. 