### PR TITLE
Initialize java.lang.ref.Reference early to avoid deadlock

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -598,6 +598,9 @@ public final class VmImpl implements Vm {
             // phase 3
             // TODO: Haven't tried yet...still working on phase2
             // invokeExact(systemType.getMethod(systemType.findSingleMethodIndex(me -> me.nameEquals("initPhase3"))), null, List.of());
+
+            // Initialize early to avoid deadlocks
+            initialize(bootstrapClassLoader.loadClass("java/lang/ref/Reference"));
         }
     }
 


### PR DESCRIPTION
Closes #812 