### PR TITLE
Improve CPU utilization of DOT generation

### DIFF
--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -1548,11 +1548,19 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
     }
 
     private String nextName() {
-        return "n" + counter++;
+        int id = counter++;
+        if (id > 500) {
+            throw new TooBigException();
+        }
+        return "n" + id;
     }
 
     private String nextBBName() {
-        return "b" + bbCounter++;
+        int id = bbCounter++;
+        if (id > 100) {
+            throw new TooBigException();
+        }
+        return "b" + id;
     }
 
     void processPhiQueue(Appendable param) {


### PR DESCRIPTION
Improve CPU utilization by further limiting the size/complexity of DOT graphs and running DOT tasks in parallel; also, quiet the warning output when a DOT graph is too big