### PR TITLE
No longer need qbicc-runtime-api dep in hello.world example

### DIFF
--- a/examples/helloworld/hello/world/Main.java
+++ b/examples/helloworld/hello/world/Main.java
@@ -9,7 +9,6 @@
 // Run the executable
 // $ /tmp/output/a.out
 //
-//DEPS org.qbicc:qbicc-runtime-api:0.1.0-SNAPSHOT
 package hello.world;
 
 /**


### PR DESCRIPTION
We don't need the dependency, and having it actually is a problem for doing
```
 --boot-path-append-file $(jbang info classpath examples/helloworld/hello/world/Main.java)
```
 because `--boot-path-append-file` doesn't support currently support adding a `:` separated list of files.
