### PR TITLE
Multiple optimization and verification improvements

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -56,6 +56,7 @@ import org.qbicc.plugin.coreclasses.BasicInitializationBasicBlockBuilder;
 import org.qbicc.plugin.coreclasses.BasicInitializationManualInitializer;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.constants.ConstantBasicBlockBuilder;
+import org.qbicc.plugin.correctness.StaticChecksBasicBlockBuilder;
 import org.qbicc.plugin.llvm.LLVMCompatibleBasicBlockBuilder;
 import org.qbicc.plugin.conversion.MethodCallFixupBasicBlockBuilder;
 import org.qbicc.plugin.conversion.NumericalConversionBasicBlockBuilder;
@@ -396,6 +397,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.CORRECT, SynchronizedMethodBasicBlockBuilder::createIfNeeded);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.OPTIMIZE, SimpleOptBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.INTEGRITY, StaticChecksBasicBlockBuilder::new);
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::reportStats);
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::clear);
 
@@ -424,6 +426,8 @@ public class Main implements Callable<DiagnosticContext> {
                                 }
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, LocalVariableFindingBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, StaticChecksBasicBlockBuilder::new);
+
                                 builder.addPostHook(Phase.ANALYZE, ReachabilityInfo::reportStats);
                                 // todo: restore when adapted for run time initializers
                                 //builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
@@ -467,6 +471,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, LowerVerificationBasicBlockBuilder::new);
                                 // MethodDataStringsSerializer should be the last BBB in the list
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, MethodDataStringsSerializer::new);
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, StaticChecksBasicBlockBuilder::new);
 
                                 builder.addPreHook(Phase.GENERATE, new SupersDisplayEmitter());
                                 builder.addPreHook(Phase.GENERATE, new DispatchTableEmitter());

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/StaticChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/StaticChecksBasicBlockBuilder.java
@@ -1,0 +1,91 @@
+package org.qbicc.plugin.correctness;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.BlockEarlyTermination;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.type.ArrayObjectType;
+import org.qbicc.type.ArrayType;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.PointerType;
+import org.qbicc.type.TypeSystem;
+import org.qbicc.type.UnsignedIntegerType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ *
+ */
+public final class StaticChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder {
+    private final CompilationContext ctxt;
+    private final ExecutableElement originalElement;
+
+    public StaticChecksBasicBlockBuilder(CompilationContext ctxt, BasicBlockBuilder delegate) {
+        super(delegate);
+        this.ctxt = ctxt;
+        this.originalElement = delegate.getCurrentElement();
+    }
+
+    @Override
+    public ValueHandle memberOf(ValueHandle structHandle, CompoundType.Member member) {
+        if (structHandle.getValueType() instanceof CompoundType) {
+            return super.memberOf(structHandle, member);
+        }
+        ctxt.error(getLocation(), "`memberOf` handle must have structure type");
+        throw new BlockEarlyTermination(unreachable());
+    }
+
+    @Override
+    public ValueHandle elementOf(ValueHandle array, Value index) {
+        if (array.getValueType() instanceof ArrayType || array.getValueType() instanceof ArrayObjectType) {
+            if (index.getType() instanceof UnsignedIntegerType uit) {
+                // try to extend it
+                Value extended = tryExtend(index, uit);
+                if (extended != null) {
+                    index = extended;
+                } else {
+                    ctxt.error(getLocation(), "`elementOf` index must be signed");
+                }
+                // recoverable
+            }
+            return super.elementOf(array, index);
+        }
+        ctxt.error(getLocation(), "`elementOf` handle must have array type");
+        throw new BlockEarlyTermination(unreachable());
+    }
+
+    @Override
+    public ValueHandle pointerHandle(Value pointer, Value offsetValue) {
+        if (pointer.getType() instanceof PointerType) {
+            if (offsetValue.getType() instanceof UnsignedIntegerType uit) {
+                // try to extend it
+                Value extended = tryExtend(offsetValue, uit);
+                if (extended != null) {
+                    offsetValue = extended;
+                } else {
+                    ctxt.error(getLocation(), "`pointerHandle` offset must be signed");
+                }
+                // recoverable
+            }
+            return super.pointerHandle(pointer, offsetValue);
+        }
+        ctxt.error(getLocation(), "`pointerHandle` value mut have pointer type");
+        throw new BlockEarlyTermination(unreachable());
+    }
+
+    private Value tryExtend(final Value unsignedValue, final UnsignedIntegerType inputType) {
+        final BasicBlockBuilder fb = getFirstBuilder();
+        final TypeSystem ts = ctxt.getTypeSystem();
+        if (inputType.getMinBits() < 32) {
+            return fb.extend(unsignedValue, ts.getSignedInteger32Type());
+        } else if (inputType.getMinBits() < 64) {
+            return fb.extend(unsignedValue, ts.getSignedInteger64Type());
+        } else if (unsignedValue.isDefLe(ctxt.getLiteralFactory().literalOf(ts.getSignedInteger64Type().getMaxValue()))) {
+            return fb.bitCast(unsignedValue, ts.getSignedInteger64Type());
+        } else {
+            // cannot work out a safe conversion
+            return null;
+        }
+    }
+}

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -1,8 +1,7 @@
 package org.qbicc.plugin.llvm;
 
 import static org.qbicc.machine.llvm.Types.*;
