### PR TITLE
Exclude Hidden methods from stack trace

### DIFF
--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -67,7 +67,7 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
             methodName = ((FunctionElement)element).getName();
         }
         String fileName = element.getSourceFileName();
-        String className = element.getEnclosingType().getInternalName();
+        String className = element.getEnclosingType().getInternalName().replace('/', '.');
         String methodDesc = element.getDescriptor().toString();
         int typeId = element.getEnclosingType().load().getTypeId();
 
@@ -85,7 +85,7 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
         SymbolLiteral mdLiteral = btHeap.getSerializedVmObject(vm.intern(methodDesc));
         Assert.assertNotNull(mdLiteral);
 
-        return methodData.add(new MethodInfo(fnLiteral, cnLiteral, mnLiteral, mdLiteral, typeId));
+        return methodData.add(new MethodInfo(fnLiteral, cnLiteral, mnLiteral, mdLiteral, typeId, element.getModifiers()));
     }
 
     private int createSourceCodeInfo(CompilationContext ctxt, MethodData methodData, ExecutableElement element, int lineNumber, int bcIndex, int inlinedAtIndex) {
@@ -186,12 +186,14 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
             Literal mnLiteral = castHeapSymbolTo(ctxt, minfo.getMethodNameSymbolLiteral(), jlsRef);
             Literal mdLiteral = castHeapSymbolTo(ctxt, minfo.getMethodDescSymbolLiteral(), jlsRef);
             Literal typeIdLiteral = lf.literalOf(minfo.getTypeId());
+            Literal modifiersLiteral = lf.literalOf(minfo.getModifiers());
 
             valueMap.put(methodInfoType.getMember("fileName"), fnLiteral);
             valueMap.put(methodInfoType.getMember("className"), cnLiteral);
             valueMap.put(methodInfoType.getMember("methodName"), mnLiteral);
             valueMap.put(methodInfoType.getMember("methodDesc"), mdLiteral);
             valueMap.put(methodInfoType.getMember("typeId"), typeIdLiteral);
+            valueMap.put(methodInfoType.getMember("modifiers"), modifiersLiteral);
             return lf.literalOf(methodInfoType, valueMap);
         }).toArray(Literal[]::new);
 

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
@@ -46,6 +46,7 @@ public class MethodDataTypes {
             .addNextMember("methodName", jlsRef)
             .addNextMember("methodDesc", jlsRef)
             .addNextMember("typeId", ts.getUnsignedInteger32Type())
+            .addNextMember("modifiers", ts.getUnsignedInteger32Type())
             .build();
 
         sourceCodeInfoType = CompoundType.builder(ts)

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
@@ -10,13 +10,15 @@ final class MethodInfo {
     private SymbolLiteral methodNameSymbolLiteral;
     private SymbolLiteral methodDescSymbolLiteral;
     private int typeId;
+    private int modifiers;
 
-    MethodInfo(SymbolLiteral fileSymbolLiteral, SymbolLiteral classSymbolLiteral, SymbolLiteral methodSymbolLiteral, SymbolLiteral methodDescSymbolLiteral, int typeId) {
+    MethodInfo(SymbolLiteral fileSymbolLiteral, SymbolLiteral classSymbolLiteral, SymbolLiteral methodSymbolLiteral, SymbolLiteral methodDescSymbolLiteral, int typeId, int modifiers) {
         this.fileNameSymbolLiteral = fileSymbolLiteral;
         this.classNameSymbolLiteral = classSymbolLiteral;
         this.methodNameSymbolLiteral = methodSymbolLiteral;
         this.methodDescSymbolLiteral = methodDescSymbolLiteral;
         this.typeId = typeId;
+        this.modifiers = modifiers;
     }
 
     public boolean equals(Object other) {
@@ -24,9 +26,11 @@ final class MethodInfo {
         if (other == null || getClass() != other.getClass()) return false;
         MethodInfo that = (MethodInfo) other;
         return Objects.equals(fileNameSymbolLiteral, that.fileNameSymbolLiteral) // fileNameSymbolLiteral can be null, avoid using equals() on it
-            && classNameSymbolLiteral.equals(that.classNameSymbolLiteral)
-            && methodNameSymbolLiteral.equals(that.methodNameSymbolLiteral)
-            && methodDescSymbolLiteral.equals(that.methodDescSymbolLiteral);
+            && Objects.equals(classNameSymbolLiteral, that.classNameSymbolLiteral)
+            && Objects.equals(methodNameSymbolLiteral, that.methodNameSymbolLiteral)
+            && Objects.equals(methodDescSymbolLiteral, that.methodDescSymbolLiteral)
+            && typeId == that.typeId
+            && modifiers == that.modifiers;
     }
 
     SymbolLiteral getFileNameSymbolLiteral() {
@@ -49,12 +53,10 @@ final class MethodInfo {
         return typeId;
     }
 
+    int getModifiers() { return modifiers; }
+
     @Override
     public int hashCode() {
-        int result = fileNameSymbolLiteral != null ? fileNameSymbolLiteral.hashCode() : 0;
-        result = 31 * result + (classNameSymbolLiteral != null ? classNameSymbolLiteral.hashCode() : 0);
-        result = 31 * result + (methodNameSymbolLiteral != null ? methodNameSymbolLiteral.hashCode() : 0);
-        result = 31 * result + (methodDescSymbolLiteral != null ? methodDescSymbolLiteral.hashCode() : 0);
-        return result;
+        return Objects.hash(fileNameSymbolLiteral, classNameSymbolLiteral, methodDescSymbolLiteral, methodDescSymbolLiteral, typeId, modifiers);
     }
 }

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/MethodDataStringsSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/MethodDataStringsSerializer.java
@@ -43,7 +43,7 @@ public final class MethodDataStringsSerializer extends DelegatingBasicBlockBuild
         }
 
         String fileName = element.getSourceFileName();
-        String className = element.getEnclosingType().getInternalName();
+        String className = element.getEnclosingType().getInternalName().replace('/', '.');
         String methodDesc = element.getDescriptor().toString();
 
         if (fileName != null) {

--- a/runtime/main/pom.xml
+++ b/runtime/main/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>org.qbicc</groupId>
+            <artifactId>qbicc-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.qbicc</groupId>
             <artifactId>qbicc-runtime-api</artifactId>
         </dependency>
         <dependency>

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/Main.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/Main.java
@@ -4,6 +4,7 @@ import static org.qbicc.runtime.CNative.*;
 import static org.qbicc.runtime.posix.PThread.pthread_exit;
 
 import org.qbicc.runtime.Build;
+import org.qbicc.runtime.Hidden;
 import org.qbicc.runtime.NotReachableException;
 
 /**
@@ -24,6 +25,7 @@ public final class Main {
     static native ThreadGroup createSystemThreadGroup();
 
     @export
+    @Hidden
     public static c_int main(c_int argc, char_ptr[] argv) {
 
         // first set up VM

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
@@ -1,35 +1,67 @@
 package org.qbicc.runtime.stackwalk;
 
+import org.qbicc.runtime.Hidden;
+import org.qbicc.type.definition.classfile.ClassFile;
+
 public class JavaStackWalker implements StackFrameVisitor {
+    private Throwable exceptionObject;
     private JavaStackFrameVisitor visitor;
     private int javaFrameCount;
 
-    private JavaStackWalker(JavaStackFrameVisitor visitor) {
+    private JavaStackWalker(Throwable exceptionObject, JavaStackFrameVisitor visitor) {
+        this.exceptionObject = exceptionObject;
         this.visitor = visitor;
-        javaFrameCount = 0;
+        this.javaFrameCount = 0;
     }
 
-    public static int getFrameCount() {
-        JavaStackWalker javaStackWalker = new JavaStackWalker(new NopVisitor());
+    @Hidden
+    public static int getFrameCount(Throwable exceptionObject) {
+        JavaStackWalker javaStackWalker = new JavaStackWalker(exceptionObject, new NopVisitor());
         StackWalker.walkStack(javaStackWalker);
         return javaStackWalker.javaFrameCount;
     }
 
-    public static void walkStack(JavaStackFrameVisitor visitor) {
-        StackFrameVisitor javaStackWalker = new JavaStackWalker(visitor);
+    @Hidden
+    public static void walkStack(Throwable exceptionObject, JavaStackFrameVisitor visitor) {
+        StackFrameVisitor javaStackWalker = new JavaStackWalker(exceptionObject, visitor);
         StackWalker.walkStack(javaStackWalker);
+    }
+
+    private boolean skipFrame(int scIndex, boolean isTopFrame) {
+        int minfoIndex = MethodData.getMethodInfoIndex(scIndex);
+        String methodName = MethodData.getMethodName(minfoIndex);
+        String className = MethodData.getClassName(minfoIndex);
+
+        if (isTopFrame) {
+            // if this is top frame, skip it if it is for excepption constructor or "fillInStackTrace" method
+            if (exceptionObject.getClass().getName().equals(className)) {
+                if (methodName.equals("<init>") || methodName.equals("fillInStackTrace")) {
+                    return true;
+                }
+            }
+        }
+        if (MethodData.hasAllModifiersOf(minfoIndex, ClassFile.I_ACC_HIDDEN)) {
+            return true;
+        }
+        return false;
     }
 
     public void visitFrame(int frameIndex, long ip, long sp) {
         int index = MethodData.findInstructionIndex(ip);
         if (index != -1) {
             int scIndex = MethodData.getSourceCodeInfoIndex(index);
-            visitor.visitFrame(javaFrameCount, scIndex);
-            javaFrameCount += 1;
+            boolean topFrame = (javaFrameCount == 0);
+            if (!skipFrame(scIndex, topFrame)) {
+                visitor.visitFrame(javaFrameCount, scIndex);
+                javaFrameCount += 1;
+            }
             int inlinedAtIndex = MethodData.getInlinedAtIndex(scIndex);
             while (inlinedAtIndex != -1) {
-                visitor.visitFrame(javaFrameCount, inlinedAtIndex);
-                javaFrameCount += 1;
+                topFrame = (javaFrameCount == 0);
+                if (!skipFrame(scIndex, topFrame)) {
+                    visitor.visitFrame(javaFrameCount, inlinedAtIndex);
+                    javaFrameCount += 1;
+                }
                 inlinedAtIndex = MethodData.getInlinedAtIndex(inlinedAtIndex);
             }
         } else {

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -9,6 +9,16 @@ public final class MethodData {
     public static native String getMethodName(int minfoIndex);
     public static native String getMethodDesc(int minfoIndex);
     public static native int getTypeId(int minfoIndex);
+    public static native int getModifiers(int minfoIndex);
+    public static boolean hasAllModifiersOf(int minfoIndex, int mask) {
+        int modifiers = getModifiers(minfoIndex);
+        return (modifiers & mask) == mask;
+    }
+
+    public static boolean hasNoModifiersOf(int minfoIndex, int mask) {
+        int modifiers = getModifiers(minfoIndex);
+        return (modifiers & mask) == 0;
+    }
 
     public static native int getMethodInfoIndex(int scIndex);
     public static native int getLineNumber(int scIndex);


### PR DESCRIPTION
~Do not generate method data for methods marked as `Hidden` so that
they are not included in stack trace.~
Store method modifiers in method data so that the frames for methods
marked as hidden can be skipped when creating stack trace.
Annotate following methods with `Hidden` annotation:
- `org.qbicc.runtime.Main#main`
- `org.qbicc.runtime.stackwalk.JavaStackWalker#getFrameCount`
- `org.qbicc.runtime.stackwalk.JavaStackWalker#walkStack`
    
Also exclude exception constructors and `Throwable.fillInStackTrace`
method from stack trace

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>