### PR TITLE
Track threads started in initializers and make them available

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/Vm.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Vm.java
@@ -258,4 +258,11 @@ public interface Vm {
      * @return the lookup object (not {@code null})
      */
     VmObject getLookup(VmClass vmClass);
+
+    /**
+     * Get the complete list of threads which were started from within interpreted code.
+     *
+     * @return the thread list
+     */
+    VmThread[] getStartedThreads();
 }


### PR DESCRIPTION
Just an incremental step over what's already there. Next step would be finding a solution for starting them up at run time (see #764 for more discussion).