-import static org.qbicc.machine.llvm.Values.ZERO;
-import static org.qbicc.machine.llvm.Values.diExpression;
+import static org.qbicc.machine.llvm.Values.*;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -627,7 +626,11 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Type javaInputType = node.getInput().getType();
         LLValue inputType = map(javaInputType);
         LLValue llvmInput = map(node.getInput());
-        return builder.fneg(inputType, llvmInput).asLocal();
+        if (isFloating(javaInputType)) {
+            return builder.fneg(inputType, llvmInput).asLocal();
+        } else {
+            return builder.sub(inputType, ZERO, llvmInput).asLocal();
+        }
     }
 
     public LLValue visit(Void param, NotNull node) {

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/PointerBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/PointerBasicBlockBuilder.java
@@ -4,7 +4,6 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.BlockEarlyTermination;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
-import org.qbicc.graph.Load;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.type.ArrayType;
@@ -23,10 +22,6 @@ public class PointerBasicBlockBuilder extends DelegatingBasicBlockBuilder {
 
     @Override
     public ValueHandle referenceHandle(Value reference) {
-        if (reference instanceof Load) {
-            ValueHandle target = reference.getValueHandle();
-
-        }
         if (reference.getType() instanceof PointerType) {
             return pointerHandle(reference);
         } else if (reference.getType() instanceof ArrayType) {

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/GotoRemovingVisitor.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/GotoRemovingVisitor.java
@@ -8,6 +8,7 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.BlockEntry;
 import org.qbicc.graph.Goto;
+import org.qbicc.graph.If;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.NodeVisitor;
 import org.qbicc.graph.PhiValue;
@@ -42,10 +43,60 @@ public class GotoRemovingVisitor implements NodeVisitor.Delegating<Node.Copier, 
         }
     }
 
+    @Override
+    public BasicBlock visit(final Node.Copier param, final If node) {
+        // try to find diamond constructs of this form:
+        //
+        //         If(cond, a, b)
+        //        [T]/         \[F]
+        //  a: BlockEntry  b: BlockEntry
+        //     Goto(c)[g1]    Goto(c)[g2]
+        //          \          /
+        //         c: BlockEntry
+        //              [...]
+        //       [c] Phi(a: x, b: y)
+        //
+        // ...and replace them inline with:
+        //
+        //      Select(cond, x, y)
+        //
+        // ...by treating the If as a Goto to be deleted.
+
+        // determine if the shape matches.
+        if (node.getTrueBranch().getTerminator() instanceof Goto g1
+            && node.getFalseBranch().getTerminator() instanceof Goto g2
+            && g1.getResumeTarget() == g2.getResumeTarget()
+            && g1.getDependency() instanceof BlockEntry
+            && g2.getDependency() instanceof BlockEntry
+            && node.getTrueBranch().getIncoming().size() == 1
+            && node.getFalseBranch().getIncoming().size() == 1
+            && g1.getResumeTarget().getIncoming().size() == 2
+        ) {
+            // either branch works, because we want the successor's successor
+            final BasicBlock tb = node.getTrueBranch();
+            // delete the if's successor's successor and fold it into the current block
+            final BasicBlock successor = tb.getTerminator().getSuccessor(0);
+            deleted.add(successor);
+            return param.copyTerminator(successor.getTerminator());
+        } else {
+            return getDelegateTerminatorVisitor().visit(param, node);
+        }
+    }
+
     public Value visit(final Node.Copier param, final PhiValue node) {
-        if (deleted.contains(node.getPinnedBlock())) {
+        final BasicBlock pinnedBlock = node.getPinnedBlock();
+        final Set<BasicBlock> incoming = pinnedBlock.getIncoming();
+        final boolean delete = deleted.contains(pinnedBlock);
+        if (incoming.size() == 2 && delete) {
+            // This is the `phi` part of a diamond.  This `If` is the sole predecessor of either of the predecessors of the pinned block.
+            final If if_ = (If) incoming.iterator().next().getIncoming().iterator().next().getTerminator();
+            Value trueValue = param.copyValue(node.getValueForInput(if_.getTrueBranch().getTerminator()));
+            Value falseValue = param.copyValue(node.getValueForInput(if_.getFalseBranch().getTerminator()));
+            return param.getBlockBuilder().select(param.copyValue(if_.getCondition()), trueValue, falseValue);
+        } else if (delete) {
+            assert incoming.size() == 1;
             // the deleted block only has one incoming block, so the phi must also have only one valid incoming value
-            return param.copyValue(node.getValueForInput(node.getPinnedBlock().getIncoming().iterator().next().getTerminator()));
+            return param.copyValue(node.getValueForInput(incoming.iterator().next().getTerminator()));
         } else {
             return getDelegateValueVisitor().visit(param, node);
         }

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
@@ -466,11 +466,8 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
 
     @Override
     public Value addressOf(ValueHandle handle) {
-        if (handle instanceof PointerHandle ph) {
-            final Value offsetValue = ph.getOffsetValue();
-            if (offsetValue.getType() instanceof IntegerType it && offsetValue.isDefEq(ctxt.getLiteralFactory().literalOf(it, 0))) {
-                return ((PointerHandle) handle).getPointerValue();
-            }
+        if (handle instanceof PointerHandle ph && isZero(ph.getOffsetValue())) {
+            return ((PointerHandle) handle).getPointerValue();
         }
         return super.addressOf(handle);
     }

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
@@ -431,28 +431,6 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         }
     }
 
-    // special pointer behavior
-
-    @Override
-    public Value add(Value v1, Value v2) {
-        // todo: maybe opt is not the right place for this
-        if (v1.getType() instanceof PointerType) {
-            return addressOf(pointerHandle(v1, v2));
-        } else if (v2.getType() instanceof PointerType) {
-            return addressOf(pointerHandle(v2, v1));
-        }
-        return super.add(v1, v2);
-    }
-
-    @Override
-    public Value sub(Value v1, Value v2) {
-        // todo: maybe opt is not the right place for this
-        if (v1.getType() instanceof PointerType) {
-            return addressOf(pointerHandle(v1, negate(v2)));
-        }
-        return super.sub(v1, v2);
-    }
-
     @Override
     public Value negate(Value v) {
         if (isCmp(v)) {

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/SimpleOptBasicBlockBuilder.java
@@ -159,10 +159,10 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             return isEq(ctxt.getLiteralFactory().zeroInitializerLiteralOfType(input.getType()), input);
         }
 
-        if (isCmp(v1) && isLiteral(v2, 0)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, 0)) {
             return isEq(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, 0)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 0)) {
             return isEq(cmpLeft(v2), cmpRight(v2));
         }
 
@@ -197,10 +197,10 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             }
         }
 
