### PR TITLE
Add stack walker and intrinsics to access method data

### DIFF
--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -283,13 +283,16 @@ final class CompilationContextImpl implements CompilationContext {
         DefinedTypeDefinition dtd = bootstrapClassContext.findDefinedType("org/qbicc/runtime/main/ObjectModel");
         if (dtd == null) {
             error("Can't find runtime library class: " + "org/qbicc/runtime/main/ObjectModel");
+            return null;
         }
         LoadedTypeDefinition helpers = dtd.load();
         int idx = helpers.findMethodIndex(e -> name.equals(e.getName()));
         if (idx == -1) {
             error("Can't find the runtime helper method %s", name);
+            return null;
         }
         return helpers.getMethod(idx);
+
     }
 
     public void enqueue(final ExecutableElement element) {

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -397,6 +397,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::reportStats);
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::clear);
 
+                                builder.addPreHook(Phase.ANALYZE, new VMHelpersSetupHook());
                                 builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachable);
                                 builder.addElementHandler(Phase.ANALYZE, new ElementBodyCopier());
                                 builder.addElementHandler(Phase.ANALYZE, new ElementVisitorAdapter(new DotGenerator(Phase.ANALYZE, graphGenConfig)));
@@ -408,6 +409,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 }
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, IntrinsicBasicBlockBuilder::createForAnalyzePhase);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, InitializedStaticFieldBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, BasicInitializationBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, ThreadLocalBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
                                 if (optMemoryTracking) {

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/RuntimeMethodFinder.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/RuntimeMethodFinder.java
@@ -1,0 +1,62 @@
+package org.qbicc.plugin.coreclasses;
+
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.ConstructorElement;
+import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.descriptor.MethodDescriptor;
+
+public class RuntimeMethodFinder {
+    private static final AttachmentKey<RuntimeMethodFinder> KEY = new AttachmentKey<>();
+    private final CompilationContext ctxt;
+
+    private RuntimeMethodFinder(CompilationContext ctxt) {
+        this.ctxt = ctxt;
+    }
+
+    public static RuntimeMethodFinder get(CompilationContext ctxt) {
+        RuntimeMethodFinder helpers = ctxt.getAttachment(KEY);
+        if (helpers == null) {
+            helpers = new RuntimeMethodFinder(ctxt);
+            RuntimeMethodFinder appearing = ctxt.putAttachmentIfAbsent(KEY, helpers);
+            if (appearing != null) {
+                helpers = appearing;
+            }
+        }
+        return helpers;
+    }
+
+    public MethodElement getMethod(String runtimeClass, String helperName) {
+        ClassContext context = ctxt.getBootstrapClassContext();
+        DefinedTypeDefinition dtd = context.findDefinedType(runtimeClass);
+        if (dtd == null) {
+            ctxt.error("Can't find runtime library class: " + runtimeClass);
+            return null;
+        }
+        LoadedTypeDefinition ltd = dtd.load();
+        int idx = ltd.findMethodIndex(e -> helperName.equals(e.getName()));
+        if (idx == -1) {
+            ctxt.error("Can't find the runtime helper method %s", helperName);
+            return null;
+        }
+        return ltd.getMethod(idx);
+    }
+
+    public ConstructorElement getConstructor(String runtimeClass, MethodDescriptor descriptor) {
+        ClassContext context = ctxt.getBootstrapClassContext();
+        DefinedTypeDefinition dtd = context.findDefinedType(runtimeClass);
+        if (dtd == null) {
+            ctxt.error("Can't find runtime library class: " + runtimeClass);
+            return null;
+        }
+        LoadedTypeDefinition ltd = dtd.load();
+        int idx = ltd.findConstructorIndex(descriptor);
+        if (idx == -1) {
+            ctxt.error("Can't find the constructor with descriptor %s for class %s", descriptor.toString(), runtimeClass);
+        }
+        return ltd.getConstructor(idx);
+    }
+}

--- a/plugins/intrinsics/pom.xml
+++ b/plugins/intrinsics/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-methodinfo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-serialization</artifactId>
         </dependency>
     </dependencies>

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -853,12 +853,24 @@ public final class CoreIntrinsics {
 
         intrinsics.registerIntrinsic(Phase.LOWER, mdDesc, "getMethodDesc", intToStringDesc, getMethodDesc);
 
+        StaticIntrinsic getTypeId = (builder, target, arguments) -> {
+            GlobalVariable gmdVariable = (GlobalVariable) builder.globalVariable(mdTypes.getAndRegisterGlobalMethodData(builder.getCurrentElement()));
+            Value tablePointer = builder.load(builder.memberOf(gmdVariable, gmdType.getMember("methodInfoTable")), MemoryAtomicityMode.UNORDERED);
+
+            ValueHandle minfoHandle = builder.elementOf(builder.pointerHandle(builder.bitCast(tablePointer, minfoType.getPointer())), arguments.get(0));
+            return builder.load(builder.memberOf(minfoHandle, minfoType.getMember("typeId")), MemoryAtomicityMode.UNORDERED);
+        };
+
+        intrinsics.registerIntrinsic(Phase.LOWER, mdDesc, "getTypeId", intToIntDesc, getTypeId);
+
         String methodDataClass = "org/qbicc/runtime/stackwalk/MethodData";
         MethodElement getLineNumberElement = methodFinder.getMethod(methodDataClass, "getLineNumber");
         MethodElement getMethodInfoIndexElement = methodFinder.getMethod(methodDataClass, "getMethodInfoIndex");
         MethodElement getFileNameElement = methodFinder.getMethod(methodDataClass, "getFileName");
         MethodElement getClassNameElement = methodFinder.getMethod(methodDataClass, "getClassName");
         MethodElement getMethodNameElement = methodFinder.getMethod(methodDataClass, "getMethodName");
+        MethodElement getTypeIdElement = methodFinder.getMethod(methodDataClass, "getTypeId");
+        MethodElement getClassFromTypeIdElement = methodFinder.getMethod("org/qbicc/runtime/main/ObjectModel", "get_class_from_type_id");
 
         StaticIntrinsic fillStackTraceElement = (builder, target, arguments) -> {
             DefinedTypeDefinition jls = classContext.findDefinedType("java/lang/StackTraceElement");
@@ -881,17 +893,25 @@ public final class CoreIntrinsics {
             Value methodName = builder.getFirstBuilder().call(
                 builder.staticMethod(getMethodNameElement, getMethodNameElement.getDescriptor(), getMethodNameElement.getType()),
                 List.of(minfoIndex));
+            Value typeId = builder.getFirstBuilder().call(
+                builder.staticMethod(getTypeIdElement, getTypeIdElement.getDescriptor(), getTypeIdElement.getType()),
+                List.of(minfoIndex));
+            Value classObject = builder.getFirstBuilder().call(
+                builder.staticMethod(getClassFromTypeIdElement, getClassFromTypeIdElement.getDescriptor(), getClassFromTypeIdElement.getType()),
+                List.of(typeId, ctxt.getLiteralFactory().literalOf(0)));
 
             ValueHandle steRefHandle = builder.referenceHandle(arguments.get(0));
             FieldElement dcField = jlsVal.findField("declaringClass");
             FieldElement mnField = jlsVal.findField("methodName");
             FieldElement fnField = jlsVal.findField("fileName");
             FieldElement lnField = jlsVal.findField("lineNumber");
+            FieldElement classField = jlsVal.findField("declaringClassObject");
 
             builder.store(builder.instanceFieldOf(steRefHandle, dcField), className, MemoryAtomicityMode.NONE);
             builder.store(builder.instanceFieldOf(steRefHandle, mnField), methodName, MemoryAtomicityMode.NONE);
             builder.store(builder.instanceFieldOf(steRefHandle, fnField), fileName, MemoryAtomicityMode.NONE);
             builder.store(builder.instanceFieldOf(steRefHandle, lnField), lineNumber, MemoryAtomicityMode.NONE);
+            builder.store(builder.instanceFieldOf(steRefHandle, classField), classObject, MemoryAtomicityMode.NONE);
             return ctxt.getLiteralFactory().zeroInitializerLiteralOfType(ctxt.getTypeSystem().getVoidType()); // void literal
         };
 

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -117,6 +117,7 @@ import org.qbicc.machine.llvm.op.OrderingConstraint;
 import org.qbicc.machine.llvm.op.Phi;
 import org.qbicc.machine.llvm.op.YieldingInstruction;
 import org.qbicc.object.Function;
+import org.qbicc.plugin.methodinfo.CallSiteInfo;
 import org.qbicc.plugin.unwind.UnwindHelper;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.CompoundType;
@@ -1118,7 +1119,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
     private void addStatepointId(Call call, Node node) {
         int statepointId = LLVM.getNextStatepointId();
         call.attribute(FunctionAttributes.statepointId(statepointId));
-        LLVMCallSiteInfo.get(ctxt).mapStatepointIdToNode(statepointId, node);
+        CallSiteInfo.get(ctxt).mapStatepointIdToNode(statepointId, node);
     }
 
     // GEP

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
@@ -1,8 +1,12 @@
 package org.qbicc.plugin.lowering;
 
 import org.qbicc.context.CompilationContext;
+import org.qbicc.plugin.coreclasses.RuntimeMethodFinder;
 import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.descriptor.MethodDescriptor;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -10,39 +14,49 @@ import java.util.function.Consumer;
  */
 public class VMHelpersSetupHook implements Consumer<CompilationContext> {
     public void accept(final CompilationContext ctxt) {
+        RuntimeMethodFinder methodFinder = RuntimeMethodFinder.get(ctxt);
         // Helpers for dynamic type checking
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("arrayStoreCheck"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("checkcast_class"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("checkcast_typeId"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("instanceof_class"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("instanceof_typeId"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("get_class"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("classof_from_typeid"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("get_superclass"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("arrayStoreCheck"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("checkcast_class"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("checkcast_typeId"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("instanceof_class"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("instanceof_typeId"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("get_class"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("classof_from_typeid"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("get_superclass"));
 
         // Helpers to create and throw common runtime exceptions
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseAbstractMethodError"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArithmeticException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArrayIndexOutOfBoundsException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArrayStoreException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseClassCastException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseNegativeArraySizeException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseNullPointerException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseAbstractMethodError"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseArithmeticException"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseArrayIndexOutOfBoundsException"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseArrayStoreException"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseClassCastException"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseNegativeArraySizeException"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseNullPointerException"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError"));
 
         // Object monitors
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("monitor_enter"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("monitor_exit"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("monitor_enter"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("monitor_exit"));
 
         // class initialization
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("initialize_class"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("initialize_class"));
 
         // helper to create j.l.Class instance of an array class at runtime
-        ctxt.registerEntryPoint(ctxt.getOMHelperMethod("get_or_create_class_for_refarray"));
+        ctxt.enqueue(ctxt.getOMHelperMethod("get_or_create_class_for_refarray"));
 
         // java.lang.Thread
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("JLT_start0"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("threadWrapper"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("JLT_start0"));
+        ctxt.enqueue(ctxt.getVMHelperMethod("threadWrapper"));
+
+        // Helpers for stack walk
+        ctxt.enqueue(methodFinder.getMethod("org/qbicc/runtime/stackwalk/MethodData", "fillStackTraceElements"));
+        ctxt.enqueue(methodFinder.getMethod("org/qbicc/runtime/stackwalk/JavaStackWalker", "getFrameCount"));
+        ctxt.enqueue(methodFinder.getMethod("org/qbicc/runtime/stackwalk/JavaStackWalker", "walkStack"));
+        ctxt.enqueue(methodFinder.getMethod("org/qbicc/runtime/stackwalk/JavaStackFrameCache", "getSourceCodeIndexList"));
+        ctxt.enqueue(methodFinder.getMethod("org/qbicc/runtime/stackwalk/JavaStackFrameCache", "visitFrame"));
+        ctxt.enqueue(methodFinder.getConstructor("org/qbicc/runtime/stackwalk/JavaStackFrameCache",
+            MethodDescriptor.synthesize(ctxt.getBootstrapClassContext(), BaseTypeDescriptor.V, List.of(BaseTypeDescriptor.I))));
     }
 }

--- a/plugins/methodinfo/pom.xml
+++ b/plugins/methodinfo/pom.xml
@@ -13,11 +13,11 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-linker</artifactId>
+            <artifactId>qbicc-machine-llvm</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-llvm</artifactId>
+            <artifactId>qbicc-plugin-linker</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/CallSiteInfo.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/CallSiteInfo.java
@@ -1,24 +1,22 @@
-package org.qbicc.plugin.llvm;
+package org.qbicc.plugin.methodinfo;
 
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.Node;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
-public class LLVMCallSiteInfo {
+public class CallSiteInfo {
     // This is a rough estimate based on number of callsites for an app with empty main().
     // A better way would be to collect this stat during compilation and use it to initialize the list capacity.
     private static final int INITIAL_LIST_SIZE = 100000;
     private final ArrayList<Node> nodeList = new ArrayList<>(INITIAL_LIST_SIZE);
-    public static final AttachmentKey<LLVMCallSiteInfo> KEY = new AttachmentKey<>();
+    public static final AttachmentKey<CallSiteInfo> KEY = new AttachmentKey<>();
 
-    private LLVMCallSiteInfo() {}
+    private CallSiteInfo() {}
 
-    public static LLVMCallSiteInfo get(CompilationContext ctxt) {
-        return ctxt.computeAttachmentIfAbsent(KEY, LLVMCallSiteInfo::new);
+    public static CallSiteInfo get(CompilationContext ctxt) {
+        return ctxt.computeAttachmentIfAbsent(KEY, CallSiteInfo::new);
     }
 
     public void mapStatepointIdToNode(int statepointId, Node node) {

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -69,6 +69,7 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
         String fileName = element.getSourceFileName();
         String className = element.getEnclosingType().getInternalName();
         String methodDesc = element.getDescriptor().toString();
+        int typeId = element.getEnclosingType().load().getTypeId();
 
         Vm vm = ctxt.getVm();
         BuildtimeHeap btHeap = BuildtimeHeap.get(ctxt);
@@ -84,7 +85,7 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
         SymbolLiteral mdLiteral = btHeap.getSerializedVmObject(vm.intern(methodDesc));
         Assert.assertNotNull(mdLiteral);
 
-        return methodData.add(new MethodInfo(fnLiteral, cnLiteral, mnLiteral, mdLiteral));
+        return methodData.add(new MethodInfo(fnLiteral, cnLiteral, mnLiteral, mdLiteral, typeId));
     }
 
     private int createSourceCodeInfo(CompilationContext ctxt, MethodData methodData, ExecutableElement element, int lineNumber, int bcIndex, int inlinedAtIndex) {
@@ -184,11 +185,13 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
             Literal cnLiteral = castHeapSymbolTo(ctxt, minfo.getClassNameSymbolLiteral(), jlsRef);
             Literal mnLiteral = castHeapSymbolTo(ctxt, minfo.getMethodNameSymbolLiteral(), jlsRef);
             Literal mdLiteral = castHeapSymbolTo(ctxt, minfo.getMethodDescSymbolLiteral(), jlsRef);
+            Literal typeIdLiteral = lf.literalOf(minfo.getTypeId());
 
             valueMap.put(methodInfoType.getMember("fileName"), fnLiteral);
             valueMap.put(methodInfoType.getMember("className"), cnLiteral);
             valueMap.put(methodInfoType.getMember("methodName"), mnLiteral);
             valueMap.put(methodInfoType.getMember("methodDesc"), mdLiteral);
+            valueMap.put(methodInfoType.getMember("typeId"), typeIdLiteral);
             return lf.literalOf(methodInfoType, valueMap);
         }).toArray(Literal[]::new);
 

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -16,8 +16,8 @@ import org.qbicc.machine.object.ObjectFileProvider;
 import org.qbicc.object.Function;
 import org.qbicc.object.Section;
 import org.qbicc.plugin.linker.Linker;
-import org.qbicc.plugin.llvm.LLVMCallSiteInfo;
 import org.qbicc.plugin.serialization.BuildtimeHeap;
+import org.qbicc.type.ArrayType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
@@ -121,7 +121,7 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
 
     public MethodData createMethodData(CompilationContext ctxt) {
         List<StackMapRecord> stackMapRecords = new StackMapRecordCollector(ctxt).collect();
-        LLVMCallSiteInfo callSiteInfo = ctxt.getAttachment(LLVMCallSiteInfo.KEY);
+        CallSiteInfo callSiteInfo = ctxt.getAttachment(CallSiteInfo.KEY);
         MethodData methodData = new MethodData(stackMapRecords.size());
         Iterator<StackMapRecord> recordIterator = stackMapRecords.iterator();
         final int[] recordIndex = { 0 };
@@ -164,21 +164,19 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
         return result;
     }
 
+    private void defineData(CompilationContext ctxt, String variableName, Literal value) {
+        Section section = ctxt.getImplicitSection(ctxt.getDefaultTypeDefinition());
+        section.addData(null, variableName, value);
+    }
+
     Literal emitMethodInfoTable(CompilationContext ctxt, MethodInfo[] minfoList) {
         TypeSystem ts = ctxt.getTypeSystem();
         LiteralFactory lf = ctxt.getLiteralFactory();
+        MethodDataTypes mdTypes = MethodDataTypes.get(ctxt);
+
         LoadedTypeDefinition jls = ctxt.getBootstrapClassContext().findDefinedType("java/lang/String").load();
         ReferenceType jlsRef = jls.getType().getReference();
-
-        CompoundType methodInfoType = CompoundType.builder(ts)
-            .setTag(CompoundType.Tag.STRUCT)
-            .setName("qbicc_method_info")
-            .setOverallAlignment(jlsRef.getAlign())
-            .addNextMember("fileName", jlsRef)
-            .addNextMember("className", jlsRef)
-            .addNextMember("methodName", jlsRef)
-            .addNextMember("methodDesc", jlsRef)
-            .build();
+        CompoundType methodInfoType = mdTypes.getMethodInfoType();
 
         Literal[] minfoLiterals = Arrays.stream(minfoList).parallel().map(minfo -> {
             HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
@@ -187,46 +185,43 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
             Literal mnLiteral = castHeapSymbolTo(ctxt, minfo.getMethodNameSymbolLiteral(), jlsRef);
             Literal mdLiteral = castHeapSymbolTo(ctxt, minfo.getMethodDescSymbolLiteral(), jlsRef);
 
-            valueMap.put(methodInfoType.getMember(0), fnLiteral);
-            valueMap.put(methodInfoType.getMember(1), cnLiteral);
-            valueMap.put(methodInfoType.getMember(2), mnLiteral);
-            valueMap.put(methodInfoType.getMember(3), mdLiteral);
+            valueMap.put(methodInfoType.getMember("fileName"), fnLiteral);
+            valueMap.put(methodInfoType.getMember("className"), cnLiteral);
+            valueMap.put(methodInfoType.getMember("methodName"), mnLiteral);
+            valueMap.put(methodInfoType.getMember("methodDesc"), mdLiteral);
             return lf.literalOf(methodInfoType, valueMap);
         }).toArray(Literal[]::new);
 
         methodInfoTableCount += minfoLiterals.length;
         methodInfoTableSize += methodInfoTableCount * methodInfoType.getSize();
 
-        return lf.literalOf(ts.getArrayType(methodInfoType, minfoLiterals.length), List.of(minfoLiterals));
+        SymbolLiteral minfoTableLiteral = lf.literalOfSymbol("qbicc_method_info_table", ts.getArrayType(methodInfoType, minfoLiterals.length));
+        defineData(ctxt, minfoTableLiteral.getName(), lf.literalOf((ArrayType)minfoTableLiteral.getType(), List.of(minfoLiterals)));
+        return minfoTableLiteral;
     }
 
     Literal emitSourceCodeInfoTable(CompilationContext ctxt, SourceCodeInfo[] scList) {
         TypeSystem ts = ctxt.getTypeSystem();
         LiteralFactory lf = ctxt.getLiteralFactory();
-        ValueType uint32Type = ts.getUnsignedInteger32Type();
-        CompoundType sourceCodeInfoType = CompoundType.builder(ts)
-            .setTag(CompoundType.Tag.STRUCT)
-            .setName("qbicc_souce_code_info")
-            .setOverallAlignment(uint32Type.getAlign())
-            .addNextMember("methodInfoIndex", uint32Type)
-            .addNextMember("lineNumber", uint32Type)
-            .addNextMember("bcIndex", uint32Type)
-            .addNextMember("inlinedAtIndex", uint32Type)
-            .build();
+        MethodDataTypes mdTypes = MethodDataTypes.get(ctxt);
+
+        CompoundType sourceCodeInfoType = mdTypes.getSourceCodeInfoType();
 
         Literal[] scInfoLiterals = Arrays.stream(scList).parallel().map(scInfo -> {
             HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
-            valueMap.put(sourceCodeInfoType.getMember(0), lf.literalOf(scInfo.getMethodInfoIndex()));
-            valueMap.put(sourceCodeInfoType.getMember(1), lf.literalOf(scInfo.getLineNumber()));
-            valueMap.put(sourceCodeInfoType.getMember(2), lf.literalOf(scInfo.getBcIndex()));
-            valueMap.put(sourceCodeInfoType.getMember(3), lf.literalOf(scInfo.getInlinedAtIndex()));
+            valueMap.put(sourceCodeInfoType.getMember("methodInfoIndex"), lf.literalOf(scInfo.getMethodInfoIndex()));
+            valueMap.put(sourceCodeInfoType.getMember("lineNumber"), lf.literalOf(scInfo.getLineNumber()));
+            valueMap.put(sourceCodeInfoType.getMember("bcIndex"), lf.literalOf(scInfo.getBcIndex()));
+            valueMap.put(sourceCodeInfoType.getMember("inlinedAtIndex"), lf.literalOf(scInfo.getInlinedAtIndex()));
             return lf.literalOf(sourceCodeInfoType, valueMap);
         }).toArray(Literal[]::new);
 
         sourceCodeInfoTableCount += scInfoLiterals.length;
         sourceCodeInfoTableSize += sourceCodeInfoTableCount * sourceCodeInfoType.getSize();
 
-        return lf.literalOf(ts.getArrayType(sourceCodeInfoType, scInfoLiterals.length), List.of(scInfoLiterals));
+        SymbolLiteral scInfoTableLiteral = lf.literalOfSymbol("qbicc_source_code_info_table", ts.getArrayType(sourceCodeInfoType, scInfoLiterals.length));
+        defineData(ctxt, scInfoTableLiteral.getName(), lf.literalOf((ArrayType)scInfoTableLiteral.getType(), List.of(scInfoLiterals)));
+        return scInfoTableLiteral;
     }
 
     Literal emitSourceCodeIndexList(CompilationContext ctxt, InstructionMap[] imapList) {
@@ -241,7 +236,9 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
         sourceCodeIndexListCount += scIndexLiterals.length;
         sourceCodeIndexListSize += sourceCodeIndexListCount * uint32Type.getSize();
 
-        return lf.literalOf(ts.getArrayType(uint32Type, scIndexLiterals.length), List.of(scIndexLiterals));
+        SymbolLiteral scInfoIndexTableLiteral = lf.literalOfSymbol("qbicc_source_code_index_table", ts.getArrayType(uint32Type, scIndexLiterals.length));
+        defineData(ctxt, scInfoIndexTableLiteral.getName(), lf.literalOf((ArrayType)scInfoIndexTableLiteral.getType(), List.of(scIndexLiterals)));
+        return scInfoIndexTableLiteral;
     }
 
     Literal emitInstructionList(CompilationContext ctxt, InstructionMap[] imapList) {
@@ -263,35 +260,52 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
         instructionListCount += instructionLiterals.length;
         instructionListSize += instructionListCount * uint64Type.getSize();
 
-        return lf.literalOf(ts.getArrayType(uint64Type, instructionLiterals.length), List.of(instructionLiterals));
+        SymbolLiteral instructionTableLiteral = lf.literalOfSymbol("qbicc_instruction_table", ts.getArrayType(uint64Type, instructionLiterals.length));
+        defineData(ctxt, instructionTableLiteral.getName(), lf.literalOf((ArrayType)instructionTableLiteral.getType(), List.of(instructionLiterals)));
+        return instructionTableLiteral;
     }
 
-    Literal emitInstructionListCount(CompilationContext ctxt, InstructionMap[] imapList) {
-        return ctxt.getLiteralFactory().literalOf(imapList.length);
-    }
+    void emitGlobalMethodData(CompilationContext ctxt,
+                              SymbolLiteral minfoTable,
+                              SymbolLiteral scInfoTable,
+                              SymbolLiteral scIndexTable,
+                              SymbolLiteral instructionTable,
+                              int instructionTableSize) {
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        TypeSystem ts = ctxt.getTypeSystem();
+        MethodDataTypes mdTypes = MethodDataTypes.get(ctxt);
+        CompoundType mdhType = mdTypes.getGlobalMethodDataType();
+        HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
+        CompoundType.Member member;
 
-    private void emitGlobalVariable(CompilationContext ctxt, String variableName, Literal value) {
-        Section section = ctxt.getImplicitSection(ctxt.getDefaultTypeDefinition());
-        section.addData(null, variableName, value);
+        SymbolLiteral pointerSymbol = lf.literalOfSymbol(minfoTable.getName(), minfoTable.getType().getPointer());
+        member = mdhType.getMember("methodInfoTable");
+        valueMap.put(member, lf.bitcastLiteral(pointerSymbol, (WordType) member.getType()));
+
+        pointerSymbol = lf.literalOfSymbol(scInfoTable.getName(), scInfoTable.getType().getPointer());
+        member = mdhType.getMember("sourceCodeInfoTable");
+        valueMap.put(member, lf.bitcastLiteral(pointerSymbol, (WordType) member.getType()));
+
+        pointerSymbol = lf.literalOfSymbol(scIndexTable.getName(), scIndexTable.getType().getPointer());
+        member = mdhType.getMember("sourceCodeIndexTable");
+        valueMap.put(member, lf.bitcastLiteral(pointerSymbol, (WordType) member.getType()));
+
+        pointerSymbol = lf.literalOfSymbol(instructionTable.getName(), instructionTable.getType().getPointer());
+        member = mdhType.getMember("instructionTable");
+        valueMap.put(member, lf.bitcastLiteral(pointerSymbol, (WordType) member.getType()));
+
+        valueMap.put(mdhType.getMember("instructionTableSize"), lf.literalOf(instructionTableSize));
+
+        Literal mdhLiteral = lf.literalOf(mdhType, valueMap);
+        defineData(ctxt, MethodDataTypes.QBICC_GLOBAL_METHOD_DATA, mdhLiteral);
     }
 
     public void emitMethodData(CompilationContext ctxt, MethodData methodData) {
-        Literal value;
-
-        value = emitMethodInfoTable(ctxt, methodData.getMethodInfoTable());
-        emitGlobalVariable(ctxt, "qbicc_method_info_table", value);
-
-        value = emitSourceCodeInfoTable(ctxt, methodData.getSourceCodeInfoTable());
-        emitGlobalVariable(ctxt, "qbicc_source_code_info_table", value);
-
-        value = emitInstructionList(ctxt, methodData.getInstructionMapList());
-        emitGlobalVariable(ctxt, "qbicc_instruction_list", value);
-
-        value = emitInstructionListCount(ctxt, methodData.getInstructionMapList());
-        emitGlobalVariable(ctxt, "qbicc_instruction_list_size", value);
-
-        value = emitSourceCodeIndexList(ctxt, methodData.getInstructionMapList());
-        emitGlobalVariable(ctxt, "qbicc_source_code_index_list", value);
+        SymbolLiteral minfoTableSymbol = (SymbolLiteral) emitMethodInfoTable(ctxt, methodData.getMethodInfoTable());
+        SymbolLiteral scInfoTableSymbol = (SymbolLiteral) emitSourceCodeInfoTable(ctxt, methodData.getSourceCodeInfoTable());
+        SymbolLiteral scIndexTableSymbol = (SymbolLiteral) emitSourceCodeIndexList(ctxt, methodData.getInstructionMapList());
+        SymbolLiteral instructionTableSymbol = (SymbolLiteral) emitInstructionList(ctxt, methodData.getInstructionMapList());
+        emitGlobalMethodData(ctxt, minfoTableSymbol, scInfoTableSymbol, scIndexTableSymbol, instructionTableSymbol, methodData.getInstructionMapList().length);
     }
 
     private void displayStats() {

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
@@ -1,0 +1,112 @@
+package org.qbicc.plugin.methodinfo;
+
+import io.smallrye.common.constraint.Assert;
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.object.Section;
+import org.qbicc.type.ArrayType;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.ReferenceType;
+import org.qbicc.type.TypeSystem;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.generic.BaseTypeSignature;
+
+public class MethodDataTypes {
+    private static final AttachmentKey<MethodDataTypes> KEY = new AttachmentKey<>();
+
+    public static final String QBICC_GLOBAL_METHOD_DATA = "qbicc_global_method_data";
+
+    private final CompilationContext ctxt;
+
+    private GlobalVariableElement globalMethodData;
+
+    private CompoundType methodInfoType;
+    private CompoundType sourceCodeInfoType;
+    private CompoundType globalMethodDataType;
+
+    public MethodDataTypes(final CompilationContext ctxt) {
+        this.ctxt = ctxt;
+        TypeSystem ts = ctxt.getTypeSystem();
+        LoadedTypeDefinition jls = ctxt.getBootstrapClassContext().findDefinedType("java/lang/String").load();
+        ReferenceType jlsRef = jls.getType().getReference();
+        ValueType uint8Type = ts.getUnsignedInteger8Type();
+        ValueType uint32Type = ts.getUnsignedInteger32Type();
+        ValueType uint64Type = ts.getUnsignedInteger64Type();
+
+        methodInfoType = CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc_method_info")
+            .setOverallAlignment(jlsRef.getAlign())
+            .addNextMember("fileName", jlsRef)
+            .addNextMember("className", jlsRef)
+            .addNextMember("methodName", jlsRef)
+            .addNextMember("methodDesc", jlsRef)
+            .build();
+
+        sourceCodeInfoType = CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc_souce_code_info")
+            .setOverallAlignment(uint32Type.getAlign())
+            .addNextMember("methodInfoIndex", uint32Type)
+            .addNextMember("lineNumber", uint32Type)
+            .addNextMember("bcIndex", uint32Type)
+            .addNextMember("inlinedAtIndex", uint32Type)
+            .build();
+
+        globalMethodDataType = CompoundType.builder(ts)
+            .setTag(CompoundType.Tag.STRUCT)
+            .setName("qbicc_method_data")
+            .setOverallAlignment(ts.getPointerSize())
+            .addNextMember("methodInfoTable", uint8Type.getPointer())
+            .addNextMember("sourceCodeInfoTable", uint8Type.getPointer())
+            .addNextMember("sourceCodeIndexTable", uint32Type.getPointer())
+            .addNextMember("instructionTable", uint64Type.getPointer())
+            .addNextMember("instructionTableSize", uint32Type)
+            .build();
+
+        GlobalVariableElement.Builder builder = GlobalVariableElement.builder();
+        builder.setName(QBICC_GLOBAL_METHOD_DATA);
+        builder.setType(globalMethodDataType);
+        builder.setEnclosingType(ctxt.getDefaultTypeDefinition().load());
+        builder.setDescriptor(BaseTypeDescriptor.V);
+        builder.setSignature(BaseTypeSignature.V);
+        globalMethodData = builder.build();
+    }
+
+    public static MethodDataTypes get(CompilationContext ctxt) {
+        MethodDataTypes dt = ctxt.getAttachment(KEY);
+        if (dt == null) {
+            dt = new MethodDataTypes(ctxt);
+            MethodDataTypes appearing = ctxt.putAttachmentIfAbsent(KEY, dt);
+            if (appearing != null) {
+                dt = appearing;
+            }
+        }
+        return dt;
+    }
+
+    public GlobalVariableElement getAndRegisterGlobalMethodData(ExecutableElement originalElement) {
+        Assert.assertNotNull(globalMethodData);
+        if (originalElement != null && !globalMethodData.getEnclosingType().equals(originalElement.getEnclosingType())) {
+            Section section = ctxt.getImplicitSection(originalElement.getEnclosingType());
+            section.declareData(null, globalMethodData.getName(), globalMethodData.getType());
+        }
+        return globalMethodData;
+    }
+
+    public CompoundType getMethodInfoType() {
+        return methodInfoType;
+    }
+
+    public CompoundType getSourceCodeInfoType() {
+        return sourceCodeInfoType;
+    }
+
+    public CompoundType getGlobalMethodDataType() {
+        return globalMethodDataType;
+    }
+}

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
@@ -45,6 +45,7 @@ public class MethodDataTypes {
             .addNextMember("className", jlsRef)
             .addNextMember("methodName", jlsRef)
             .addNextMember("methodDesc", jlsRef)
+            .addNextMember("typeId", ts.getUnsignedInteger32Type())
             .build();
 
         sourceCodeInfoType = CompoundType.builder(ts)

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
@@ -9,12 +9,14 @@ final class MethodInfo {
     private SymbolLiteral classNameSymbolLiteral;
     private SymbolLiteral methodNameSymbolLiteral;
     private SymbolLiteral methodDescSymbolLiteral;
+    private int typeId;
 
-    MethodInfo(SymbolLiteral fileSymbolLiteral, SymbolLiteral classSymbolLiteral, SymbolLiteral methodSymbolLiteral, SymbolLiteral methodDescSymbolLiteral) {
+    MethodInfo(SymbolLiteral fileSymbolLiteral, SymbolLiteral classSymbolLiteral, SymbolLiteral methodSymbolLiteral, SymbolLiteral methodDescSymbolLiteral, int typeId) {
         this.fileNameSymbolLiteral = fileSymbolLiteral;
         this.classNameSymbolLiteral = classSymbolLiteral;
         this.methodNameSymbolLiteral = methodSymbolLiteral;
         this.methodDescSymbolLiteral = methodDescSymbolLiteral;
+        this.typeId = typeId;
     }
 
     public boolean equals(Object other) {
@@ -41,6 +43,10 @@ final class MethodInfo {
 
     SymbolLiteral getMethodDescSymbolLiteral() {
         return methodDescSymbolLiteral;
+    }
+
+    int getTypeId() {
+        return typeId;
     }
 
     @Override

--- a/runtime/main/pom.xml
+++ b/runtime/main/pom.xml
@@ -19,11 +19,15 @@
         </dependency>
         <dependency>
             <groupId>org.qbicc</groupId>
+            <artifactId>qbicc-runtime-linux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.qbicc</groupId>
             <artifactId>qbicc-runtime-posix</artifactId>
         </dependency>
         <dependency>
             <groupId>org.qbicc</groupId>
-            <artifactId>qbicc-runtime-linux</artifactId>
+            <artifactId>qbicc-runtime-unwind</artifactId>
         </dependency>
     </dependencies>
 

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackFrameCache.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackFrameCache.java
@@ -1,0 +1,20 @@
+package org.qbicc.runtime.stackwalk;
+
+import java.util.Arrays;
+
+public class JavaStackFrameCache implements JavaStackFrameVisitor {
+    private final int sourceCodeIndexList[];
+
+    JavaStackFrameCache(final int frameCount) {
+        this.sourceCodeIndexList = new int[frameCount];
+    }
+
+    public Object getSourceCodeIndexList() {
+        return Arrays.copyOf(sourceCodeIndexList, sourceCodeIndexList.length);
+    }
+
+    @Override
+    public void visitFrame(final int frameIndex, final int scIndex) {
+        sourceCodeIndexList[frameIndex] = scIndex;
+    }
+}

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackFrameVisitor.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackFrameVisitor.java
@@ -1,0 +1,6 @@
+package org.qbicc.runtime.stackwalk;
+
+@FunctionalInterface
+public interface JavaStackFrameVisitor {
+    void visitFrame(int frameIndex, int scIndex);
+}

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
@@ -1,0 +1,44 @@
+package org.qbicc.runtime.stackwalk;
+
+public class JavaStackWalker implements StackFrameVisitor {
+    private JavaStackFrameVisitor visitor;
+    private int javaFrameCount;
+
+    private JavaStackWalker(JavaStackFrameVisitor visitor) {
+        this.visitor = visitor;
+        javaFrameCount = 0;
+    }
+
+    public static int getFrameCount() {
+        JavaStackWalker javaStackWalker = new JavaStackWalker(new NopVisitor());
+        StackWalker.walkStack(javaStackWalker);
+        return javaStackWalker.javaFrameCount;
+    }
+
+    public static void walkStack(JavaStackFrameVisitor visitor) {
+        StackFrameVisitor javaStackWalker = new JavaStackWalker(visitor);
+        StackWalker.walkStack(javaStackWalker);
+    }
+
+    public void visitFrame(int frameIndex, long ip, long sp) {
+        int index = MethodData.findInstructionIndex(ip);
+        if (index != -1) {
+            int scIndex = MethodData.getSourceCodeInfoIndex(index);
+            visitor.visitFrame(javaFrameCount, scIndex);
+            javaFrameCount += 1;
+            int inlinedAtIndex = MethodData.getInlinedAtIndex(scIndex);
+            while (inlinedAtIndex != -1) {
+                visitor.visitFrame(javaFrameCount, inlinedAtIndex);
+                javaFrameCount += 1;
+                inlinedAtIndex = MethodData.getInlinedAtIndex(inlinedAtIndex);
+            }
+        } else {
+            // skip this frame; probably a native frame
+        }
+    }
+
+    private static class NopVisitor implements JavaStackFrameVisitor {
+        @Override
+        public void visitFrame(int frameIndex, int scIndex) { /* no-op */ }
+    }
+}

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -8,6 +8,7 @@ public final class MethodData {
     public static native String getClassName(int minfoIndex);
     public static native String getMethodName(int minfoIndex);
     public static native String getMethodDesc(int minfoIndex);
+    public static native int getTypeId(int minfoIndex);
 
     public static native int getMethodInfoIndex(int scIndex);
     public static native int getLineNumber(int scIndex);

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -1,0 +1,70 @@
+package org.qbicc.runtime.stackwalk;
+
+import org.qbicc.runtime.CNative;
+
+public final class MethodData {
+
+    public static native String getFileName(int minfoIndex);
+    public static native String getClassName(int minfoIndex);
+    public static native String getMethodName(int minfoIndex);
+    public static native String getMethodDesc(int minfoIndex);
+
+    public static native int getMethodInfoIndex(int scIndex);
+    public static native int getLineNumber(int scIndex);
+    public static native int getBytecodeIndex(int scIndex);
+    public static native int getInlinedAtIndex(int scIndex);
+
+    public static native int getSourceCodeInfoIndex(int index);
+    public static native long getInstructionAddress(int index);
+    public static native int getInstructionListSize();
+
+    static int findInstructionIndex(long ip) {
+        // do a binary search in instruction table
+        int upper = MethodData.getInstructionListSize();
+        int lower = 0;
+        while (upper >= lower) {
+            int mid = ( upper + lower ) >>> 1;
+            long addr = MethodData.getInstructionAddress(mid);
+            if (ip == addr) {
+                return mid;
+            } else if (ip > addr) {
+                lower = mid+1;
+            } else {
+                upper = mid-1;
+            }
+        }
+        return -1;
+    }
+
+    private static native void fillStackTraceElement(StackTraceElement element, int scIndex);
+
+    @CNative.extern
+    public static native int putchar(int arg);
+
+    // helper to print a string
+    private static void printString(String string) {
+        char[] contents = string.toCharArray();
+        for (char ch: contents) {
+            putchar((byte)ch);
+        }
+        putchar('\n');
+    }
+
+    // helper to print a stack frame info
+    private static void printFrame(int scIndex) {
+        int minfoIndex = getMethodInfoIndex(scIndex);
+        String className = getClassName(minfoIndex);
+        String fileName = getFileName(minfoIndex);
+        String methodName = getMethodName(minfoIndex);
+        printString(className + "#" + methodName + "(" + fileName + ")");
+    }
+
+    public static void fillStackTraceElements(StackTraceElement[] steArray, Object backtrace, int depth) {
+        int[] sourceCodeIndexList = (int[]) backtrace;
+        for (int i = 0; i < depth; i++) {
+            //printFrame(sourceCodeIndexList[i]);
+            fillStackTraceElement(steArray[i], sourceCodeIndexList[i]);
+        }
+    }
+}
+

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackFrameVisitor.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackFrameVisitor.java
@@ -1,0 +1,6 @@
+package org.qbicc.runtime.stackwalk;
+
+@FunctionalInterface
+public interface StackFrameVisitor {
+    void visitFrame(int frameIndex, long ip, long sp);
+}

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
@@ -1,0 +1,26 @@
+package org.qbicc.runtime.stackwalk;
+
+import org.qbicc.runtime.CNative;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.unwind.LibUnwind.*;
+
+public class StackWalker {
+    public static void walkStack(StackFrameVisitor visitor) {
+        unw_cursor_t_ptr cursor = alloca(CNative.sizeof(unw_cursor_t.class));
+        unw_context_t_ptr uc = alloca(CNative.sizeof(unw_context_t.class));
+        unw_word_t_ptr ip = alloca(CNative.sizeof(unw_word_t.class));
+        unw_word_t_ptr sp = alloca(CNative.sizeof(unw_word_t.class));
+
+        unw_getcontext(uc);
+        unw_init_local(cursor, uc);
+        int index = 0;
+        while (unw_step(cursor).intValue() > 0) {
+            unw_get_reg(cursor, UNW_REG_IP, ip);
+            unw_get_reg(cursor, UNW_REG_IP, sp);
+
+            visitor.visitFrame(index, ip.deref().longValue(), sp.deref().longValue());
+            index += 1;
+        }
+    }
+}


### PR DESCRIPTION
Add stack walker and provided intrinsics to access method data.
I have addressed the review comments mentioned in https://github.com/qbicc/qbicc/pull/709 viz:

1. Moved stack walker to runtime main module
2. Updated stack walker to handle frames for inlined methods (although it is not tested)

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>