### PR TITLE
Make build time initialization always-on

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/InterpreterHaltedException.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/InterpreterHaltedException.java
@@ -1,0 +1,50 @@
+package org.qbicc.interpreter;
+
+import java.io.Serial;
+
+/**
+ * An exception thrown when the interpreter is halted.
+ */
+public class InterpreterHaltedException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = -8299653786740116372L;
+
+    /**
+     * Constructs a new {@code InterpreterHaltedException} instance.  The message is left blank ({@code null}), and no
+     * cause is specified.
+     */
+    public InterpreterHaltedException() {
+    }
+
+    /**
+     * Constructs a new {@code InterpreterHaltedException} instance with an initial message.  No
+     * cause is specified.
+     *
+     * @param msg the message
+     */
+    public InterpreterHaltedException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructs a new {@code InterpreterHaltedException} instance with an initial cause.  If
+     * a non-{@code null} cause is specified, its message is used to initialize the message of this
+     * {@code InterpreterHaltedException}; otherwise the message is left blank ({@code null}).
+     *
+     * @param cause the cause
+     */
+    public InterpreterHaltedException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new {@code InterpreterHaltedException} instance with an initial message and cause.
+     *
+     * @param msg   the message
+     * @param cause the cause
+     */
+    public InterpreterHaltedException(final String msg, final Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/compiler/src/main/java/org/qbicc/interpreter/Thrown.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Thrown.java
@@ -3,9 +3,11 @@ package org.qbicc.interpreter;
 @SuppressWarnings("serial")
 public final class Thrown extends RuntimeException {
     private final VmThrowable throwable;
+    private final StackTraceElement[] realStackTrace;
 
     public Thrown(final VmThrowable throwable) {
         this.throwable = throwable;
+        realStackTrace = getStackTrace();
         setStackTrace(throwable.getStackTrace());
         VmThrowable cause = throwable.getCause();
         if (cause != null) {

--- a/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
@@ -290,6 +290,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
                                         LoadedTypeDefinition vmHelpers = bc.findDefinedType("org/qbicc/runtime/main/VMHelpers").load();
                                         MethodElement icce = vmHelpers.resolveMethodElementExact("raiseIncompatibleClassChangeError", MethodDescriptor.synthesize(bc, BaseTypeDescriptor.V, List.of()));
                                         BasicBlock entryBlock = bbb.callNoReturn(bbb.staticMethod(icce, icce.getDescriptor(), icce.getType()), List.of());
+                                        bbb.finish();
                                         Schedule schedule = Schedule.forMethod(entryBlock);
                                         return MethodBody.of(entryBlock, schedule, thisValue, paramValues);
                                     }, 0);
@@ -336,6 +337,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
                                 // just cast the list because it's fine; todo: maybe this method should accept List<? extends Value>
                                 //noinspection unchecked,rawtypes
                                 BasicBlock entryBlock = bbb.tailCall(bbb.exactMethodOf(thisValue, finalDefaultMethod, finalDefaultMethod.getDescriptor(), finalDefaultMethod.getType()), (List<Value>) (List) paramValues);
+                                bbb.finish();
                                 Schedule schedule = Schedule.forMethod(entryBlock);
                                 return MethodBody.of(entryBlock, schedule, thisValue, paramValues);
                             }, 0);

--- a/driver/src/main/java/org/qbicc/driver/ElementInitializer.java
+++ b/driver/src/main/java/org/qbicc/driver/ElementInitializer.java
@@ -3,6 +3,7 @@ package org.qbicc.driver;
 import java.util.function.Consumer;
 
 import org.qbicc.context.CompilationContext;
+import org.qbicc.interpreter.InterpreterHaltedException;
 import org.qbicc.interpreter.Thrown;
 import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmClass;
