### PR TITLE
Always bind current thread during invocations

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
@@ -120,7 +120,14 @@ final class VmInvokableImpl implements VmInvokable {
 
     @Override
     public Object invokeAny(VmThread thread, VmObject target, List<Object> args) {
-        return run((VmThreadImpl) thread, target, args);
+        VmThreadImpl threadImpl = (VmThreadImpl) thread;
+        Thread old = threadImpl.getBoundThread();
+        threadImpl.setBoundThread(Thread.currentThread());
+        try {
+            return run(threadImpl, target, args);
+        } finally {
+            threadImpl.setBoundThread(old);
+        }
     }
 
     Object run(VmThreadImpl thread, VmObject target, List<Object> args) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThreadImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThreadImpl.java
@@ -8,6 +8,7 @@ import org.qbicc.type.definition.element.FieldElement;
 
 final class VmThreadImpl extends VmObjectImpl implements VmThread {
     final VmImpl vm;
+    volatile Thread boundThread;
     Frame currentFrame;
 
     VmThreadImpl(VmClassImpl clazz, VmImpl vm) {
@@ -52,5 +53,13 @@ final class VmThreadImpl extends VmObjectImpl implements VmThread {
             throw new IllegalArgumentException("Invalid thread priority: "+priority);
         }
         memory.store32(offset, priority, MemoryAtomicityMode.UNORDERED);
+    }
+
+    void setBoundThread(Thread boundThread) {
+        this.boundThread = boundThread;
+    }
+
+    Thread getBoundThread() {
+        return boundThread;
     }
 }


### PR DESCRIPTION
This and #866 are predecessors to `park`/`unpark` in the interpreter.