### PR TITLE
Use `LockSupport`-based monitors with full API support

### DIFF
--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/BasicInitializationBasicBlockBuilder.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/BasicInitializationBasicBlockBuilder.java
@@ -63,7 +63,7 @@ public class BasicInitializationBasicBlockBuilder extends DelegatingBasicBlockBu
         ValueHandle handle = referenceHandle(allocated);
         store(instanceFieldOf(handle, coreClasses.getObjectTypeIdField()), lf.literalOfType(type), MemoryAtomicityMode.UNORDERED);
         FieldElement monitorField = coreClasses.getObjectNativeObjectMonitorField();
-        store(instanceFieldOf(handle, monitorField), ctxt.getLiteralFactory().literalOf((IntegerType)monitorField.getType(), 0L), MemoryAtomicityMode.NONE);
+        store(instanceFieldOf(handle, monitorField), ctxt.getLiteralFactory().zeroInitializerLiteralOfType(monitorField.getType()), MemoryAtomicityMode.NONE);
         return handle;
     }
 

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/BasicInitializationManualInitializer.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/BasicInitializationManualInitializer.java
@@ -34,7 +34,7 @@ public class BasicInitializationManualInitializer implements Consumer<VmObject> 
         FieldElement typeIdField = coreClasses.getObjectTypeIdField();
         memory.storeType(vmObject.indexOf(typeIdField), objectTypeId, MemoryAtomicityMode.UNORDERED);
         FieldElement nativeMonitorField = coreClasses.getObjectNativeObjectMonitorField();
-        memory.store64(vmObject.indexOf(nativeMonitorField), 0, MemoryAtomicityMode.UNORDERED);
+        memory.storeRef(vmObject.indexOf(nativeMonitorField), null, MemoryAtomicityMode.UNORDERED);
         if (vmObject instanceof VmArray) {
             FieldElement lengthField = coreClasses.getArrayLengthField();
             memory.store32(vmObject.indexOf(lengthField), ((VmArray) vmObject).getLength(), MemoryAtomicityMode.UNORDERED);

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/CoreClasses.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/CoreClasses.java
@@ -99,12 +99,12 @@ public final class CoreClasses {
         jlo.injectField(field);
         objectTypeIdField = field;
 
-        // inject a field to hold the object pthread_mutex_t
-        builder = FieldElement.builder("nativeObjectMonitor", BaseTypeDescriptor.V);
-        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
+        // inject a field to hold the object monitor ref
+        // todo: make selectable by platform
+        builder = FieldElement.builder("nativeObjectMonitor", ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/main/Monitor"));
+        builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.I_ACC_NO_REFLECT | ClassFile.I_ACC_NO_RESOLVE);
         builder.setEnclosingType(jloDef);
-        builder.setSignature(BaseTypeSignature.V);
-        builder.setType(ts.getSignedInteger64Type());
+        builder.setSignature(TypeSignature.synthesize(classContext, builder.getDescriptor()));
         field = builder.build();
         jlo.injectField(field);
         objectNativeObjectMonitorField = field;

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/Monitor.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/Monitor.java
@@ -1,0 +1,82 @@
+package org.qbicc.runtime.main;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.qbicc.runtime.Hidden;
+
+/**
+ * An object monitor (lock) implementation. This is the platform-independent implementation and should not be assumed to be
+ * the actual monitor implementation for some targets. This implementation is guaranteed to be based on
+ * {@link java.util.concurrent.locks.LockSupport LockSupport}'s {@code park} mechanism.
+ */
+public final class Monitor {
+    private static final long MAX_MILLIS = Long.MAX_VALUE / 1_000_000L;
+
+    private final ReentrantLock lock;
+    private final Condition condition;
+
+    /**
+     * Construct a new instance.
+     */
+    public Monitor() {
+        lock = new ReentrantLock();
+        condition = lock.newCondition();
+    }
+
+    @Hidden
+    public boolean isHeldByCurrentThread() {
+        return lock.isHeldByCurrentThread();
+    }
+
+    @Hidden
+    public void enter() {
+        lock.lock();
+    }
+
+    @Hidden
+    public void exit() throws IllegalMonitorStateException {
+        lock.unlock();
+    }
+
+    @Hidden
+    public void await() throws InterruptedException {
+        condition.await();
+    }
+
+    @Hidden
+    public void await(long millis) throws InterruptedException {
+        if (millis < 0) {
+            throw new IllegalArgumentException("Invalid milliseconds");
+        }
+        condition.await(millis, TimeUnit.MILLISECONDS);
+    }
+
+    @Hidden
+    public void await(long millis, int nanos) throws InterruptedException {
+        if (millis < 0) {
+            throw new IllegalArgumentException("Invalid milliseconds");
+        } else if (nanos < 0 || nanos > 999999) {
+            throw new IllegalArgumentException("Invalid nanoseconds");
+        } else if (millis < MAX_MILLIS) {
+            // be exact
+            condition.await(millis * 1_000_000L + nanos, TimeUnit.NANOSECONDS);
+        } else {
+            if (nanos > 0) {
+                millis++;
+            }
+            condition.await(millis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Hidden
+    public void signal() throws IllegalMonitorStateException {
+        condition.signal();
+    }
+
+    @Hidden
+    public void signalAll() throws IllegalMonitorStateException {
+        condition.signalAll();
+    }
+}

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -334,15 +334,5 @@ public class ObjectModel {
      * @return the pthread mutex of the object
      */
     @Hidden
-    public static native pthread_mutex_t_ptr get_nativeObjectMonitor(Object reference);
-
-    /**
-     * Set the native object monitor (mutex) for the referenced object. This method is atomic and will return true on success.
-     *
-     * @param reference the object reference (must not be {@code null})
-     * @param nom mutex for the referenced object (must not be {@code null})
-     * @return true if successful
-     */
-    @Hidden
-    public static native boolean set_nativeObjectMonitor(Object reference, pthread_mutex_t_ptr nom);
+    public static native Monitor getMonitor(Object reference);
 }


### PR DESCRIPTION
This implementation allows thread interruption and conditions to work properly, in theory.

There may be a dependency on some other PRs but I wanted to get this one up here for review sooner rather than later. #866 doesn't do much without this (because those methods are native and we can't update the class libs without this API).