### PR TITLE
Add @undef annotation, C probe fixes

### DIFF
--- a/machine/probe/src/main/java/org/qbicc/machine/probe/CProbe.java
+++ b/machine/probe/src/main/java/org/qbicc/machine/probe/CProbe.java
@@ -186,6 +186,11 @@ public final class CProbe {
             return this;
         }
 
+        public Builder undef(String key) {
+            items.add(new Undefine(key));
+            return this;
+        }
+
         public Builder line(int line, String file) {
             if (line > 0) {
                 items.add(new Line(line, file));
@@ -936,8 +941,14 @@ public final class CProbe {
         }
 
         StringBuilder appendTo(final StringBuilder b) {
+            b.append('#').append("if").append(' ').append("defined").append('(').append(key).append(')');
+            nl(b);
+            b.append('#').append("undef").append(' ').append(key);
+            nl(b);
+            b.append('#').append("endif");
+            nl(b);
             b.append('#').append("define").append(' ').append(key);
-            Iterator iterator = arguments.iterator();
+            Iterator<String> iterator = arguments.iterator();
             if (iterator.hasNext()) {
                 b.append('(');
                 b.append(iterator.next());
@@ -950,6 +961,23 @@ public final class CProbe {
             if (value != null && ! value.isEmpty()) {
                 b.append(' ').append(value);
             }
+            return nl(b);
+        }
+    }
+
+    static final class Undefine extends PreProc {
+        private final String key;
+
+        Undefine(final String key) {
+            this.key = key;
+        }
+
+        StringBuilder appendTo(final StringBuilder b) {
+            b.append('#').append("if").append(' ').append("defined").append('(').append(key).append(')');
+            nl(b);
+            b.append('#').append("undef").append(' ').append(key);
+            nl(b);
+            b.append('#').append("endif");
             return nl(b);
         }
     }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
@@ -235,9 +235,16 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
 
             private String getFunctionNameFromMacro(final MethodElement origMethod) {
                 CProbe.Builder builder = CProbe.builder();
+                ProbeUtils.ProbeProcessor pp = new ProbeUtils.ProbeProcessor(classCtxt, origMethod.getEnclosingType());
                 for (Annotation annotation : origMethod.getEnclosingType().getInvisibleAnnotations()) {
-                    ProbeUtils.processCommonAnnotation(classCtxt, origMethod, builder, annotation);
+                    pp.processAnnotation(annotation);
                 }
+                pp.accept(builder);
+                pp = new ProbeUtils.ProbeProcessor(classCtxt, origMethod);
+                for (Annotation annotation : origMethod.getInvisibleAnnotations()) {
+                    pp.processAnnotation(annotation);
+                }
+                pp.accept(builder);
                 builder.probeMacroFunctionName(origMethod.getName(), origMethod.getSourceFileName(), 0);
                 CProbe probe = builder.build();
                 CProbe.Result result;

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
@@ -16,6 +16,8 @@ final class Native {
     static final String ANN_ALIGN_LIST = className(align.List.class);
     static final String ANN_DEFINE = className(define.class);
     static final String ANN_DEFINE_LIST = className(define.List.class);
+    static final String ANN_UNDEF = className(define.class);
+    static final String ANN_UNDEF_LIST = className(define.List.class);
     static final String ANN_EXTERN = className(extern.class);
     static final String ANN_EXPORT = className(export.class);
     static final String ANN_INCLUDE = className(include.class);

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -1074,6 +1074,38 @@ public final class CNative {
         }
     }
 
+    @Repeatable(undef.List.class)
+    @Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+    @Retention(RetentionPolicy.CLASS)
+    public @interface undef {
+        /**
+         * The name of the symbol being undefined. Must not be empty.
+         *
+         * @return the name
+         */
+        String value();
+
+        /**
+         * Cause this annotation to take effect only if <em>all</em> of the given conditions return {@code true}.
+         *
+         * @return the condition classes
+         */
+        Class<? extends BooleanSupplier>[] when() default {};
+
+        /**
+         * Prevent this annotation from taking effect if <em>all</em> of the given conditions return {@code true}.
+         *
+         * @return the condition classes
+         */
+        Class<? extends BooleanSupplier>[] unless() default {};
+
+        @Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+        @Retention(RetentionPolicy.CLASS)
+        @interface List {
+            undef[] value();
+        }
+    }
+
     @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.CLASS)
     public @interface macro {


### PR DESCRIPTION
Adds an `@undef` annotation and ensures that define/undef come before include; also makes sure that members can (for the most part) override enclosing class annotations by ordering their define/undefs after the enclosing type