### PR TITLE
Rename `ClassInitCheck` to `InitCheck`

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
@@ -12,7 +12,7 @@ public interface ActionVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
-    default R visit(T param, ClassInitCheck node) {
+    default R visit(T param, InitCheck node) {
         return visitUnknown(param, node);
     }
 
@@ -47,7 +47,7 @@ public interface ActionVisitor<T, R> {
             return getDelegateActionVisitor().visit(param, node);
         }
 
-        default R visit(T param, ClassInitCheck node) {
+        default R visit(T param, InitCheck node) {
             return getDelegateActionVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -398,7 +398,7 @@ public interface BasicBlockBuilder extends Locatable {
 
     Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode);
 
-    Node classInitCheck(ObjectType objectType);
+    Node initCheck(ObjectType objectType);
 
     Node fence(MemoryAtomicityMode fenceType);
 

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -354,8 +354,8 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().store(handle, value, mode);
     }
 
-    public Node classInitCheck(final ObjectType objectType) {
-        return getDelegate().classInitCheck(objectType);
+    public Node initCheck(final ObjectType objectType) {
+        return getDelegate().initCheck(objectType);
     }
 
     public Node fence(final MemoryAtomicityMode fenceType) {

--- a/compiler/src/main/java/org/qbicc/graph/InitCheck.java
+++ b/compiler/src/main/java/org/qbicc/graph/InitCheck.java
@@ -5,11 +5,11 @@ import java.util.Objects;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
-public class ClassInitCheck extends AbstractNode implements Action, OrderedNode {
+public class InitCheck extends AbstractNode implements Action, OrderedNode {
     private final Node dependency;
     private final ObjectType objectType;
 
-    ClassInitCheck(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ObjectType objectType) {
+    InitCheck(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ObjectType objectType) {
         super(callSite, element, line, bci);
         this.dependency = dependency;
         this.objectType = objectType;
@@ -20,12 +20,12 @@ public class ClassInitCheck extends AbstractNode implements Action, OrderedNode 
     }
 
     int calcHashCode() {
-        return Objects.hash(ClassInitCheck.class, dependency, objectType);
+        return Objects.hash(InitCheck.class, dependency, objectType);
     }
 
     @Override
     String getNodeName() {
-        return "ClassInitCheck";
+        return "InitCheck";
     }
 
     @Override
@@ -34,7 +34,7 @@ public class ClassInitCheck extends AbstractNode implements Action, OrderedNode 
     }
 
     public boolean equals(Object other) {
-        return other instanceof ClassInitCheck && equals((ClassInitCheck) other);
+        return other instanceof InitCheck && equals((InitCheck) other);
     }
 
     @Override
@@ -46,7 +46,7 @@ public class ClassInitCheck extends AbstractNode implements Action, OrderedNode 
         return b;
     }
 
-    public boolean equals(final ClassInitCheck other) {
+    public boolean equals(final InitCheck other) {
         return this == other || other != null
                && dependency.equals(other.dependency)
                && objectType == other.objectType;

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -339,9 +339,9 @@ public interface Node {
                 return param.getBlockBuilder().monitorExit(param.copyValue(node.getInstance()));
             }
 
-            public Node visit(Copier param, ClassInitCheck node) {
+            public Node visit(Copier param, InitCheck node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().classInitCheck(node.getObjectType());
+                return param.getBlockBuilder().initCheck(node.getObjectType());
             }
 
             public Node visit(Copier param, DebugAddressDeclaration node) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -642,8 +642,8 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new Store(callSite, element, line, bci, requireDependency(), handle, value, mode));
     }
 
-    public Node classInitCheck(final ObjectType objectType) {
-        return asDependency(new ClassInitCheck(callSite, element, line, bci, requireDependency(), objectType));
+    public Node initCheck(final ObjectType objectType) {
+        return asDependency(new InitCheck(callSite, element, line, bci, requireDependency(), objectType));
     }
 
     public Node fence(final MemoryAtomicityMode fenceType) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -23,7 +23,7 @@ import org.qbicc.graph.Call;
 import org.qbicc.graph.CallNoReturn;
 import org.qbicc.graph.CallNoSideEffects;
 import org.qbicc.graph.CheckCast;
-import org.qbicc.graph.ClassInitCheck;
+import org.qbicc.graph.InitCheck;
 import org.qbicc.graph.ClassOf;
 import org.qbicc.graph.Clone;
 import org.qbicc.graph.Cmp;
@@ -1438,7 +1438,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     // Other
 
     @Override
-    public Void visit(VmThreadImpl thread, ClassInitCheck node) {
+    public Void visit(VmThreadImpl thread, InitCheck node) {
         ObjectType objectType = node.getObjectType();
         VmImpl vm = thread.getVM();
         ClassContext context = objectType.getDefinition().getContext();

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
@@ -129,7 +129,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
 
     @Override
     public Value new_(final ClassObjectType type) {
-        initCheck(type);
+        doInitCheck(type);
         return super.new_(type);
     }
 
@@ -262,7 +262,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
                 if (! node.getVariableElement().isStatic()) {
                     throwIncompatibleClassChangeError();
                 }
-                initCheck(node.getVariableElement().getEnclosingType().load().getType());
+                doInitCheck(node.getVariableElement().getEnclosingType().load().getType());
                 return null;
             }
 
@@ -342,20 +342,20 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
                     throwIncompatibleClassChangeError();
                     throw Assert.unreachableCode();
                 }
-                initCheck(node.getExecutable().getEnclosingType().load().getType());
+                doInitCheck(node.getExecutable().getEnclosingType().load().getType());
                 // return value unused in this case
                 return null;
             }
         }, null);
     }
 
-    private void initCheck(ObjectType objectType) {
+    private void doInitCheck(ObjectType objectType) {
         if (objectType.equals(originalElement.getEnclosingType().load().getType())) {
             // Same type, must already be initialized.
             return;
         }
         // TODO: further tuning of places init checks can be skipped
-        classInitCheck(objectType);
+        initCheck(objectType);
     }
 
     private void nullCheck(Value value) {

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -25,7 +25,7 @@ import org.qbicc.graph.Call;
 import org.qbicc.graph.CallNoReturn;
 import org.qbicc.graph.CallNoSideEffects;
 import org.qbicc.graph.CastValue;
-import org.qbicc.graph.ClassInitCheck;
+import org.qbicc.graph.InitCheck;
 import org.qbicc.graph.ClassOf;
 import org.qbicc.graph.Clone;
 import org.qbicc.graph.Cmp;
@@ -714,7 +714,7 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
         return name;
     }
 
-    public String visit(Appendable param, ClassInitCheck node) {
+    public String visit(Appendable param, InitCheck node) {
         String name = register(node);
         appendTo(param, name);
         attr(param, "shape", "rectangle");

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
@@ -31,12 +31,12 @@ public class LowerClassInitCheckBlockBuilder extends DelegatingBasicBlockBuilder
         this.ctxt = ctxt;
     }
  
-    public Node classInitCheck(final ObjectType objectType) {
-        initCheck(objectType);
+    public Node initCheck(final ObjectType objectType) {
+        doInitCheck(objectType);
         return nop();
     }
 
-    private void initCheck(ObjectType objectType) {
+    private void doInitCheck(ObjectType objectType) {
         SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
         
         final BlockLabel callInit = new BlockLabel();

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -403,7 +403,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
     }
 
     @Override
-    public Node classInitCheck(ObjectType objectType) {
+    public Node initCheck(ObjectType objectType) {
         // either this is handled by an earlier BBB, or else init was 100% build time
         return nop();
     }

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/LowerVerificationBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/LowerVerificationBasicBlockBuilder.java
@@ -57,7 +57,7 @@ public class LowerVerificationBasicBlockBuilder extends DelegatingBasicBlockBuil
         return nop();
     }
 
-    public Node classInitCheck(final ObjectType objectType) {
+    public Node initCheck(final ObjectType objectType) {
         invalidNode("classInitCheck");
         return nop();
     }


### PR DESCRIPTION
The idea is to begin migrating the `InitCheck` node to be per-initializer rather than per-class. Doing this rename early will simplify the diff of those changes.