### PR TITLE
Fix compiler selection problems

### DIFF
--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/CToolChain.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/CToolChain.java
@@ -34,6 +34,10 @@ public interface CToolChain extends Tool {
         String cpuName = cpu.getSimpleName();
         OS os = platform.getOs();
         String osName = os.getName();
+        String cc = System.getenv("CC");
+        if (cc != null) {
+            names.add(cc);
+        }
         if (os == OS.LINUX && (os != Platform.HOST_PLATFORM.getOs() || cpu != Platform.HOST_PLATFORM.getCpu())) {
             names.add(cpuName + "-" + osName + "-gnu-gcc");
         }

--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/ToolProvider.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/ToolProvider.java
@@ -28,22 +28,21 @@ public interface ToolProvider {
     static <T extends Tool> Iterable<T> findAllTools(Class<T> type, final Platform platform, Predicate<? super T> filter, ClassLoader classLoader, List<Path> paths) {
         final List<T> list = new ArrayList<>();
         final ServiceLoader<ToolProvider> loader = ServiceLoader.load(ToolProvider.class, classLoader);
-        final Iterator<ToolProvider> iterator = loader.iterator();
-        for (;;)
-            try {
+        for (Path path : paths) {
+            final Iterator<ToolProvider> iterator = loader.iterator();
+            for (;;) try {
                 if (!iterator.hasNext()) {
                     break;
                 }
                 ToolProvider item = iterator.next();
-                for (Path path : paths) {
-                    for (T t : item.findTools(type, platform, path)) {
-                        if (filter.test(t)) {
-                            list.add(t);
-                        }
+                for (T t : item.findTools(type, platform, path)) {
+                    if (filter.test(t)) {
+                        list.add(t);
                     }
                 }
             } catch (ServiceConfigurationError ignored) {
             }
+        }
         return list;
     }
 }


### PR DESCRIPTION
Looks for compilers in path preference order instead of random service loader order.  Also, accept the `CC` env variable as the highest preference for C compiler.