### PR TITLE
Handle native functions that are defined as macros

### DIFF
--- a/machine/file/object/src/main/java/org/qbicc/machine/object/ObjectFile.java
+++ b/machine/file/object/src/main/java/org/qbicc/machine/object/ObjectFile.java
@@ -18,7 +18,7 @@ public interface ObjectFile extends Closeable {
 
     byte[] getSymbolAsBytes(String name, int size);
 
-    String getSymbolValueAsUtfString(String name);
+    String getSymbolValueAsUtfString(String name, int nbytes);
 
     long getSymbolSize(String name);
 

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
@@ -24,6 +24,7 @@ final class Native {
     static final String ANN_INTERNAL = className(internal.class);
     static final String ANN_LIB = className(lib.class);
     static final String ANN_LIB_LIST = className(lib.List.class);
+    static final String ANN_MACRO = className(macro.class);
     static final String ANN_NAME = className(name.class);
     static final String ANN_SIZE = className(size.class);
     static final String ANN_SIZE_LIST = className(size.List.class);

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -1071,6 +1071,11 @@ public final class CNative {
         }
     }
 
+    @Target({ ElementType.METHOD })
+    @Retention(RetentionPolicy.CLASS)
+    public @interface macro {
+    }
+
     @Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
     @Retention(RetentionPolicy.CLASS)
     @Documented

--- a/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/LibUnwind.java
+++ b/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/LibUnwind.java
@@ -11,13 +11,21 @@ import static org.qbicc.runtime.CNative.*;
 public final class LibUnwind {
     private LibUnwind() {}
 
+    @macro
     public static native c_int unw_getcontext(unw_context_t_ptr context_ptr);
+    @macro
     public static native c_int unw_init_local(unw_cursor_t_ptr cursor, unw_context_t_ptr context_ptr);
+    @macro
     public static native c_int unw_step(unw_cursor_t_ptr cursor);
+    @macro
     public static native c_int unw_get_reg(unw_cursor_t_ptr cursor, unw_regnum_t reg, unw_word_t_ptr output);
+    @macro
     public static native c_int unw_set_reg(unw_cursor_t_ptr cursor, unw_regnum_t reg, unw_word_t value);
+    @macro
     public static native c_int unw_resume(unw_cursor_t_ptr cursor);
+    @macro
     public static native c_int unw_get_proc_info(unw_cursor_t_ptr cursor, unw_proc_info_t_ptr info);
+    @macro
     public static native c_int unw_is_signal_frame(unw_cursor_t_ptr cursor);
 
     public static final class unw_context_t extends object {}


### PR DESCRIPTION
This implements the solution mentioned [here](https://github.com/qbicc/qbicc/pull/709#discussion_r730068824), with one change - the type of the variable is changed from pointer to array. 
If the type is pointer, then the string value gets stored in `.rodata` and is referenced through a relocation entry created for the pointer data type. This requires extra work to obtain the string.
If the type is array, then the string value gets stored in `.data` section and can be obtained using existing APIs.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>