### PR TITLE
Complete vararg calling support

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/InsertElement.java
+++ b/compiler/src/main/java/org/qbicc/graph/InsertElement.java
@@ -2,6 +2,7 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -84,6 +85,10 @@ public final class InsertElement extends AbstractValue implements Unschedulable 
     @Override
     public <T, R> R accept(ValueVisitor<T, R> visitor, T param) {
         return visitor.visit(param, this);
+    }
+
+    public Value extractElement(LiteralFactory lf, final Value index) {
+        return index.equals(this.index) ? insertedValue : arrayValue.extractElement(lf, index);
     }
 
     public boolean isConstant() {

--- a/compiler/src/main/java/org/qbicc/graph/InsertMember.java
+++ b/compiler/src/main/java/org/qbicc/graph/InsertMember.java
@@ -2,6 +2,7 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -84,6 +85,11 @@ public final class InsertMember extends AbstractValue implements Unschedulable {
     @Override
     public <T, R> R accept(ValueVisitor<T, R> visitor, T param) {
         return visitor.visit(param, this);
+    }
+
+    @Override
+    public Value extractMember(LiteralFactory lf, CompoundType.Member member) {
+        return member.equals(this.member) ? insertedValue : compoundValue.extractMember(lf, member);
     }
 
     public boolean isConstant() {

--- a/compiler/src/main/java/org/qbicc/graph/Value.java
+++ b/compiler/src/main/java/org/qbicc/graph/Value.java
@@ -1,5 +1,7 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.type.CompoundType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.ValueType;
 
@@ -39,6 +41,28 @@ public interface Value extends Node {
 
     default boolean isDefNaN() {
         return false;
+    }
+
+    /**
+     * Extract an element from this array value if it has a known value for the given index.
+     *
+     * @param lf the literal factory (must not be {@code null})
+     * @param index the element index value (must not be {@code null})
+     * @return the extracted value, or {@code null} if the value is not known
+     */
+    default Value extractElement(LiteralFactory lf, Value index) {
+        return null;
+    }
+
+    /**
+     * Extract a member from this compound value if it has a known value for the given member.
+     *
+     * @param lf the literal factory (must not be {@code null})
+     * @param member the member (must not be {@code null})
+     * @return the extracted value, or {@code null} if the value is not known
+     */
+    default Value extractMember(LiteralFactory lf, CompoundType.Member member) {
+        return null;
     }
 
     default boolean isDefNotNaN() {

--- a/compiler/src/main/java/org/qbicc/graph/literal/ArrayLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ArrayLiteral.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
+import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueVisitor;
 import org.qbicc.type.ArrayType;
 
@@ -31,6 +32,17 @@ public final class ArrayLiteral extends Literal {
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    @Override
+    public Value extractElement(LiteralFactory lf, Value index) {
+        if (index instanceof IntegerLiteral il) {
+            final int realIndex = il.intValue();
+            if (0 <= realIndex && realIndex < values.size()) {
+                return values.get(realIndex);
+            }
+        }
+        return null;
     }
 
     public boolean isZero() {

--- a/compiler/src/main/java/org/qbicc/graph/literal/ByteArrayLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ByteArrayLiteral.java
@@ -2,8 +2,11 @@ package org.qbicc.graph.literal;
 
 import java.util.Arrays;
 
+import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueVisitor;
 import org.qbicc.type.ArrayType;
+import org.qbicc.type.IntegerType;
+import org.qbicc.type.SignedIntegerType;
 
 /**
  * A literal array of bytes.  This is not a Java array object literal (use {@code ObjectLiteral}).
@@ -29,6 +32,23 @@ public final class ByteArrayLiteral extends Literal {
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    public Value extractElement(LiteralFactory lf, final Value index) {
+        if (index instanceof IntegerLiteral il) {
+            final int realIndex = il.intValue();
+            if (0 <= realIndex && realIndex < values.length) {
+                final byte realVal = values[realIndex];
+                if (type.getElementType() instanceof IntegerType it) {
+                    if (it instanceof SignedIntegerType) {
+                        return new IntegerLiteral(it, realVal);
+                    } else {
+                        return new IntegerLiteral(it, realVal & 0xff);
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     public boolean isZero() {

--- a/compiler/src/main/java/org/qbicc/graph/literal/CompoundLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/CompoundLiteral.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 
+import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueVisitor;
 import org.qbicc.type.CompoundType;
 
@@ -32,6 +33,10 @@ public final class CompoundLiteral extends Literal {
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    public Value extractMember(LiteralFactory lf, CompoundType.Member member) {
+        return values.get(member);
     }
 
     public boolean isZero() {

--- a/compiler/src/main/java/org/qbicc/graph/literal/ZeroInitializerLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ZeroInitializerLiteral.java
@@ -1,6 +1,9 @@
 package org.qbicc.graph.literal;
 
+import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueVisitor;
+import org.qbicc.type.ArrayType;
+import org.qbicc.type.CompoundType;
 import org.qbicc.type.ValueType;
 
 /**
@@ -32,6 +35,20 @@ public final class ZeroInitializerLiteral extends Literal {
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    public Value extractElement(LiteralFactory lf, final Value index) {
+        if (type instanceof ArrayType at) {
+            return lf.zeroInitializerLiteralOfType(at.getElementType());
+        }
+        return null;
+    }
+
+    public Value extractMember(LiteralFactory lf, CompoundType.Member member) {
+        if (type instanceof CompoundType) {
+            return lf.zeroInitializerLiteralOfType(member.getType());
+        }
+        return null;
     }
 
     public int hashCode() {

--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -269,9 +269,6 @@ public final class TypeSystem {
     public ArrayType getArrayType(ValueType memberType, long elements) {
         Assert.checkNotNullParam("memberType", memberType);
         Assert.checkMinimumParameter("elements", 0, elements);
-        if (! memberType.isComplete()) {
-            throw new IllegalArgumentException("Arrays of incomplete type are not allowed");
-        }
         return new ArrayType(this, memberType, elements);
     }
 

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeResolver.java
@@ -32,6 +32,8 @@ public class NativeTypeResolver implements DescriptorTypeResolver.Delegating {
                 return classCtxt.findDefinedType("java/lang/Object").load().getClassType().getReference().getTypeType();
             } else if (rewrittenName.equals(Native.VOID)) {
                 return ctxt.getTypeSystem().getVoidType();
+            } else if (rewrittenName.equals(Native.OBJECT)) {
+                return ctxt.getTypeSystem().getVariadicType();
             } else if (rewrittenName.equals(Native.PTR)) {
                 return ctxt.getTypeSystem().getVoidType().getPointer();
             }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/PointerTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/PointerTypeResolver.java
@@ -135,7 +135,7 @@ public class PointerTypeResolver implements DescriptorTypeResolver.Delegating {
             if (elemType instanceof ArrayType) {
                 // it's an array of arrays, make it into a native array instead of a reference array
                 return ctxt.getTypeSystem().getArrayType(elemType, detectArraySize(visibleAnnotations));
-            } else if (! (elemType instanceof ObjectType) && elemType instanceof WordType && elemDesc instanceof ClassTypeDescriptor) {
+            } else if (! (elemType instanceof ObjectType) && elemDesc instanceof ClassTypeDescriptor) {
                 // this means it's an array of native type (wrapped as ref type) and should be transformed to a "real" array type
                 return ctxt.getTypeSystem().getArrayType(elemType, detectArraySize(visibleAnnotations));
             }


### PR DESCRIPTION
This works by fixing a few longstanding problems:
* Arrays of native types are actual array values instead of pointers to them
* Fully implement extraction and insertion of literal array and structure values
* Be less strict about handling values of incomplete type
* Add optimizations which can optimize away array values for vararg calls

After this patch, things like `printf(utf8z("The size of an int is %d\n"), word(sizeof(c_int.class)))` will work as expected.

As an aside, this should significantly alleviate at least some of the issues with pointer dereferencing by eliminating a class of invalid handle types.

/cc @theresa-m