### PR TITLE
Use typeId in MethodData to get class name

### DIFF
--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -67,7 +67,6 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
             methodName = ((FunctionElement)element).getName();
         }
         String fileName = element.getSourceFileName();
-        String className = element.getEnclosingType().getInternalName().replace('/', '.');
         String methodDesc = element.getDescriptor().toString();
         int typeId = element.getEnclosingType().load().getTypeId();
 
@@ -78,14 +77,12 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
             fnLiteral = btHeap.getSerializedVmObject(vm.intern(fileName));
             Assert.assertNotNull(fnLiteral);
         }
-        SymbolLiteral cnLiteral = btHeap.getSerializedVmObject(vm.intern(className));
-        Assert.assertNotNull(cnLiteral);
         SymbolLiteral mnLiteral = btHeap.getSerializedVmObject(vm.intern(methodName));
         Assert.assertNotNull(mnLiteral);
         SymbolLiteral mdLiteral = btHeap.getSerializedVmObject(vm.intern(methodDesc));
         Assert.assertNotNull(mdLiteral);
 
-        return methodData.add(new MethodInfo(fnLiteral, cnLiteral, mnLiteral, mdLiteral, typeId, element.getModifiers()));
+        return methodData.add(new MethodInfo(fnLiteral, mnLiteral, mdLiteral, typeId, element.getModifiers()));
     }
 
     private int createSourceCodeInfo(CompilationContext ctxt, MethodData methodData, ExecutableElement element, int lineNumber, int bcIndex, int inlinedAtIndex) {
@@ -182,14 +179,12 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
         Literal[] minfoLiterals = Arrays.stream(minfoList).parallel().map(minfo -> {
             HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
             Literal fnLiteral = castHeapSymbolTo(ctxt, minfo.getFileNameSymbolLiteral(), jlsRef);
-            Literal cnLiteral = castHeapSymbolTo(ctxt, minfo.getClassNameSymbolLiteral(), jlsRef);
             Literal mnLiteral = castHeapSymbolTo(ctxt, minfo.getMethodNameSymbolLiteral(), jlsRef);
             Literal mdLiteral = castHeapSymbolTo(ctxt, minfo.getMethodDescSymbolLiteral(), jlsRef);
             Literal typeIdLiteral = lf.literalOf(minfo.getTypeId());
             Literal modifiersLiteral = lf.literalOf(minfo.getModifiers());
 
             valueMap.put(methodInfoType.getMember("fileName"), fnLiteral);
-            valueMap.put(methodInfoType.getMember("className"), cnLiteral);
             valueMap.put(methodInfoType.getMember("methodName"), mnLiteral);
             valueMap.put(methodInfoType.getMember("methodDesc"), mdLiteral);
             valueMap.put(methodInfoType.getMember("typeId"), typeIdLiteral);

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
@@ -42,7 +42,6 @@ public class MethodDataTypes {
             .setName("qbicc_method_info")
             .setOverallAlignment(jlsRef.getAlign())
             .addNextMember("fileName", jlsRef)
-            .addNextMember("className", jlsRef)
             .addNextMember("methodName", jlsRef)
             .addNextMember("methodDesc", jlsRef)
             .addNextMember("typeId", ts.getUnsignedInteger32Type())

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodInfo.java
@@ -6,15 +6,13 @@ import java.util.Objects;
 
 final class MethodInfo {
     private SymbolLiteral fileNameSymbolLiteral;
-    private SymbolLiteral classNameSymbolLiteral;
     private SymbolLiteral methodNameSymbolLiteral;
     private SymbolLiteral methodDescSymbolLiteral;
     private int typeId;
     private int modifiers;
 
-    MethodInfo(SymbolLiteral fileSymbolLiteral, SymbolLiteral classSymbolLiteral, SymbolLiteral methodSymbolLiteral, SymbolLiteral methodDescSymbolLiteral, int typeId, int modifiers) {
+    MethodInfo(SymbolLiteral fileSymbolLiteral, SymbolLiteral methodSymbolLiteral, SymbolLiteral methodDescSymbolLiteral, int typeId, int modifiers) {
         this.fileNameSymbolLiteral = fileSymbolLiteral;
-        this.classNameSymbolLiteral = classSymbolLiteral;
         this.methodNameSymbolLiteral = methodSymbolLiteral;
         this.methodDescSymbolLiteral = methodDescSymbolLiteral;
         this.typeId = typeId;
@@ -25,8 +23,7 @@ final class MethodInfo {
         if (this == other) return true;
         if (other == null || getClass() != other.getClass()) return false;
         MethodInfo that = (MethodInfo) other;
-        return Objects.equals(fileNameSymbolLiteral, that.fileNameSymbolLiteral) // fileNameSymbolLiteral can be null, avoid using equals() on it
-            && Objects.equals(classNameSymbolLiteral, that.classNameSymbolLiteral)
+        return Objects.equals(fileNameSymbolLiteral, that.fileNameSymbolLiteral)
             && Objects.equals(methodNameSymbolLiteral, that.methodNameSymbolLiteral)
             && Objects.equals(methodDescSymbolLiteral, that.methodDescSymbolLiteral)
             && typeId == that.typeId
@@ -35,10 +32,6 @@ final class MethodInfo {
 
     SymbolLiteral getFileNameSymbolLiteral() {
         return fileNameSymbolLiteral;
-    }
-
-    SymbolLiteral getClassNameSymbolLiteral() {
-        return classNameSymbolLiteral;
     }
 
     SymbolLiteral getMethodNameSymbolLiteral() {
@@ -57,6 +50,6 @@ final class MethodInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileNameSymbolLiteral, classNameSymbolLiteral, methodDescSymbolLiteral, methodDescSymbolLiteral, typeId, modifiers);
+        return Objects.hash(fileNameSymbolLiteral, methodDescSymbolLiteral, methodDescSymbolLiteral, typeId, modifiers);
     }
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -1,15 +1,27 @@
 package org.qbicc.runtime.stackwalk;
 
 import org.qbicc.runtime.CNative;
+import org.qbicc.runtime.main.ObjectModel;
+
+import static org.qbicc.runtime.CNative.*;
 
 public final class MethodData {
 
     public static native String getFileName(int minfoIndex);
-    public static native String getClassName(int minfoIndex);
     public static native String getMethodName(int minfoIndex);
     public static native String getMethodDesc(int minfoIndex);
     public static native int getTypeId(int minfoIndex);
     public static native int getModifiers(int minfoIndex);
+
+    public static String getClassName(int minfoIndex) {
+        return getClass(minfoIndex).getName();
+    }
+
+    public static Class<?> getClass(int minfoIndex) {
+        type_id typeId = word(getTypeId(minfoIndex));
+        return ObjectModel.get_class_from_type_id(typeId, word(0));
+    }
+
     public static boolean hasAllModifiersOf(int minfoIndex, int mask) {
         int modifiers = getModifiers(minfoIndex);
         return (modifiers & mask) == mask;


### PR DESCRIPTION
MethodData stores typeId and that can be used to get the class name,
instead of storing pointer to class name String object explicitly.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>