### PR TITLE
A number of improvements to boolean values & a unit test fwk

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/AbstractBooleanCompare.java
+++ b/compiler/src/main/java/org/qbicc/graph/AbstractBooleanCompare.java
@@ -18,20 +18,4 @@ public abstract class AbstractBooleanCompare extends AbstractBinaryValue impleme
     public BooleanType getType() {
         return booleanType;
     }
-
-    @Override
-    public Value getValueIfTrue(Value input) {
-        if (equals(input)) {
-            return getElement().getEnclosingType().getContext().getLiteralFactory().literalOf(true);
-        }
-        return input;
-    }
-
-    @Override
-    public Value getValueIfFalse(Value input) {
-        if (equals(input)) {
-            return getElement().getEnclosingType().getContext().getLiteralFactory().literalOf(false);
-        }
-        return input;
-    }
 }

--- a/compiler/src/main/java/org/qbicc/graph/And.java
+++ b/compiler/src/main/java/org/qbicc/graph/And.java
@@ -1,5 +1,6 @@
 package org.qbicc.graph;
 
+import org.qbicc.type.BooleanType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
@@ -12,6 +13,14 @@ public final class And extends AbstractBinaryValue implements CommutativeBinaryV
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    @Override
+    public Value getValueIfTrue(Value input) {
+        assert getType() instanceof BooleanType;
+        // both inputs must be true
+        // TODO: merge values algorithm
+        return getLeftInput().getValueIfTrue(getRightInput().getValueIfTrue(input));
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -235,6 +235,8 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value negate(Value v); // neg is only needed for FP; ints should use 0-n
 
+    Value complement(Value v);
+
     Value byteSwap(Value v);
 
     Value bitReverse(Value v);

--- a/compiler/src/main/java/org/qbicc/graph/BooleanValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/BooleanValue.java
@@ -13,22 +13,4 @@ import org.qbicc.type.BooleanType;
  */
 public interface BooleanValue extends Value {
     BooleanType getType();
-
-    /**
-     * Get the actual value of the given input if this value evaluates to {@code true}.
-     * If the input is equal to this value, then the result must be the {@code true} literal.
-     *
-     * @param input the input value (must not be {@code null})
-     * @return the value if {@code true} (not {@code null})
-     */
-    Value getValueIfTrue(Value input);
-
-    /**
-     * Get the actual value of the given input if this value evaluates to {@code false}.
-     * If the input is equal to this value, then the result must be the {@code false} literal.
-     *
-     * @param input the input value (must not be {@code null})
-     * @return the value if {@code false} (not {@code null})
-     */
-    Value getValueIfFalse(Value input);
 }

--- a/compiler/src/main/java/org/qbicc/graph/CommutativeBinaryValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/CommutativeBinaryValue.java
@@ -4,4 +4,25 @@ package org.qbicc.graph;
  *
  */
 public interface CommutativeBinaryValue extends BinaryValue {
+    /**
+     * Test whether the two inputs equal the given two values, in any order.
+     *
+     * @param v1 the first value (must not be {@code null})
+     * @param v2 the second value (must not be {@code null})
+     * @return {@code true} if the inputs are equal to the values, or {@code false} if either or both differ
+     */
+    default boolean inputsEqual(Value v1, Value v2) {
+        return getLeftInput().equals(v1) && getRightInput().equals(v2)
+            || getLeftInput().equals(v2) && getRightInput().equals(v1);
+    }
+
+    /**
+     * Test whether either input equals the given value.
+     *
+     * @param v the value (must not be {@code null})
+     * @return {@code true} if an input is equal to the given value, or {@code false} otherwise
+     */
+    default boolean eitherInputEquals(Value v) {
+        return getLeftInput().equals(v) || getRightInput().equals(v);
+    }
 }

--- a/compiler/src/main/java/org/qbicc/graph/Comp.java
+++ b/compiler/src/main/java/org/qbicc/graph/Comp.java
@@ -1,0 +1,42 @@
+package org.qbicc.graph;
+
+import org.qbicc.type.WordType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * Represents the bitwise complement of the integer or boolean input.
+ */
+public final class Comp extends AbstractUnaryValue {
+    Comp(final Node callSite, final ExecutableElement element, final int line, final int bci, final Value v) {
+        super(callSite, element, line, bci, v);
+    }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+
+    @Override
+    public WordType getType() {
+        return (WordType) super.getType();
+    }
+
+    @Override
+    public boolean isDefNe(Value other) {
+        return other.isDefEq(input) || super.isDefNe(other);
+    }
+
+    @Override
+    public Value getValueIfTrue(Value input) {
+        return getInput().getValueIfFalse(input);
+    }
+
+    @Override
+    public Value getValueIfFalse(Value input) {
+        return getInput().getValueIfTrue(input);
+    }
+
+    @Override
+    String getNodeName() {
+        return "Comp";
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -530,6 +530,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().negate(v);
     }
 
+    public Value complement(final Value v) {
+        return getDelegate().complement(v);
+    }
+
     public Value byteSwap(final Value v) {
         return getDelegate().byteSwap(v);
     }

--- a/compiler/src/main/java/org/qbicc/graph/If.java
+++ b/compiler/src/main/java/org/qbicc/graph/If.java
@@ -26,13 +26,10 @@ public final class If extends AbstractTerminator implements Terminator {
     @Override
     public Value getOutboundValue(PhiValue phi) {
         Value outboundValue = super.getOutboundValue(phi);
-        if (condition instanceof BooleanValue) {
-            BooleanValue booleanValue = (BooleanValue) condition;
-            if (phi.getPinnedBlock().equals(getTrueBranch())) {
-                return booleanValue.getValueIfTrue(outboundValue);
-            } else if (phi.getPinnedBlock().equals(getFalseBranch())) {
-                return booleanValue.getValueIfFalse(outboundValue);
-            }
+        if (phi.getPinnedBlock().equals(getTrueBranch())) {
+            return condition.getValueIfTrue(outboundValue);
+        } else if (phi.getPinnedBlock().equals(getFalseBranch())) {
+            return condition.getValueIfFalse(outboundValue);
         }
         return outboundValue;
     }

--- a/compiler/src/main/java/org/qbicc/graph/InstanceOf.java
+++ b/compiler/src/main/java/org/qbicc/graph/InstanceOf.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.ObjectType;
-import org.qbicc.type.ReferenceType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
@@ -13,15 +12,17 @@ import org.qbicc.type.definition.element.ExecutableElement;
 public final class InstanceOf extends AbstractValue implements InstanceOperation, OrderedNode, BooleanValue {
     private final Node dependency;
     private final Value input;
+    private final Value valueIfTrue;
     private final ObjectType checkType;
     private final int checkDimensions;
     private final BooleanType booleanType;
 
     InstanceOf(final Node callSite, final ExecutableElement element, final int line, final int bci, Node dependency, final Value input,
-               final ObjectType checkType, final int checkDimensions, final BooleanType booleanType) {
+               Value valueIfTrue, final ObjectType checkType, final int checkDimensions, final BooleanType booleanType) {
         super(callSite, element, line, bci);
         this.dependency = dependency;
         this.input = input;
+        this.valueIfTrue = valueIfTrue;
         this.checkType = checkType;
         this.checkDimensions = checkDimensions;
         this.booleanType = booleanType;
@@ -36,7 +37,7 @@ public final class InstanceOf extends AbstractValue implements InstanceOperation
      }
 
     int calcHashCode() {
-        return Objects.hash(dependency, input, checkType, checkDimensions);
+        return Objects.hash(dependency, input, checkType) * 31 + checkDimensions;
     }
 
     @Override
@@ -83,10 +84,7 @@ public final class InstanceOf extends AbstractValue implements InstanceOperation
 
     @Override
     public Value getValueIfTrue(Value input) {
-        return input.equals(this.input) ?
-            new NotNull(getCallSite(), getElement(), getSourceLine(), getBytecodeIndex(),
-                new BitCast(getCallSite(), getElement(), getSourceLine(), getBytecodeIndex(), input, ((ReferenceType)input.getType()).narrow(checkType)))
-            : input;
+        return input.equals(this.input) ? valueIfTrue : super.getValueIfTrue(input);
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -533,6 +533,10 @@ public interface Node {
                 return param.getBlockBuilder().cmpL(param.copyValue(node.getLeftInput()), param.copyValue(node.getRightInput()));
             }
 
+            public Value visit(Copier param, Comp node) {
+                return param.getBlockBuilder().complement(param.copyValue(node.getInput()));
+            }
+
             public Value visit(final Copier param, final CompoundLiteral node) {
                 return node;
             }

--- a/compiler/src/main/java/org/qbicc/graph/Or.java
+++ b/compiler/src/main/java/org/qbicc/graph/Or.java
@@ -1,5 +1,6 @@
 package org.qbicc.graph;
 
+import org.qbicc.type.BooleanType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
@@ -12,6 +13,14 @@ public final class Or extends AbstractBinaryValue implements CommutativeBinaryVa
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
         return visitor.visit(param, this);
+    }
+
+    @Override
+    public Value getValueIfFalse(Value input) {
+        assert getType() instanceof BooleanType;
+        // both inputs must be false
+        // TODO: merge values algorithm
+        return getLeftInput().getValueIfFalse(getRightInput().getValueIfFalse(input));
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -14,9 +14,11 @@ import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.type.ArrayObjectType;
+import org.qbicc.type.BooleanType;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.FunctionType;
+import org.qbicc.type.IntegerType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
@@ -315,6 +317,14 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
 
     public Value negate(final Value v) {
         return new Neg(callSite, element, line, bci, v);
+    }
+
+    public Value complement(Value v) {
+        Assert.checkNotNullParam("v", v);
+        if (! (v.getType() instanceof IntegerType || v.getType() instanceof BooleanType)) {
+            throw new IllegalArgumentException("Invalid input type");
+        }
+        return new Comp(callSite, element, line, bci, v);
     }
 
     public Value byteSwap(final Value v) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -358,7 +358,8 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
     }
 
     public Value instanceOf(final Value input, final ObjectType expectedType, final int expectedDimensions) {
-        return asDependency(new InstanceOf(callSite, element, line, bci, requireDependency(), input, expectedType, expectedDimensions, typeSystem.getBooleanType()));
+        final BasicBlockBuilder fb = getFirstBuilder();
+        return asDependency(new InstanceOf(callSite, element, line, bci, requireDependency(), input, fb.notNull(fb.bitCast(input, ((ReferenceType)input.getType()).narrow(expectedType))), expectedType, expectedDimensions, typeSystem.getBooleanType()));
     }
 
     public Value instanceOf(final Value input, final TypeDescriptor desc) {

--- a/compiler/src/main/java/org/qbicc/graph/Value.java
+++ b/compiler/src/main/java/org/qbicc/graph/Value.java
@@ -44,6 +44,34 @@ public interface Value extends Node {
     }
 
     /**
+     * Get the actual value of the given input if this value evaluates to {@code true}.
+     * If the input is equal to this value, then the result must be the {@code true} literal.
+     *
+     * @param input the input value (must not be {@code null})
+     * @return the value if {@code true} (not {@code null})
+     */
+    default Value getValueIfTrue(Value input) {
+        if (equals(input)) {
+            return this;
+        }
+        return input;
+    }
+
+    /**
+     * Get the actual value of the given input if this value evaluates to {@code false}.
+     * If the input is equal to this value, then the result must be the {@code false} literal.
+     *
+     * @param input the input value (must not be {@code null})
+     * @return the value if {@code false} (not {@code null})
+     */
+    default Value getValueIfFalse(Value input) {
+        if (equals(input)) {
+            return this;
+        }
+        return input;
+    }
+
+    /**
      * Extract an element from this array value if it has a known value for the given index.
      *
      * @param lf the literal factory (must not be {@code null})

--- a/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
@@ -88,6 +88,10 @@ public interface ValueVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, Comp node) {
+        return visitUnknown(param, node);
+    }
+
     default R visit(T param, CountLeadingZeros node) {
         return visitUnknown(param, node);
     }
@@ -448,6 +452,10 @@ public interface ValueVisitor<T, R> {
         }
 
         default R visit(T param, Clone node) {
+            return getDelegateValueVisitor().visit(param, node);
+        }
+
+        default R visit(T param, Comp node) {
             return getDelegateValueVisitor().visit(param, node);
         }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -30,6 +30,7 @@ import org.qbicc.graph.Cmp;
 import org.qbicc.graph.CmpAndSwap;
 import org.qbicc.graph.CmpG;
 import org.qbicc.graph.CmpL;
+import org.qbicc.graph.Comp;
 import org.qbicc.graph.ConstructorElementHandle;
 import org.qbicc.graph.Convert;
 import org.qbicc.graph.CountLeadingZeros;
@@ -1451,6 +1452,20 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         VmObjectImpl original = (VmObjectImpl) require(node.getInput());
         return original.clone();
     }
+
+    public Object visit(final VmThreadImpl param, final Comp node) {
+        Value input = node.getInput();
+        ValueType inputType = input.getType();
+        if (isInt64(inputType)) {
+            return box(unboxLong(input) ^ ~0L, node.getType());
+        } else if (isInt32(inputType)) {
+            return box(unboxInt(input) ^ ~0, node.getType());
+        } else if (isBool(inputType)) {
+            return Boolean.valueOf(!unboxBool(input));
+        }
+        throw badInputType();
+    }
+
     @Override
     public Object visit(VmThreadImpl thread, CmpAndSwap node) {
         ValueHandle valueHandle = node.getValueHandle();

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -32,6 +32,7 @@ import org.qbicc.graph.Cmp;
 import org.qbicc.graph.CmpAndSwap;
 import org.qbicc.graph.CmpG;
 import org.qbicc.graph.CmpL;
+import org.qbicc.graph.Comp;
 import org.qbicc.graph.ConstructorElementHandle;
 import org.qbicc.graph.CountLeadingZeros;
 import org.qbicc.graph.CountTrailingZeros;
@@ -842,6 +843,10 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
         processDependency(param, node.getDependency());
         addEdge(param, node, node.getInput(), EdgeType.VALUE_DEPENDENCY);
         return name;
+    }
+
+    public String visit(final Appendable param, final Comp node) {
+        return node(param, "~", node);
     }
 
     public String visit(final Appendable param, final CountLeadingZeros node) {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -28,6 +28,7 @@ import org.qbicc.graph.Cmp;
 import org.qbicc.graph.CmpAndSwap;
 import org.qbicc.graph.CmpG;
 import org.qbicc.graph.CmpL;
+import org.qbicc.graph.Comp;
 import org.qbicc.graph.Convert;
 import org.qbicc.graph.DebugAddressDeclaration;
 import org.qbicc.graph.Deref;
@@ -432,6 +433,19 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
                 map(ctxt.getLiteralFactory().literalOf(0))
             ).asLocal()
         ).asLocal();
+    }
+
+    public LLValue visit(final Void param, final Comp node) {
+        final Value input = node.getInput();
+        final LLValue inputType = map(input.getType());
+        final LLValue llvmInput = map(input);
+        if (input.getType() instanceof BooleanType) {
+            return builder.xor(inputType, llvmInput, TRUE).asLocal();
+        } else if (input.getType() instanceof IntegerType it) {
+            return builder.xor(inputType, llvmInput, intConstant(it.asUnsigned().truncateValue(0xFFFF_FFFF_FFFF_FFFFL))).asLocal();
+        } else {
+            throw new IllegalStateException();
+        }
     }
 
     public LLValue visit(final Void param, final IsEq node) {

--- a/plugins/optimization/pom.xml
+++ b/plugins/optimization/pom.xml
@@ -21,6 +21,12 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-driver</artifactId>
         </dependency>
+        <!-- test -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/plugins/optimization/src/test/java/org/qbicc/plugin/opt/TestSimpleOptBasicBlockBuilderBooleanLogic.java
+++ b/plugins/optimization/src/test/java/org/qbicc/plugin/opt/TestSimpleOptBasicBlockBuilderBooleanLogic.java
@@ -1,0 +1,121 @@
+package org.qbicc.plugin.opt;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.qbicc.graph.MemoryAtomicityMode.NONE;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.qbicc.graph.And;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.BlockLabel;
+import org.qbicc.graph.Comp;
+import org.qbicc.graph.Or;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.test.AbstractCompilerTestCase;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.classfile.ClassFile;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.LocalVariableElement;
+import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
+import org.qbicc.type.descriptor.MethodDescriptor;
+import org.qbicc.type.generic.BaseTypeSignature;
+import org.qbicc.type.generic.ClassSignature;
+import org.qbicc.type.generic.MethodSignature;
+
+public final class TestSimpleOptBasicBlockBuilderBooleanLogic extends AbstractCompilerTestCase {
+
+    ExecutableElement element;
+
+    @BeforeEach
+    public void setUpEach() {
+        final DefinedTypeDefinition.Builder typeBuilder = DefinedTypeDefinition.Builder.basic();
+        typeBuilder.setName("TestClass");
+        typeBuilder.setDescriptor(ClassTypeDescriptor.synthesize(bootClassContext, "TestClass"));
+        typeBuilder.setModifiers(ClassFile.ACC_SUPER | ClassFile.ACC_PUBLIC);
+        typeBuilder.setSignature(ClassSignature.synthesize(bootClassContext, null, List.of()));
+        typeBuilder.setSimpleName("TestClass");
+        typeBuilder.setInitializer((index, enclosing, builder) -> builder.build(), 0);
+        final DefinedTypeDefinition enclosingType = typeBuilder.build();
+        final MethodElement.Builder builder = MethodElement.builder("testMethod", MethodDescriptor.VOID_METHOD_DESCRIPTOR);
+        builder.setEnclosingType(enclosingType);
+        builder.setSignature(MethodSignature.VOID_METHOD_SIGNATURE);
+        builder.setModifiers(ClassFile.ACC_STATIC);
+        builder.setParameters(List.of());
+        builder.setMethodBodyFactory((index, e) -> {
+            final BasicBlockBuilder bbb = BasicBlockBuilder.simpleBuilder(ts, e);
+            BasicBlock emptyBlock = bbb.unreachable();
+            bbb.finish();
+            return MethodBody.of(
+                emptyBlock,
+                Schedule.forMethod(emptyBlock),
+                null,
+                List.of()
+            );
+        }, 0);
+        element = builder.build();
+    }
+
+    private LocalVariableElement createLocalVar(String name, ValueType type) {
+        final LocalVariableElement.Builder builder = LocalVariableElement.builder(name, BaseTypeDescriptor.V);
+        builder.setEnclosingType(element.getEnclosingType());
+        builder.setType(type);
+        builder.setSignature(BaseTypeSignature.V);
+        builder.setTypeParameterContext(element.getEnclosingType());
+        return builder.build();
+    }
+
+    @Test
+    public void testDeMorgansAnd2Or() {
+        final BasicBlockBuilder bbb = makeBlockBuilder();
+        Value v1 = bbb.load(bbb.localVariable(createLocalVar("v1", ts.getBooleanType())), NONE);
+        Value v2 = bbb.load(bbb.localVariable(createLocalVar("v2", ts.getBooleanType())), NONE);
+        final Value res = bbb.and(bbb.complement(v1), bbb.complement(v2));
+        assertTrue(res instanceof Comp comp
+            && comp.getInput() instanceof Or or
+            && or.getLeftInput().equals(v1)
+            && or.getRightInput().equals(v2)
+        );
+    }
+
+    @Test
+    public void testDeMorgansOr2And() {
+        final BasicBlockBuilder bbb = makeBlockBuilder();
+        Value v1 = bbb.load(bbb.localVariable(createLocalVar("v1", ts.getBooleanType())), NONE);
+        Value v2 = bbb.load(bbb.localVariable(createLocalVar("v2", ts.getBooleanType())), NONE);
+        final Value res = bbb.or(bbb.complement(v1), bbb.complement(v2));
+        assertTrue(res instanceof Comp comp
+            && comp.getInput() instanceof And and
+            && and.getLeftInput().equals(v1)
+            && and.getRightInput().equals(v2)
+        );
+    }
+
+    @Test
+    public void testDistributiveAnd() {
+        final BasicBlockBuilder bbb = makeBlockBuilder();
+        Value v1 = bbb.load(bbb.localVariable(createLocalVar("v1", ts.getBooleanType())), NONE);
+        Value v2 = bbb.load(bbb.localVariable(createLocalVar("v2", ts.getBooleanType())), NONE);
+        Value v3 = bbb.load(bbb.localVariable(createLocalVar("v3", ts.getBooleanType())), NONE);
+        final Value res = bbb.or(bbb.and(v1, v2), bbb.and(v1, v3));
+        assertTrue(res instanceof And and
+            && and.getLeftInput().equals(v1)
+            && and.getRightInput() instanceof Or or
+            && or.inputsEqual(v2, v3)
+        );
+    }
+
+    private BasicBlockBuilder makeBlockBuilder() {
+        final BasicBlockBuilder bbb = new SimpleOptBasicBlockBuilder(ctxt, BasicBlockBuilder.simpleBuilder(ts, element));
+        bbb.startMethod(List.of());
+        bbb.begin(new BlockLabel());
+        return bbb;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <module>machine</module>
         <module>runtime</module>
         <module>plugins</module>
+        <module>test-utils</module>
         <module>integration-tests</module>
     </modules>
 
@@ -107,6 +108,12 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-driver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-main</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -182,6 +189,15 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-machine-tool-llvm</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <!-- test utility -->
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-test-utils</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- VM -->

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.qbicc</groupId>
+        <artifactId>qbicc-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>qbicc-test-utils</artifactId>
+
+    <name>Qbicc testing utilities</name>
+    <description>Qbicc testing utilities</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-driver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-file-elf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-file-macho</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-tool-gnu</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-tool-clang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-tool-llvm</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-utils/src/main/java/org/qbicc/test/AbstractCompilerTestCase.java
+++ b/test-utils/src/main/java/org/qbicc/test/AbstractCompilerTestCase.java
@@ -1,0 +1,89 @@
+package org.qbicc.test;
+
+import static io.smallrye.common.constraint.Assert.unreachableCode;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.driver.BaseDiagnosticContext;
+import org.qbicc.driver.Driver;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.machine.arch.Platform;
+import org.qbicc.machine.object.ObjectFileProvider;
+import org.qbicc.machine.tool.CToolChain;
+import org.qbicc.tool.llvm.LlvmToolChain;
+import org.qbicc.type.TypeSystem;
+
+/**
+ * A class which is usable as a base class for simple test cases which use the compiler and need a compiler context.
+ */
+public abstract class AbstractCompilerTestCase {
+    public static CompilationContext ctxt;
+    public static ClassContext bootClassContext;
+    public static TypeSystem ts;
+    public static LiteralFactory lf;
+    private static Driver driver;
+
+    @BeforeAll
+    protected static void setUp() {
+        final Driver.Builder builder = Driver.builder();
+        builder.setInitialContext(new BaseDiagnosticContext());
+        builder.setOutputDirectory(Path.of(System.getProperty("user.dir", "."), "target", "test-fwk"));
+        final Platform platform = getPlatform();
+        builder.setTargetPlatform(platform);
+        Optional<ObjectFileProvider> ofp = ObjectFileProvider.findProvider(platform.getObjectType(), AbstractCompilerTestCase.class.getClassLoader());
+        if (ofp.isEmpty()) {
+            fail("No object file provider found for " + platform);
+            throw unreachableCode();
+        }
+        builder.setObjectFileProvider(ofp.get());
+        Iterator<CToolChain> toolChains = CToolChain.findAllCToolChains(platform, t -> true, AbstractCompilerTestCase.class.getClassLoader()).iterator();
+        if (! toolChains.hasNext()) {
+            fail("No tool chains found for " + platform);
+            throw unreachableCode();
+        }
+        builder.setToolChain(toolChains.next());
+        Iterator<LlvmToolChain> llvmTools = LlvmToolChain.findAllLlvmToolChains(platform, t -> true, AbstractCompilerTestCase.class.getClassLoader()).iterator();
+        LlvmToolChain llvmToolChain = null;
+        while (llvmTools.hasNext()) {
+            llvmToolChain = llvmTools.next();
+            if (llvmToolChain.compareVersionTo("12") >= 0) {
+                break;
+            }
+            llvmToolChain = null;
+        }
+        if (llvmToolChain == null) {
+            fail("No LLVM tool chain found");
+            throw unreachableCode();
+        } else {
+            builder.setLlvmToolChain(llvmToolChain);
+        }
+        final TypeSystem.Builder tsBuilder = TypeSystem.builder();
+        final TypeSystem ts = tsBuilder.build();
+        builder.setTypeSystem(ts);
+        AbstractCompilerTestCase.ts = ts;
+        builder.setVmFactory(CompilationContext::getVm);
+
+        final Driver driver = builder.build();
+        ctxt = driver.getCompilationContext();
+        bootClassContext = ctxt.getBootstrapClassContext();
+        lf = ctxt.getLiteralFactory();
+        AbstractCompilerTestCase.driver = driver;
+    }
+
+    @AfterAll
+    protected static void cleanUp() {
+        // avoid leaking things
+        driver.close();
+    }
+
+    static Platform getPlatform() {
+        return Platform.HOST_PLATFORM;
+    }
+}


### PR DESCRIPTION
* Introduce a general unit test utility
* Introduce `Comp` ones-complement node, use it as canonical form for boolean inversion
* Introduce several transformations to optimize and/or canonicalize boolean forms
* Allow any value to have a value-if-true/false
* Front-load `InstanceOf` value-if-true (allows optimizations to simplify it)
* Add the start of unit tests for individual optimization transformations using the unit test utility