### PR TITLE
post #760 cleanup of Reachability

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -328,7 +328,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 if (nogc) {
                                     builder.addPreHook(Phase.ADD, new NoGcSetupHook());
                                 }
-                                builder.addPreHook(Phase.ADD, ReachabilityInfo::forceCoreClassesReachableBuildTimeInit);
+                                builder.addPreHook(Phase.ADD, ReachabilityInfo::forceCoreClassesReachable);
                                 builder.addElementHandler(Phase.ADD, new ElementBodyCreator());
                                 builder.addElementHandler(Phase.ADD, new ElementVisitorAdapter(new DotGenerator(Phase.ADD, graphGenConfig)));
                                 builder.addElementHandler(Phase.ADD, new ElementInitializer());
@@ -355,11 +355,11 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, LocalThrowHandlingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, SynchronizedMethodBasicBlockBuilder::createIfNeeded);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.OPTIMIZE, SimpleOptBasicBlockBuilder::new);
-                                builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForBuildTimeInit);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::reportStats);
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::clear);
 
-                                builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachableBuildTimeInit);
+                                builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachable);
                                 builder.addElementHandler(Phase.ANALYZE, new ElementBodyCopier());
                                 builder.addElementHandler(Phase.ANALYZE, new ElementVisitorAdapter(new DotGenerator(Phase.ANALYZE, graphGenConfig)));
                                 if (optGotos) {
@@ -380,7 +380,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 if (optInlining) {
                                     builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.OPTIMIZE, InliningBasicBlockBuilder::new);
                                 }
-                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::initForBuildTimeInit);
+                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, LocalVariableFindingBasicBlockBuilder::new);
                                 builder.addPostHook(Phase.ANALYZE, ReachabilityInfo::reportStats);
                                 // todo: restore when adapted for run time initializers

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -19,13 +19,13 @@ interface ReachabilityAnalysis {
 
     void processReachableStaticInvoke(final InvokableElement target, ExecutableElement originalElement);
 
-    void processReachableConstructorInvoke(LoadedTypeDefinition ltd, ConstructorElement target, boolean buildTimeInit, ExecutableElement originalElement);
+    void processReachableConstructorInvoke(LoadedTypeDefinition ltd, ConstructorElement target, ExecutableElement originalElement);
 
     void processReachableInstanceMethodInvoke(final MethodElement target, ExecutableElement originalElement);
 
-    void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, boolean buildTimeInit, ExecutableElement originalElement);
+    void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement originalElement);
 
-    void processClassInitialization(final LoadedTypeDefinition ltd, boolean buildTimeInit);
+    void processClassInitialization(final LoadedTypeDefinition ltd);
 
     void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement originalElement);
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
@@ -103,11 +103,7 @@ public class ReachabilityInfo {
 
     // We force some fundamental types to be considered reachable even if the program doesn't use them.
     // This simplifies the implementation of the core runtime.
-    public static void forceCoreClassesReachableBuildTimeInit(CompilationContext ctxt) {
-        forceCoreClassesReachable(ctxt, true);
-    }
-
-    private static void forceCoreClassesReachable(CompilationContext ctxt, boolean buildTimeInit) {
+    public static void forceCoreClassesReachable(CompilationContext ctxt) {
         ReachabilityInfo info = get(ctxt);
         CoreClasses cc = CoreClasses.get(ctxt);
         LOGGER.debugf("Forcing all array types reachable/instantiated");
@@ -116,7 +112,7 @@ public class ReachabilityInfo {
         LoadedTypeDefinition cloneable = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Cloneable").load();
         LoadedTypeDefinition serializable = ctxt.getBootstrapClassContext().findDefinedType("java/io/Serializable").load();
         info.analysis.processInstantiatedClass(obj, true, false,null);
-        info.analysis.processClassInitialization(obj, buildTimeInit);
+        info.analysis.processClassInitialization(obj);
         info.addReachableInterface(cloneable);
         info.addReachableInterface(serializable);
         for (String d : desc) {
@@ -130,17 +126,17 @@ public class ReachabilityInfo {
         LOGGER.debugf("Forcing java.lang.Class reachable/instantiated");
         LoadedTypeDefinition clz = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Class").load();
         info.analysis.processInstantiatedClass(clz, true, false,null);
-        info.analysis.processClassInitialization(clz, buildTimeInit);
+        info.analysis.processClassInitialization(clz);
 
         LOGGER.debugf("Forcing jdk.internal.misc.Unsafe reachable/instantiated");
         LoadedTypeDefinition unsafe = ctxt.getBootstrapClassContext().findDefinedType("jdk/internal/misc/Unsafe").load();
         info.analysis.processInstantiatedClass(unsafe, true, false,null);
-        info.analysis.processClassInitialization(unsafe, buildTimeInit);
+        info.analysis.processClassInitialization(unsafe);
 
         // Hack around the way NoGC entrypoints are registered and then not used until LOWERING PHASE...
         LOGGER.debugf("Forcing org.qbicc.runtime.gc.nogc.NoGcHelpers reachable");
         LoadedTypeDefinition nogc = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/gc/nogc/NoGcHelpers").load();
-        info.analysis.processClassInitialization(nogc, buildTimeInit);
+        info.analysis.processClassInitialization(nogc);
     }
 
     public boolean isInvokableMethod(MethodElement meth) {


### PR DESCRIPTION
Simplify reachability analysis by removing conditional logic for
processing <clinit> methods at either build time or runtime.