@@ -25,6 +26,8 @@ public class ElementInitializer implements Consumer<ExecutableElement> {
                 VmClass vmClass = element.getEnclosingType().load().getVmClass();
                 try {
                     vm.initialize(vmClass);
+                } catch (InterpreterHaltedException ignored) {
+                    // just skip it
                 } catch (Thrown thrown) {
                     VmThrowable throwable = thrown.getThrowable();
                     String className = throwable.getVmClass().getName();

--- a/integration-tests/src/it-in/snippets/ClassInit.java
+++ b/integration-tests/src/it-in/snippets/ClassInit.java
@@ -1,10 +1,16 @@
 import static org.qbicc.runtime.CNative.*;
 
 public class ClassInit {
+    static boolean parentInitialized;
+    static boolean childInitialized;
+    static boolean holderInitialized;
+    static boolean iInitialized;
+    static boolean jInitialized;
+    static boolean kInitialized;
 
     static class Parent {
         static {
-            putchar('P');
+            parentInitialized = true;
         }
 
         public static void call_child() {
@@ -14,7 +20,7 @@ public class ClassInit {
 
     static class Child {
         static {
-            putchar('C');
+            childInitialized = true;
         }
 
         public static void method() { }
@@ -22,7 +28,7 @@ public class ClassInit {
 
     static class FieldHolder {
         static {
-            putchar('F');
+            holderInitialized = true;
         }
 
         public static String s;
@@ -35,7 +41,7 @@ public class ClassInit {
         String s = initS();
 
         static String initS() {
-            putchar('I');
+            iInitialized = true;
             return new String("b");
         }
         default void m() { }
@@ -45,14 +51,15 @@ public class ClassInit {
         String s = initS();
 
         static String initS() {
-            putchar('J'); // should not be called by class init of implmentor
+            // should not be called by class init of implmentor
+            jInitialized = true;
             return new String("b");
         }
     }
 
     static class K implements J {
         static {
-            putchar('K');
+            kInitialized = true;
         }
 
     }
@@ -62,13 +69,19 @@ public class ClassInit {
 
     public static void main(String[] args) {
        Parent.call_child();
+       if (parentInitialized) putchar('P');
+       if (childInitialized) putchar('C');
        putchar('#');
        String s = FieldHolder.s;
+       if (holderInitialized) putchar('F');
        if (s == null) {
            throw new NullPointerException("Ensure field get isn't removed");
        }
        putchar('#');
        new K();
+       if (iInitialized) putchar('I');
+       if (jInitialized) putchar('J');
+       if (kInitialized) putchar('K');
     }
 
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -36,12 +36,17 @@ import org.qbicc.graph.Convert;
 import org.qbicc.graph.CountLeadingZeros;
 import org.qbicc.graph.CountTrailingZeros;
 import org.qbicc.graph.CurrentThreadRead;
+import org.qbicc.graph.DataDeclarationHandle;
+import org.qbicc.graph.DataHandle;
 import org.qbicc.graph.Div;
 import org.qbicc.graph.ElementOf;
 import org.qbicc.graph.ExactMethodElementHandle;
 import org.qbicc.graph.Extend;
 import org.qbicc.graph.ExtractMember;
 import org.qbicc.graph.Fence;
+import org.qbicc.graph.FunctionDeclarationHandle;
+import org.qbicc.graph.FunctionElementHandle;
+import org.qbicc.graph.FunctionHandle;
 import org.qbicc.graph.GetAndAdd;
 import org.qbicc.graph.GetAndBitwiseAnd;
 import org.qbicc.graph.GetAndBitwiseNand;
@@ -2119,6 +2124,55 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
             } else {
                 throw unsupportedType();
             }
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, FunctionDeclarationHandle node) {
+            throw unsatisfiedLink();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, FunctionElementHandle node) {
+            throw unsatisfiedLink();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, FunctionHandle node) {
+            throw unsatisfiedLink();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, DataDeclarationHandle node) {
+            throw unsatisfiedLink();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, DataHandle node) {
+            throw unsatisfiedLink();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, GlobalVariable node) {
+            throw unsatisfiedLink();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, LocalVariable node) {
+            throw unsatisfiedLink();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame param, PointerHandle node) {
+            throw unsatisfiedLink();
+        }
+
+        Thrown unsatisfiedLink() {
+            VmImpl vm = VmImpl.require();
+            VmClassImpl ule = vm.getBootstrapClassLoader().loadClass("java/lang/UnsatisfiedLinkError");
+            VmThreadImpl thread = (VmThreadImpl) Vm.requireCurrentThread();
+            VmThrowable throwable = vm.manuallyInitialize((VmThrowable) ule.newInstance());
+            thread.setThrown(throwable);
+            return new Thrown(throwable);
         }
 
         @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
@@ -17,6 +17,7 @@ import org.qbicc.graph.Terminator;
 import org.qbicc.graph.Unschedulable;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.interpreter.InterpreterHaltedException;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.Thrown;
 import org.qbicc.interpreter.VmInvokable;
@@ -52,7 +53,7 @@ final class VmInvokableImpl implements VmInvokable {
         }
         MethodBody body = element.getMethodBody();
         if (element.getEnclosingType().getContext().getCompilationContext().errors() > 0) {
-            throw new IllegalStateException("Interpreter halted due to compilation errors");
+            throw new InterpreterHaltedException("Interpreter halted due to compilation errors");
         }
         Map<BasicBlock, List<Node>> scheduled = new HashMap<>();
         buildScheduled(body, new HashSet<>(), scheduled, body.getEntryBlock().getTerminator(), sizeHolder);

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -49,9 +49,7 @@ import org.qbicc.plugin.gc.nogc.NoGcBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcMultiNewArrayBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcSetupHook;
 import org.qbicc.plugin.gc.nogc.NoGcTypeSystemConfigurator;
-import org.qbicc.plugin.instanceofcheckcast.ClassInitializerRegister;
 import org.qbicc.plugin.instanceofcheckcast.InstanceOfCheckCastBasicBlockBuilder;
-import org.qbicc.plugin.instanceofcheckcast.LowerClassInitCheckBlockBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayEmitter;
 import org.qbicc.plugin.intrinsics.IntrinsicBasicBlockBuilder;
@@ -131,7 +129,6 @@ public class Main implements Callable<DiagnosticContext> {
     private final boolean optPhis;
     private final boolean optGotos;
     private final boolean optInlining;
-    private final boolean initBuildTime;
     private final Platform platform;
     private final boolean smallTypeIds;
 
@@ -149,7 +146,6 @@ public class Main implements Callable<DiagnosticContext> {
         optPhis = builder.optPhis;
         optGotos = builder.optGotos;
         platform = builder.platform;
-        initBuildTime = builder.initBuildTime;
         smallTypeIds = builder.smallTypeIds;
     }
 
@@ -321,27 +317,19 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPreHook(Phase.ADD, CoreClasses::get);
                                 builder.addPreHook(Phase.ADD, ThrowExceptionHelper::get);
                                 builder.addPreHook(Phase.ADD, new VMHelpersSetupHook());
-                                if (initBuildTime) {
-                                    builder.addPreHook(Phase.ADD, compilationContext -> {
-                                        Vm vm = compilationContext.getVm();
-                                        VmThread initThread = vm.newThread("initialization", vm.getMainThreadGroup(), false,  Thread.currentThread().getPriority());
-                                        vm.doAttached(initThread, vm::initialize);
-                                    });
-                                }
+                                builder.addPreHook(Phase.ADD, compilationContext -> {
+                                    Vm vm = compilationContext.getVm();
+                                    VmThread initThread = vm.newThread("initialization", vm.getMainThreadGroup(), false,  Thread.currentThread().getPriority());
+                                    vm.doAttached(initThread, vm::initialize);
+                                });
                                 builder.addPreHook(Phase.ADD, new AddMainClassHook());
                                 if (nogc) {
                                     builder.addPreHook(Phase.ADD, new NoGcSetupHook());
                                 }
-                                if (initBuildTime) {
-                                    builder.addPreHook(Phase.ADD, ReachabilityInfo::forceCoreClassesReachableBuildTimeInit);
-                                } else {
-                                    builder.addPreHook(Phase.ADD, ReachabilityInfo::forceCoreClassesReachableRunTimeInit);
-                                }
+                                builder.addPreHook(Phase.ADD, ReachabilityInfo::forceCoreClassesReachableBuildTimeInit);
                                 builder.addElementHandler(Phase.ADD, new ElementBodyCreator());
                                 builder.addElementHandler(Phase.ADD, new ElementVisitorAdapter(new DotGenerator(Phase.ADD, graphGenConfig)));
-                                if (initBuildTime) {
-                                    builder.addElementHandler(Phase.ADD, new ElementInitializer());
-                                }
+                                builder.addElementHandler(Phase.ADD, new ElementInitializer());
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, IntrinsicBasicBlockBuilder::createForAddPhase);
                                 if (nogc) {
                                     builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, NoGcMultiNewArrayBasicBlockBuilder::new);
@@ -365,19 +353,11 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, LocalThrowHandlingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, SynchronizedMethodBasicBlockBuilder::createIfNeeded);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.OPTIMIZE, SimpleOptBasicBlockBuilder::new);
-                                if (initBuildTime) {
-                                    builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForBuildTimeInit);
-                                } else {
-                                    builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForRunTimeInit);
-                                }
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForBuildTimeInit);
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::reportStats);
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::clear);
 
-                                if (initBuildTime) {
-                                    builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachableBuildTimeInit);
-                                } else {
-                                    builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachableRunTimeInit);
-                                }
+                                builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachableBuildTimeInit);
                                 builder.addElementHandler(Phase.ANALYZE, new ElementBodyCopier());
                                 builder.addElementHandler(Phase.ANALYZE, new ElementVisitorAdapter(new DotGenerator(Phase.ANALYZE, graphGenConfig)));
                                 if (optGotos) {
@@ -387,9 +367,7 @@ public class Main implements Callable<DiagnosticContext> {
                                     builder.addCopyFactory(Phase.ANALYZE, PhiOptimizerVisitor::new);
                                 }
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, IntrinsicBasicBlockBuilder::createForAnalyzePhase);
-                                if (initBuildTime) {
-                                    builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, InitializedStaticFieldBasicBlockBuilder::new);
-                                }
+                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, InitializedStaticFieldBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, ThreadLocalBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
                                 if (optMemoryTracking) {
@@ -400,16 +378,11 @@ public class Main implements Callable<DiagnosticContext> {
                                 if (optInlining) {
                                     builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.OPTIMIZE, InliningBasicBlockBuilder::new);
                                 }
-                                if (initBuildTime) {
-                                    builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForBuildTimeInit);
-                                } else {
-                                    builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForRunTimeInit);
-                                }
+                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForBuildTimeInit);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, LocalVariableFindingBasicBlockBuilder::new);
                                 builder.addPostHook(Phase.ANALYZE, ReachabilityInfo::reportStats);
