### PR TITLE
Add VMHelpers methods that raise an exception as entry points

### DIFF
--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
@@ -26,15 +26,15 @@ public class VMHelpersSetupHook implements Consumer<CompilationContext> {
         ctxt.enqueue(ctxt.getVMHelperMethod("get_superclass"));
 
         // Helpers to create and throw common runtime exceptions
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseAbstractMethodError"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseArithmeticException"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseArrayIndexOutOfBoundsException"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseArrayStoreException"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseClassCastException"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseNegativeArraySizeException"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseNullPointerException"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseAbstractMethodError"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArithmeticException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArrayIndexOutOfBoundsException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArrayStoreException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseClassCastException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseNegativeArraySizeException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseNullPointerException"));
+        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError"));
 
         // Object monitors
         ctxt.enqueue(ctxt.getVMHelperMethod("monitor_enter"));


### PR DESCRIPTION
Some of the methods like `VMHelpers#raiseUnsatisfiedLinkError`
may be referenced post lower phase only. Therefore if we rely on manually
enqueuing such methods, then it has to be done in each phase.
Instead its better if we register them as entry points so that they get
queued in each phase.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>