-        if (isCmp(v1) && isLiteral(v2, 0)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, 0)) {
             return isNe(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, 0)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 0)) {
             return isNe(cmpLeft(v2), cmpRight(v2));
         }
 
@@ -224,16 +224,16 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             }
         }
 
-        if (isCmp(v1) && isLiteral(v2, 1)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, 1)) {
             return isLe(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, -1)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, -1)) {
             return isGe(cmpLeft(v2), cmpRight(v2));
         }
-        if (isCmp(v1) && isLiteral(v2, 0)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, 0)) {
             return isLt(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, 0)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 0)) {
             return isLt(cmpRight(v2), cmpLeft(v2));
         }
 
@@ -257,16 +257,16 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             }
         }
 
-        if (isCmp(v2) && isLiteral(v1, 1)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 1)) {
             return isLe(cmpLeft(v2), cmpRight(v2));
         }
-        if (isCmp(v1) && isLiteral(v2, -1)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, -1)) {
             return isGe(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v1) && isLiteral(v2, 0)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, 0)) {
             return isGt(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, 0)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 0)) {
             return isGt(cmpRight(v2), cmpLeft(v2));
         }
 
@@ -290,16 +290,16 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             }
         }
 
-        if (isCmp(v2) && isLiteral(v1, 1)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 1)) {
             return isGt(cmpLeft(v2), cmpRight(v2));
         }
