### PR TITLE
Delete files if they're too big

### DIFF
--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotGenerator.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotGenerator.java
@@ -120,24 +120,35 @@ public class DotGenerator implements ElementVisitor<CompilationContext, Void>, C
             return;
         }
         Path path = dir.resolve(phase.toString() + ".dot");
-        try (BufferedWriter bw = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
-            bw.write("digraph {");
-            bw.newLine();
-            bw.write("graph [ rankdir = BT ];");
-            bw.newLine();
-            bw.write("edge [ splines = true ];");
-            bw.newLine();
-            bw.newLine();
-            DotNodeVisitor visitor = new DotNodeVisitor(entryBlock);
-            visitor.process(bw);
-            bw.write("}");
-        } catch (IOException e) {
-            failedToWrite(ctxt, path, e);
-        } catch (UncheckedIOException e) {
-            IOException cause = e.getCause();
-            failedToWrite(ctxt, path, cause);
+        try {
+            try (BufferedWriter bw = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                bw.write("digraph {");
+                bw.newLine();
+                bw.write("graph [ rankdir = BT ];");
+                bw.newLine();
+                bw.write("edge [ splines = true ];");
+                bw.newLine();
+                bw.newLine();
+                DotNodeVisitor visitor = new DotNodeVisitor(entryBlock);
+                visitor.process(bw);
+                bw.write("}");
+            } catch (IOException e) {
+                failedToWrite(ctxt, path, e);
+            } catch (UncheckedIOException e) {
+                IOException cause = e.getCause();
+                failedToWrite(ctxt, path, cause);
+            } catch (TooBigException e) {
+                log.debugf("Element \"%s\" is too big to graph", element);
+                throw e;
+            }
         } catch (TooBigException e) {
-            log.debugf("Element \"%s\" is too big to graph", element);
+            try {
+                // Some operating systems will not let you delete a file while it is open.
+                // So, if the graph is too big, attempt to delete the file when the original file has been closed.
+                Files.delete(path);
+            } catch (IOException ex) {
+                // Ignore
+            }
         }
     }
 

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -401,7 +401,7 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
     public String visit(Appendable param, LocalVariable node) {
         String name = register(node);
         appendTo(param, name);
-        attr(param, "label", "local\n\n"+node.getVariableElement().getName());
+        attr(param, "label", "local\\n\\n"+node.getVariableElement().getName());
         nl(param);
         return name;
     }


### PR DESCRIPTION
Closes #806

* This avoids confusion when files are partially written,
and you think the dot node visitor has a bug instead.
* Also fixed some formatting on local variables.
* Too big graphs take too long to convert to svg,
so discarding option to add a system property to expand
the configured counts in dot node visitor.