-                                if (! initBuildTime) {
-                                    builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
-                                }
+                                // todo: restore when adapted for run time initializers
+                                //builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
                                 builder.addPostHook(Phase.ANALYZE, new DispatchTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
 
@@ -438,9 +411,8 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, StaticFieldLoweringBasicBlockBuilder::new);
                                 // InstanceOfCheckCastBB must come before ObjectAccessLoweringBuilder or typeIdOf won't be lowered correctly
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, InstanceOfCheckCastBasicBlockBuilder::new);
-                                if (! initBuildTime) {
-                                    builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LowerClassInitCheckBlockBuilder::new);
-                                }
+                                // todo: restore when adapted for run time initializers
+                                //builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LowerClassInitCheckBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectAccessLoweringBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ObjectMonitorBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LLVMCompatibleBasicBlockBuilder::new);
@@ -506,7 +478,6 @@ public class Main implements Callable<DiagnosticContext> {
             .setOptInlining(optionsProcessor.optArgs.optInlining)
             .setOptGotos(optionsProcessor.optArgs.optGotos)
             .setOptPhis(optionsProcessor.optArgs.optPhis)
-            .setInitBuildTime(optionsProcessor.initBuildTime)
             .setSmallTypeIds(optionsProcessor.smallTypeIds)
             .setGraphGenConfig(optionsProcessor.graphGenConfig);
         Platform platform = optionsProcessor.platform;
@@ -580,8 +551,6 @@ public class Main implements Callable<DiagnosticContext> {
         private Platform platform;
         @CommandLine.Option(names = "--string-pool-stats")
         private boolean stringPoolStats;
-        @CommandLine.Option(names = "--init-build-time", negatable = true, defaultValue = "false", description = "Initialize all classes at build time")
-        private boolean initBuildTime;
 
         @CommandLine.Option(names = "--small-type-ids", negatable = true, defaultValue = "false", description = "Use narrow (16-bit) type ID values if true, wide (32-bit) type ID values if false")
         private boolean smallTypeIds;
@@ -702,7 +671,6 @@ public class Main implements Callable<DiagnosticContext> {
         private boolean optPhis = true;
         private boolean optGotos = true;
         private GraphGenConfig graphGenConfig;
-        private boolean initBuildTime = false;
         private boolean smallTypeIds = false;
 
         Builder() {}
@@ -786,11 +754,6 @@ public class Main implements Callable<DiagnosticContext> {
 
         public Builder setOptGotos(boolean optGotos) {
             this.optGotos = optGotos;
-            return this;
-        }
-
-        public Builder setInitBuildTime(boolean initBuildTime) {
-            this.initBuildTime = initBuildTime;
             return this;
         }
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -51,10 +51,6 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         return new ReachabilityBlockBuilder(ctxt, delegate, true);
     }
 
-    public static ReachabilityBlockBuilder initForRunTimeInit(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
-        return new ReachabilityBlockBuilder(ctxt, delegate, false);
-    }
-
     @Override
     public Value call(ValueHandle target, List<Value> arguments) {
         target.accept(this, null);

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
@@ -107,10 +107,6 @@ public class ReachabilityInfo {
         forceCoreClassesReachable(ctxt, true);
     }
 
-    public static void forceCoreClassesReachableRunTimeInit(CompilationContext ctxt) {
-        forceCoreClassesReachable(ctxt, false);
-    }
-
     private static void forceCoreClassesReachable(CompilationContext ctxt, boolean buildTimeInit) {
         ReachabilityInfo info = get(ctxt);
         CoreClasses cc = CoreClasses.get(ctxt);


### PR DESCRIPTION
Switch over to always using build time init.  The run time init code is preserved until we solidify our strategy on split initialization; it is my feeling that the easiest way forward will be to supplement classes with a run time init stub in some way. I'll come up with a more formal proposal for the discussion board.

May require #759 and #757 in order to compile correctly.