-        if (isCmp(v1) && isLiteral(v2, -1)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, -1)) {
             return isLt(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v1) && isLiteral(v2, 0)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, 0)) {
             return isLe(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, 0)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 0)) {
             return isLe(cmpRight(v2), cmpLeft(v2));
         }
 
@@ -323,16 +323,16 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             }
         }
 
-        if (isCmp(v1) && isLiteral(v2, -1)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, -1)) {
             return isGe(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, -1)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, -1)) {
             return isLt(cmpLeft(v2), cmpRight(v2));
         }
-        if (isCmp(v1) && isLiteral(v2, 0)) {
+        if (isCmp(v1) && isEqualToLiteral(v2, 0)) {
             return isGe(cmpLeft(v1), cmpRight(v1));
         }
-        if (isCmp(v2) && isLiteral(v1, 0)) {
+        if (isCmp(v2) && isEqualToLiteral(v1, 0)) {
             return isGe(cmpRight(v2), cmpLeft(v2));
         }
 
@@ -488,7 +488,7 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     private boolean isZero(final Value value) {
-        return value instanceof Literal && ((Literal) value).isZero();
+        return value.isDefEq(ctxt.getLiteralFactory().zeroInitializerLiteralOfType(value.getType()));
     }
 
     private static boolean isCmp(final Value value) {
@@ -503,8 +503,8 @@ public class SimpleOptBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         return ((Cmp) value).getRightInput();
     }
 
-    private boolean isLiteral(final Value value, final int literal) {
-        return literal == 0 ? isZero(value) : value instanceof IntegerLiteral &&
-            ((IntegerLiteral) value).equals(ctxt.getLiteralFactory().literalOf(literal));
+    private boolean isEqualToLiteral(final Value value, final int literal) {
+        return value.getType() instanceof IntegerType it &&
+            value.isDefEq(ctxt.getLiteralFactory().literalOf(it, literal));
     }
 }


### PR DESCRIPTION
Introduce optimizations which:

* Convert bitcasts to the same type as the first element or member of an array or structure to a GEP construct
* Allow `Neg` to be canonical for integer negation
* Transform `If`->`Goto`x2->`Phi` diamonds to `Select`
* Improve the quality and accuracy of simple transformations in the simple optimizer
* Remove an invalid conversion
* Introduce some new simple optimizations
* Remove the old unused pointer arithmetic constructs

Introduce static verification BBB which prevents invalid or buggy constructs from being emitted.  Also, remove some dead code.