### PR TITLE
Drop ShrinkWrap Resolver in favor of Aether

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install qbicc
         run: |
-          mvn install
+          mvn --batch-mode install
         working-directory: ./myqbicc
 
       - name: Prepare failure archive (if maven failed)

--- a/compiler/src/main/java/org/qbicc/context/Diagnostic.java
+++ b/compiler/src/main/java/org/qbicc/context/Diagnostic.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.smallrye.common.constraint.Assert;
+
 /**
  * A single diagnostic message.
  */
@@ -16,6 +18,7 @@ public final class Diagnostic {
     private final List<Diagnostic> children = new ArrayList<>(0);
 
     public Diagnostic(final Diagnostic parent, final Location location, final Level level, final String format, final Object... args) {
+        Assert.checkNotNullParam("location", location);
         this.parent = parent;
         this.level = level;
         this.format = format;

--- a/compiler/src/main/java/org/qbicc/context/DiagnosticContext.java
+++ b/compiler/src/main/java/org/qbicc/context/DiagnosticContext.java
@@ -98,7 +98,7 @@ public interface DiagnosticContext {
     }
 
     default Diagnostic error(Diagnostic parent, String fmt, Object... args) {
-        return msg(parent, null, Diagnostic.Level.ERROR, fmt, args);
+        return msg(parent, Location.NO_LOC, Diagnostic.Level.ERROR, fmt, args);
     }
 
     default Diagnostic error(String fmt, Object... args) {
@@ -151,7 +151,7 @@ public interface DiagnosticContext {
     }
 
     default Diagnostic warning(Diagnostic parent, String fmt, Object... args) {
-        return msg(parent, null, Diagnostic.Level.WARNING, fmt, args);
+        return msg(parent, Location.NO_LOC, Diagnostic.Level.WARNING, fmt, args);
     }
 
     default Diagnostic warning(String fmt, Object... args) {
@@ -204,7 +204,7 @@ public interface DiagnosticContext {
     }
 
     default Diagnostic note(Diagnostic parent, String fmt, Object... args) {
-        return msg(parent, null, Diagnostic.Level.NOTE, fmt, args);
+        return msg(parent, Location.NO_LOC, Diagnostic.Level.NOTE, fmt, args);
     }
 
     default Diagnostic note(String fmt, Object... args) {
@@ -236,7 +236,7 @@ public interface DiagnosticContext {
     }
 
     default Diagnostic info(Diagnostic parent, String fmt, Object... args) {
-        return msg(parent, null, Diagnostic.Level.INFO, fmt, args);
+        return msg(parent, Location.NO_LOC, Diagnostic.Level.INFO, fmt, args);
     }
 
     default Diagnostic info(String fmt, Object... args) {
@@ -268,7 +268,7 @@ public interface DiagnosticContext {
     }
 
     default Diagnostic debug(Diagnostic parent, String fmt, Object... args) {
-        return msg(parent, null, Diagnostic.Level.DEBUG, fmt, args);
+        return msg(parent, Location.NO_LOC, Diagnostic.Level.DEBUG, fmt, args);
     }
 
     default Diagnostic debug(String fmt, Object... args) {

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -198,24 +198,170 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
 
+        <!-- aether -->
+
         <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api</artifactId>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-builder-support</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model-builder</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-repository-metadata</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings-builder</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-connector-basic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-wagon</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-file</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-http-lightweight</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-http-shared</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-interpolation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-cipher</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-sec-dispatcher</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/main/src/main/java/org/qbicc/main/ClassPathEntry.java
+++ b/main/src/main/java/org/qbicc/main/ClassPathEntry.java
@@ -3,8 +3,8 @@ package org.qbicc.main;
 import java.nio.file.Path;
 
 import io.smallrye.common.constraint.Assert;
-import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
-import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinates;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import picocli.CommandLine;
 
 /**
@@ -18,7 +18,7 @@ public abstract class ClassPathEntry {
         return new FilePath(path);
     }
 
-    public static MavenArtifact of(MavenCoordinate artifact) {
+    public static MavenArtifact of(Artifact artifact) {
         Assert.checkNotNullParam("artifact", artifact);
         return new MavenArtifact(artifact);
     }
@@ -51,13 +51,13 @@ public abstract class ClassPathEntry {
     }
 
     public static final class MavenArtifact extends ClassPathEntry {
-        private final MavenCoordinate artifact;
+        private final Artifact artifact;
 
-        MavenArtifact(MavenCoordinate artifact) {
+        MavenArtifact(Artifact artifact) {
             this.artifact = artifact;
         }
 
-        public MavenCoordinate getArtifact() {
+        public Artifact getArtifact() {
             return artifact;
         }
 
@@ -67,7 +67,7 @@ public abstract class ClassPathEntry {
 
             @Override
             public MavenArtifact convert(String value) {
-                return ClassPathEntry.of(MavenCoordinates.createCoordinate(value));
+                return ClassPathEntry.of(new DefaultArtifact(value));
             }
         }
     }

--- a/main/src/main/java/org/qbicc/main/QbiccMavenResolver.java
+++ b/main/src/main/java/org/qbicc/main/QbiccMavenResolver.java
@@ -1,0 +1,397 @@
+package org.qbicc.main;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.settings.Mirror;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuilder;
+import org.apache.maven.settings.building.SettingsBuildingException;
+import org.apache.maven.settings.building.SettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuildingResult;
+import org.apache.maven.settings.building.SettingsProblem;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.artifact.DefaultArtifactType;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.DependencyGraphTransformer;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.util.artifact.DefaultArtifactTypeRegistry;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.filter.AndDependencyFilter;
+import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
+import org.eclipse.aether.util.graph.selector.ScopeDependencySelector;
+import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.graph.transformer.JavaDependencyContextRefiner;
+import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
+import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
+import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
+import org.eclipse.aether.util.graph.traverser.FatArtifactTraverser;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+import org.eclipse.aether.util.repository.DefaultMirrorSelector;
+import org.eclipse.aether.util.repository.DefaultProxySelector;
+import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
+import org.qbicc.context.Diagnostic;
+import org.qbicc.context.DiagnosticContext;
+import org.qbicc.context.Location;
+import org.qbicc.driver.ClassPathElement;
+import org.qbicc.driver.ClassPathItem;
+
+/**
+ * This class is responsible for resolving the items on the class path.
+ */
+final class QbiccMavenResolver {
+    private static final String MAVEN_CENTRAL = "https://repo1.maven.org/maven2";
+    private final RepositorySystem system;
+
+    QbiccMavenResolver(ServiceLocator locator) {
+        this.system = locator.getService(RepositorySystem.class);
+    }
+
+    Settings createSettings(DiagnosticContext ctxt, File globalSettings, File userSettings) throws SettingsBuildingException {
+        SettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
+        if (globalSettings != null) {
+            request.setGlobalSettingsFile(globalSettings);
+        }
+        if (userSettings != null) {
+            request.setUserSettingsFile(userSettings);
+        }
+        request.setSystemProperties(System.getProperties());
+        SettingsBuilder builder = new DefaultSettingsBuilderFactory().newInstance();
+
+        SettingsBuildingResult result = builder.build(request);
+        for (SettingsProblem problem : result.getProblems()) {
+            Location loc = Location.builder().setSourceFilePath(problem.getSource()).setLineNumber(problem.getLineNumber()).build();
+            SettingsProblem.Severity severity = problem.getSeverity();
+            Diagnostic.Level level = switch (severity) {
+                case FATAL, ERROR -> Diagnostic.Level.ERROR;
+                case WARNING -> Diagnostic.Level.WARNING;
+            };
+            ctxt.msg(null, loc, level, "Maven settings problem: %s", problem.getMessage());
+        }
+        Settings settings = result.getEffectiveSettings();
+        // now apply some defaults...
+        if (settings.getLocalRepository() == null) {
+            settings.setLocalRepository(System.getProperty("user.home", "") + File.separator + ".m2" + File.separator + "repository");
+        }
+        return settings;
+    }
+
+    RepositorySystemSession createSession(final Settings settings) {
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        // offline = "simple"
+        // normal = "enhanced"
+        String repositoryType = "default";
+        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, new LocalRepository(new File(settings.getLocalRepository()), repositoryType)));
+//        session.setWorkspaceReader(new QbiccWorkspaceReader(main));
+//        session.setTransferListener(new QbiccLoggingTransferListener());
+//        session.setRepositoryListener(new QbiccLoggingRepositoryListener());
+        session.setOffline(settings.isOffline());
+
+        DefaultMirrorSelector mirrorSelector = new DefaultMirrorSelector();
+        for (Mirror mirror : settings.getMirrors()) {
+            mirrorSelector.add(mirror.getId(), mirror.getUrl(), mirror.getLayout(), false, mirror.getMirrorOf(), mirror.getMirrorOfLayouts());
+        }
+        session.setMirrorSelector(mirrorSelector);
+
+        DefaultProxySelector proxySelector = new DefaultProxySelector();
+        for (org.apache.maven.settings.Proxy proxy : settings.getProxies()) {
+            proxySelector.add(convertProxy(proxy), proxy.getNonProxyHosts());
+        }
+        session.setProxySelector(proxySelector);
+
+        session.setDependencyManager(new ClassicDependencyManager());
+        session.setArtifactDescriptorPolicy(new SimpleArtifactDescriptorPolicy(true, true));
+        session.setDependencyTraverser(new FatArtifactTraverser());
+
+        DependencyGraphTransformer dependencyGraphTransformer = new ChainedDependencyGraphTransformer(
+            new ConflictResolver(
+                new NearestVersionSelector(),
+                new JavaScopeSelector(),
+                new SimpleOptionalitySelector(),
+                new JavaScopeDeriver()
+            ),
+            new JavaDependencyContextRefiner()
+        );
+        session.setDependencyGraphTransformer(dependencyGraphTransformer);
+
+        DefaultArtifactTypeRegistry artifactTypeRegistry = new DefaultArtifactTypeRegistry();
+        artifactTypeRegistry.add(new DefaultArtifactType("pom"));
+        artifactTypeRegistry.add(new DefaultArtifactType("maven-plugin", "jar", "", "java"));
+        artifactTypeRegistry.add(new DefaultArtifactType("jar", "jar", "", "java"));
+        artifactTypeRegistry.add(new DefaultArtifactType("ejb", "jar", "", "java"));
+        artifactTypeRegistry.add(new DefaultArtifactType("ejb-client", "jar", "client", "java"));
+        artifactTypeRegistry.add(new DefaultArtifactType("test-jar", "jar", "tests", "java"));
+        artifactTypeRegistry.add(new DefaultArtifactType("javadoc", "jar", "javadoc", "java"));
+        artifactTypeRegistry.add(new DefaultArtifactType("java-source", "jar", "sources", "java", false, false));
+        artifactTypeRegistry.add(new DefaultArtifactType("war", "war", "", "java", false, true));
+        artifactTypeRegistry.add(new DefaultArtifactType("ear", "ear", "", "java", false, true));
+        artifactTypeRegistry.add(new DefaultArtifactType("rar", "rar", "", "java", false, true));
+        artifactTypeRegistry.add(new DefaultArtifactType("par", "par", "", "java", false, true));
+        session.setArtifactTypeRegistry(artifactTypeRegistry);
+
+        session.setSystemProperties(System.getProperties());
+        session.setConfigProperties(System.getProperties());
+
+        session.setDependencySelector(new AndDependencySelector(
+            new ScopeDependencySelector(Set.of(JavaScopes.RUNTIME, JavaScopes.COMPILE), Set.of()),
+            new OptionalDependencySelector()
+        ));
+
+        return session;
+    }
+
+    List<RemoteRepository> createRemoteRepositoryList(final Settings settings) {
+        List<RemoteRepository> basicList;
+        if (! settings.isOffline()) {
+            RemoteRepository.Builder builder = new RemoteRepository.Builder("central", "default", MAVEN_CENTRAL);
+            builder.setSnapshotPolicy(new RepositoryPolicy(false, null, null));
+            RemoteRepository remoteRepository = builder.build();
+            basicList = List.of(remoteRepository);
+        } else {
+            return List.of();
+        }
+        DefaultMirrorSelector mirrorSelector = new DefaultMirrorSelector();
+        for (Mirror mirror : settings.getMirrors()) {
+            mirrorSelector.add(mirror.getId(), mirror.getUrl(), mirror.getLayout(), false, mirror.getMirrorOf(), mirror.getMirrorOfLayouts());
+        }
+        Set<RemoteRepository> mirroredRepos = new LinkedHashSet<RemoteRepository>();
+        for (RemoteRepository repository : basicList) {
+            RemoteRepository mirror = mirrorSelector.getMirror(repository);
+            mirroredRepos.add(mirror != null ? mirror : repository);
+        }
+        final Set<RemoteRepository> authorizedRepos = new LinkedHashSet<RemoteRepository>();
+        for (RemoteRepository remoteRepository : mirroredRepos) {
+            final RemoteRepository.Builder builder = new RemoteRepository.Builder(remoteRepository);
+            Server server = settings.getServer(remoteRepository.getId());
+            if (server != null) {
+                final AuthenticationBuilder authenticationBuilder = new AuthenticationBuilder()
+                        .addUsername(server.getUsername())
+                        .addPassword(server.getPassword())
+                        .addPrivateKey(server.getPrivateKey(), server.getPassphrase());
+                builder.setAuthentication(authenticationBuilder.build());
+            }
+            authorizedRepos.add(builder.build());
+        }
+        return List.copyOf(authorizedRepos);
+    }
+
+    List<ClassPathItem> requestArtifacts(RepositorySystemSession session, Settings settings, List<ClassPathEntry> classPathList, DiagnosticContext ctxt, DependencyFilter filter) throws IOException {
+        List<RemoteRepository> remoteRepositoryList = createRemoteRepositoryList(settings);
+        CollectRequest collectRequest = new CollectRequest((Dependency)null, null, system.newResolutionRepositories(session, remoteRepositoryList));
+        Map<String, Map<String, ClassPathEntry>> gaToCpe = new HashMap<>();
+        for (ClassPathEntry classPathEntry : classPathList) {
+            if (classPathEntry instanceof ClassPathEntry.ClassLibraries cl) {
+                DefaultArtifact artifact = new DefaultArtifact("org.qbicc.rt", "qbicc-rt", "", "pom", cl.getVersion());
+                Dependency dependency = new Dependency(artifact, "runtime", Boolean.FALSE);
+                collectRequest.addDependency(dependency);
+                gaToCpe.computeIfAbsent(artifact.getGroupId(), QbiccMavenResolver::newMap).put(artifact.getArtifactId(), classPathEntry);
+            } else if (classPathEntry instanceof ClassPathEntry.MavenArtifact ma) {
+                Artifact artifact = ma.getArtifact();
+                Dependency dependency = new Dependency(artifact, "runtime", Boolean.FALSE);
+                collectRequest.addDependency(dependency);
+                gaToCpe.computeIfAbsent(artifact.getGroupId(), QbiccMavenResolver::newMap).put(artifact.getArtifactId(), classPathEntry);
+            } else if (classPathEntry instanceof ClassPathEntry.FilePath) {
+                // TODO: open JAR file or directory path to see if it is a Maven artifact, and treat it as an override
+                // otherwise, do not add it to the requests list
+            }
+        }
+        DependencyRequest depReq = new DependencyRequest(collectRequest, filter);
+        DependencyResult dependencyResult;
+        try {
+            dependencyResult = system.resolveDependencies(session, depReq);
+        } catch (DependencyResolutionException e) {
+            Diagnostic parent = ctxt.error("Failed to resolve dependencies: %s", e);
+            DependencyResult result = e.getResult();
+            List<ArtifactResult> artifactResults = result.getArtifactResults();
+            for (ArtifactResult artifactResult : artifactResults) {
+                List<Exception> exceptions = artifactResult.getExceptions();
+                for (Exception exception : exceptions) {
+                    ctxt.error(parent, "Resolve of %s failed: %s", artifactResult.getRequest().getArtifact(), exception);
+                }
+            }
+            for (Exception collectException : result.getCollectExceptions()) {
+                ctxt.error(parent, "Collect exception: %s", collectException);
+            }
+            return List.of();
+        }
+        List<ArtifactResult> artifactResults = dependencyResult.getArtifactResults();
+        Map<ClassPathEntry, List<ArtifactResult>> resultMapping = new HashMap<>();
+        for (ArtifactResult result : artifactResults) {
+            DependencyNode node = result.getRequest().getDependencyNode();
+            ClassPathEntry entry = findDependency(node, gaToCpe);
+            if (entry != null) {
+                resultMapping.computeIfAbsent(entry, QbiccMavenResolver::newList).add(result);
+                populateChildren(entry, node, gaToCpe);
+            }
+            Artifact resultArtifact = result.getArtifact();
+            if (result.isMissing()) {
+                ctxt.error("Required artifact is missing: %s", resultArtifact);
+            } else if (! result.isResolved()) {
+                ctxt.error("Required artifact is not missing but wasn't resolved: %s", resultArtifact);
+            }
+        }
+        // second pass - produce the class path items
+        List<ClassPathItem> resultList = new ArrayList<>();
+        Set<ArtifactResult> unmappedResults = new LinkedHashSet<>(artifactResults);
+        try {
+            for (ClassPathEntry classPathEntry : classPathList) {
+                if (classPathEntry instanceof ClassPathEntry.MavenArtifact || classPathEntry instanceof ClassPathEntry.ClassLibraries) {
+                    // we requested it from Maven
+                    for (ArtifactResult artifactResult : resultMapping.getOrDefault(classPathEntry, List.of())) {
+                        unmappedResults.remove(artifactResult);
+                        appendArtifactResult(session, resultList, artifactResult);
+                    }
+                } else if (classPathEntry instanceof ClassPathEntry.FilePath fp) {
+                    Path path = fp.getPath();
+                    if (Files.isDirectory(path)) {
+                        resultList.add(new ClassPathItem(path.toString(), List.of(ClassPathElement.forDirectory(path)), List.of()));
+                    } else if (Files.isRegularFile(path)) {
+                        ClassPathElement element = ClassPathElement.forJarFile(path);
+                        try {
+                            resultList.add(new ClassPathItem(path.toString(), List.of(element), List.of()));
+                        } catch (Throwable t) {
+                            element.close();
+                            throw t;
+                        }
+                    }
+                }
+            }
+            // now append the remaining ones
+            for (ArtifactResult unmappedResult : unmappedResults) {
+                // todo - log?
+                appendArtifactResult(session, resultList, unmappedResult);
+            }
+        } catch (Throwable t) {
+            for (ClassPathItem item : resultList) {
+                item.close();
+            }
+            throw t;
+        }
+        return List.copyOf(resultList);
+    }
+
+    private static <K, V> Map<K, V> newMap(final Object ignored) {
+        return new HashMap<>();
+    }
+
+    private void appendArtifactResult(final RepositorySystemSession session, final List<ClassPathItem> resultList, final ArtifactResult artifactResult) throws IOException {
+        if (artifactResult.isResolved() && !artifactResult.isMissing()) {
+            Artifact resultArtifact = artifactResult.getArtifact();
+            if (! artifactResult.getArtifact().getExtension().equals("jar")) {
+                // aggregator POM perhaps; skip
+                return;
+            }
+            File jarFile = resultArtifact.getFile();
+            File sourceFile = null;
+            ArtifactRequest sourceRequest = new ArtifactRequest(new DefaultArtifact(resultArtifact.getGroupId(), resultArtifact.getArtifactId(), "source", "jar", resultArtifact.getVersion()), null, null);
+            try {
+                ArtifactResult sourceResult = system.resolveArtifact(session, sourceRequest);
+                if (sourceResult != null && sourceResult.isResolved() && !sourceResult.isMissing()) {
+                    sourceFile = sourceResult.getArtifact().getFile();
+                }
+            } catch (ArtifactResolutionException ignored) {}
+            ClassPathElement element = ClassPathElement.forJarFile(jarFile);
+            List<ClassPathElement> jarPath = List.of(element);
+            try {
+                ClassPathElement sourceElement = sourceFile == null ? null : ClassPathElement.forJarFile(sourceFile);
+                List<ClassPathElement> sourcePath = sourceFile == null ? List.of() : List.of(sourceElement);
+                try {
+                    resultList.add(new ClassPathItem(resultArtifact.toString(), jarPath, sourcePath));
+                } catch (Throwable t) {
+                    if (sourceElement != null) {
+                        sourceElement.close();
+                    }
+                    throw t;
+                }
+            } catch (Throwable t) {
+                element.close();
+                throw t;
+            }
+        }
+    }
+
+    private void populateChildren(final ClassPathEntry parent, final DependencyNode dependencyNode, final Map<String, Map<String, ClassPathEntry>> gaToCpe) {
+        for (DependencyNode child : dependencyNode.getChildren()) {
+            Artifact artifact = child.getArtifact();
+            gaToCpe.computeIfAbsent(artifact.getGroupId(), QbiccMavenResolver::newMap).putIfAbsent(artifact.getArtifactId(), parent);
+            populateChildren(parent, child, gaToCpe);
+        }
+    }
+
+    private ClassPathEntry findDependency(final DependencyNode dependencyNode, final Map<String, Map<String, ClassPathEntry>> gaToCpe) {
+        if (dependencyNode == null) {
+            return null;
+        }
+        Dependency dependency = dependencyNode.getDependency();
+        Artifact artifact = dependency.getArtifact();
+        ClassPathEntry classPathEntry = gaToCpe.getOrDefault(artifact.getGroupId(), Map.of()).get(artifact.getArtifactId());
+        if (classPathEntry != null) {
+            return classPathEntry;
+        }
+        for (DependencyNode child : dependencyNode.getChildren()) {
+            ClassPathEntry found = findDependency(child, gaToCpe);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private static <E> List<E> newList(final Object ignored) {
+        return new ArrayList<>();
+    }
+
+    static Proxy convertProxy(org.apache.maven.settings.Proxy proxy) {
+        final Authentication authentication;
+        if (proxy.getUsername() != null || proxy.getPassword() != null) {
+            authentication = new AuthenticationBuilder().addUsername(proxy.getUsername())
+                    .addPassword(proxy.getPassword()).build();
+        } else {
+            authentication = null;
+        }
+        return new Proxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), authentication);
+    }
+
+    public File getGlobalSettings() {
+        String mavenHome = System.getProperty("maven.home");
+        return mavenHome == null ? null : new File(mavenHome + File.separator + "conf" + File.separator + "settings.xml");
+    }
+
+    public File getUserSettings() {
+        String userHome = System.getProperty("user.home");
+        return userHome == null ? null : new File(userHome + File.separator + ".m2" + File.separator + "settings.xml");
+    }
+}

--- a/main/src/main/java/org/qbicc/main/QbiccServiceLocator.java
+++ b/main/src/main/java/org/qbicc/main/QbiccServiceLocator.java
@@ -1,0 +1,188 @@
+package org.qbicc.main;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.ModelBuilder;
+import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
+import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
+import org.apache.maven.repository.internal.DefaultVersionResolver;
+import org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory;
+import org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.ArtifactDescriptorReader;
+import org.eclipse.aether.impl.ArtifactResolver;
+import org.eclipse.aether.impl.DependencyCollector;
+import org.eclipse.aether.impl.Deployer;
+import org.eclipse.aether.impl.Installer;
+import org.eclipse.aether.impl.LocalRepositoryProvider;
+import org.eclipse.aether.impl.MetadataGeneratorFactory;
+import org.eclipse.aether.impl.MetadataResolver;
+import org.eclipse.aether.impl.OfflineController;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.impl.RepositoryConnectorProvider;
+import org.eclipse.aether.impl.RepositoryEventDispatcher;
+import org.eclipse.aether.impl.SyncContextFactory;
+import org.eclipse.aether.impl.UpdateCheckManager;
+import org.eclipse.aether.impl.UpdatePolicyAnalyzer;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.impl.VersionResolver;
+import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
+import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider;
+import org.eclipse.aether.internal.impl.DefaultDeployer;
+import org.eclipse.aether.internal.impl.DefaultFileProcessor;
+import org.eclipse.aether.internal.impl.DefaultInstaller;
+import org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider;
+import org.eclipse.aether.internal.impl.DefaultMetadataResolver;
+import org.eclipse.aether.internal.impl.DefaultOfflineController;
+import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.internal.impl.DefaultRepositoryConnectorProvider;
+import org.eclipse.aether.internal.impl.DefaultRepositoryEventDispatcher;
+import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
+import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
+import org.eclipse.aether.internal.impl.DefaultSyncContextFactory;
+import org.eclipse.aether.internal.impl.DefaultTransporterProvider;
+import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
+import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
+import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterProvider;
+import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
+import org.eclipse.aether.spi.locator.Service;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.spi.log.Logger;
+import org.eclipse.aether.spi.log.LoggerFactory;
+import org.eclipse.aether.transport.wagon.WagonProvider;
+import org.eclipse.aether.transport.wagon.WagonTransporterFactory;
+
+/**
+ * Our implementation of {@link ServiceLocator} for Maven resolution.
+ */
+final class QbiccServiceLocator implements ServiceLocator {
+    private static final Map<Class<?>, List<Supplier<Object>>> serviceClasses = Map.ofEntries(
+        Map.entry(ArtifactDescriptorReader.class, List.of(DefaultArtifactDescriptorReader::new)),
+        Map.entry(ArtifactResolver.class, List.of(DefaultArtifactResolver::new)),
+        Map.entry(ChecksumPolicyProvider.class, List.of(DefaultChecksumPolicyProvider::new)),
+        Map.entry(DependencyCollector.class, List.of(DefaultDependencyCollector::new)),
+        Map.entry(Deployer.class, List.of(DefaultDeployer::new)),
+        Map.entry(FileProcessor.class, List.of(DefaultFileProcessor::new)),
+        Map.entry(Installer.class, List.of(DefaultInstaller::new)),
+        Map.entry(LocalRepositoryManagerFactory.class, List.of(SimpleLocalRepositoryManagerFactory::new, EnhancedLocalRepositoryManagerFactory::new)),
+        Map.entry(LocalRepositoryProvider.class, List.of(DefaultLocalRepositoryProvider::new)),
+        Map.entry(MetadataGeneratorFactory.class, List.of(SnapshotMetadataGeneratorFactory::new, VersionsMetadataGeneratorFactory::new)),
+        Map.entry(MetadataResolver.class, List.of(DefaultMetadataResolver::new)),
+        Map.entry(ModelBuilder.class, List.of(() -> new DefaultModelBuilderFactory().newInstance())),
+        Map.entry(OfflineController.class, List.of(DefaultOfflineController::new)),
+        Map.entry(RemoteRepositoryManager .class, List.of(DefaultRemoteRepositoryManager::new)),
+        Map.entry(RepositoryConnectorFactory.class, List.of(BasicRepositoryConnectorFactory::new)),
+        Map.entry(RepositoryConnectorProvider.class, List.of(DefaultRepositoryConnectorProvider::new)),
+        Map.entry(RepositoryEventDispatcher.class, List.of(DefaultRepositoryEventDispatcher::new)),
+        Map.entry(RepositoryLayoutFactory.class, List.of(Maven2RepositoryLayoutFactory::new)),
+        Map.entry(RepositoryLayoutProvider.class, List.of(DefaultRepositoryLayoutProvider::new)),
+        Map.entry(RepositorySystem.class, List.of(DefaultRepositorySystem::new)),
+        Map.entry(SyncContextFactory.class, List.of(DefaultSyncContextFactory::new)),
+        Map.entry(TransporterFactory.class, List.of(WagonTransporterFactory::new)),
+        Map.entry(TransporterProvider.class, List.of(DefaultTransporterProvider::new)),
+        Map.entry(UpdateCheckManager.class, List.of(DefaultUpdateCheckManager::new)),
+        Map.entry(UpdatePolicyAnalyzer.class, List.of(DefaultUpdatePolicyAnalyzer::new)),
+        Map.entry(VersionRangeResolver.class, List.of(DefaultVersionRangeResolver::new)),
+        Map.entry(VersionResolver.class, List.of(DefaultVersionResolver::new)),
+
+        // custom implementations
+
+        Map.entry(WagonProvider.class, List.of(QbiccWagonProvider::new)),
+        Map.entry(LoggerFactory.class, List.of(Log::new))
+    );
+    private final Map<Class<?>, List<?>> instantiated = new ConcurrentHashMap<>();
+    
+
+    @Override
+    public <T> T getService(Class<T> serviceType) {
+        List<T> services = getServices(serviceType);
+        if (services.size() == 1) {
+            return services.iterator().next();
+        } else if (services.size() > 1) {
+            throw new IllegalStateException("Too many implementations of " + serviceType);
+        }
+        return null;
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> List<T> getServices(Class<T> serviceType) {
+        List<?> cachedList = instantiated.get(serviceType);
+        if (cachedList == null) {
+            List<Supplier<Object>> suppliers = serviceClasses.get(serviceType);
+            if (suppliers != null) {
+                ArrayList<T> list = new ArrayList<>(suppliers.size());
+                for (Supplier<Object> supplier : suppliers) {
+                    Object service = supplier.get();
+                    if (service instanceof Service srv) {
+                        srv.initService(this);
+                    }
+                    list.add(serviceType.cast(service));
+                }
+                cachedList = List.copyOf(list);
+            } else {
+                cachedList = List.of();
+            }
+        }
+        List<?> appearing = instantiated.putIfAbsent(serviceType, cachedList);
+        if (appearing != null) {
+            cachedList = appearing;
+        }
+        return (List<T>) cachedList;
+    }
+
+    static final class Log implements LoggerFactory {
+        @Override
+        public Logger getLogger(String name) {
+            org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(name);
+            return new Logger() {
+                @Override
+                public boolean isDebugEnabled() {
+                    return log.isDebugEnabled();
+                }
+
+                @Override
+                public void debug(String msg) {
+                    log.debug(msg, (Throwable)null);
+                }
+
+                @Override
+                public void debug(String msg, Throwable error) {
+                    log.debug(msg, error);
+                }
+
+                @Override
+                public boolean isWarnEnabled() {
+                    return log.isEnabled(org.jboss.logging.Logger.Level.WARN);
+                }
+
+                @Override
+                public void warn(String msg) {
+                    log.warn(msg, (Throwable)null);
+                }
+
+                @Override
+                public void warn(String msg, Throwable error) {
+                    log.warn(msg, error);
+                }
+            };
+        }
+    }
+}

--- a/main/src/main/java/org/qbicc/main/QbiccWagonProvider.java
+++ b/main/src/main/java/org/qbicc/main/QbiccWagonProvider.java
@@ -1,0 +1,44 @@
+package org.qbicc.main;
+
+import java.lang.reflect.Field;
+
+import org.apache.maven.wagon.Wagon;
+import org.apache.maven.wagon.providers.file.FileWagon;
+import org.apache.maven.wagon.providers.http.LightweightHttpWagon;
+import org.apache.maven.wagon.providers.http.LightweightHttpWagonAuthenticator;
+import org.apache.maven.wagon.providers.http.LightweightHttpsWagon;
+import org.eclipse.aether.transport.wagon.WagonProvider;
+
+/**
+ *
+ */
+final class QbiccWagonProvider implements WagonProvider {
+    QbiccWagonProvider() {
+    }
+
+    public Wagon lookup(final String roleHint) {
+        return switch (roleHint) {
+            case "http" -> setAuthenticator(new LightweightHttpWagon());
+            case "https" -> setAuthenticator(new LightweightHttpsWagon());
+            case "file" -> new FileWagon();
+            default -> throw new IllegalArgumentException();
+        };
+    }
+
+    public void release(final Wagon wagon) {
+    }
+
+    private <W extends LightweightHttpWagon> W setAuthenticator(final W wagon) {
+        final Field authenticator;
+        try {
+            // http://dev.eclipse.org/mhonarc/lists/aether-users/msg00113.html
+            authenticator = LightweightHttpWagon.class.getDeclaredField("authenticator");
+            authenticator.setAccessible(true);
+            authenticator.set(wagon, new LightweightHttpWagonAuthenticator());
+        } catch (final Exception e) {
+            throw new IllegalStateException(e);
+        }
+        wagon.setPreemptiveAuthentication(true);
+        return wagon;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,30 @@
         <version.junit.jupiter>5.8.2</version.junit.jupiter>
         <version.org.jboss.jandex>2.4.1.Final</version.org.jboss.jandex>
         <version.org.jboss.logging>3.4.2.Final</version.org.jboss.logging>
+        <version.org.jboss.logging.commons>1.0.0.Final</version.org.jboss.logging.commons>
         <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>
         <version.org.jboss.slf4j.logmanager>1.1.0.Final</version.org.jboss.slf4j.logmanager>
         <version.org.ow2.asm>9.2</version.org.ow2.asm>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
-        <version.shrinkwrap.resolvers>3.1.4</version.shrinkwrap.resolvers>
+
+        <!-- Aether things -->
+        <version.maven>3.8.2</version.maven>
+        <version.maven.resolver>1.4.1</version.maven.resolver>
+        <version.maven.wagon>3.4.3</version.maven.wagon>
+        <version.plexus.interpolation>1.25</version.plexus.interpolation>
+        <version.plexus.utils>3.2.1</version.plexus.utils>
+        <version.plexus.sec-dispatcher>1.4</version.plexus.sec-dispatcher>
+        <version.plexus.cipher>1.7</version.plexus.cipher>
+
+        <version.commons.codec>1.11</version.commons.codec>
+        <version.commons.lang3>3.8.1</version.commons.lang3>
+        <version.commons.io>2.11.0</version.commons.io>
+        <version.eclipse.sisu>0.3.4</version.eclipse.sisu>
+        <version.httpcomponents.httpclient>4.5.13</version.httpcomponents.httpclient>
+        <version.httpcomponents.httpcore>4.4.14</version.httpcomponents.httpcore>
+        <version.javax.inject>1</version.javax.inject>
+        <version.jsoup>1.14.2</version.jsoup>
+        <version.slf4j>1.7.30</version.slf4j>
 
         <!-- this is the class lib version; the class lib cannot be used in a POM but is used in resources -->
         <version.qbicc.classlib>11.alpha.0.1</version.qbicc.classlib>
@@ -450,6 +469,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>commons-logging-jboss-logging</artifactId>
+                <version>${version.org.jboss.logging.commons}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>jboss-logmanager</artifactId>
                 <version>${version.org.jboss.logmanager}</version>
@@ -459,14 +484,6 @@
                 <groupId>org.jboss.slf4j</groupId>
                 <artifactId>slf4j-jboss-logmanager</artifactId>
                 <version>${version.org.jboss.slf4j.logmanager}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${version.shrinkwrap.resolvers}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -485,6 +502,200 @@
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-analysis</artifactId>
                 <version>${version.org.ow2.asm}</version>
+            </dependency>
+
+            <!-- aether -->
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${version.commons.codec}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${version.commons.io}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>${version.javax.inject}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${version.commons.lang3}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${version.httpcomponents.httpclient}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>${version.httpcomponents.httpcore}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-builder-support</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model-builder</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-repository-metadata</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-resolver-provider</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings-builder</artifactId>
+                <version>${version.maven}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-api</artifactId>
+                <version>${version.maven.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-impl</artifactId>
+                <version>${version.maven.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-spi</artifactId>
+                <version>${version.maven.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-util</artifactId>
+                <version>${version.maven.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-connector-basic</artifactId>
+                <version>${version.maven.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-transport-wagon</artifactId>
+                <version>${version.maven.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-provider-api</artifactId>
+                <version>${version.maven.wagon}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-file</artifactId>
+                <version>${version.maven.wagon}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-http-lightweight</artifactId>
+                <version>${version.maven.wagon}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-http-shared</artifactId>
+                <version>${version.maven.wagon}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-interpolation</artifactId>
+                <version>${version.plexus.interpolation}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${version.plexus.utils}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>org.eclipse.sisu.inject</artifactId>
+                <version>${version.eclipse.sisu}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${version.jsoup}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${version.slf4j}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.sonatype.plexus</groupId>
+                <artifactId>plexus-cipher</artifactId>
+                <version>${version.plexus.cipher}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.sonatype.plexus</groupId>
+                <artifactId>plexus-sec-dispatcher</artifactId>
+                <version>${version.plexus.sec-dispatcher}</version>
             </dependency>
 
             <!-- test -->


### PR DESCRIPTION
This allows us to have an accurate class path in the same order it was specified on the command line. It's also much faster (but it's possible that the Maven Central repository isn't correctly configured; we'll see how CI likes it).

This also will allow us to build an app class path which automatically excludes any artifacts that are already on the boot class path.