### PR TITLE
Fix negatable options that default to `true`

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -722,9 +722,9 @@ public class Main implements Callable<DiagnosticContext> {
             boolean optMemoryTracking;
             @CommandLine.Option(names = "--opt-inlining", negatable = true, defaultValue = "false", description = "Enable/disable inliner")
             boolean optInlining;
-            @CommandLine.Option(names = "--opt-phis", negatable = true, defaultValue = "true", description = "Enable/disable `phi` elimination")
+            @CommandLine.Option(names = "--no-opt-phis", negatable = true, defaultValue = "true", description = "Enable/disable `phi` elimination")
             boolean optPhis;
-            @CommandLine.Option(names = "--opt-gotos", negatable = true, defaultValue = "true", description = "Enable/disable `goto` elimination")
+            @CommandLine.Option(names = "--no-opt-gotos", negatable = true, defaultValue = "true", description = "Enable/disable `goto` elimination")
             boolean optGotos;
         }
 


### PR DESCRIPTION
According to https://picocli.info/#_negatable_options, negatable options which default to `true` should be specified in their negative form.  Otherwise we end up with the options having the correct default but opposite meaning when specified.