### PR TITLE
Move runtime method lookup from CompilationContext to RuntimeMethodFinder

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/CompilationContext.java
+++ b/compiler/src/main/java/org/qbicc/context/CompilationContext.java
@@ -16,7 +16,6 @@ import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmClassLoader;
 import org.qbicc.machine.arch.Platform;
 import org.qbicc.object.Function;
-import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.ProgramModule;
 import org.qbicc.object.Section;
 import org.qbicc.type.FunctionType;
@@ -52,8 +51,14 @@ public interface CompilationContext extends DiagnosticContext {
 
     ClassContext constructClassContext(VmClassLoader classLoaderObject);
 
+    /**
+     * @deprecated
+     */
     MethodElement getVMHelperMethod(String helperName);
 
+    /**
+     * @deprecated
+     */
     MethodElement getOMHelperMethod(String helperName);
 
     void enqueue(ExecutableElement element);

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -268,6 +268,9 @@ final class CompilationContextImpl implements CompilationContext {
         return classContext;
     }
 
+    /**
+     * @deprecated
+     */
     public MethodElement getVMHelperMethod(String name) {
         DefinedTypeDefinition dtd = bootstrapClassContext.findDefinedType("org/qbicc/runtime/main/VMHelpers");
         if (dtd == null) {
@@ -283,6 +286,9 @@ final class CompilationContextImpl implements CompilationContext {
         return helpers.getMethod(idx);
     }
 
+    /**
+     * @deprecated
+     */
     public MethodElement getOMHelperMethod(String name) {
         DefinedTypeDefinition dtd = bootstrapClassContext.findDefinedType("org/qbicc/runtime/main/ObjectModel");
         if (dtd == null) {

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/RuntimeMethodFinder.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/RuntimeMethodFinder.java
@@ -13,8 +13,13 @@ public class RuntimeMethodFinder {
     private static final AttachmentKey<RuntimeMethodFinder> KEY = new AttachmentKey<>();
     private final CompilationContext ctxt;
 
+    final LoadedTypeDefinition VMHelpers;
+    final LoadedTypeDefinition ObjectModel;
+
     private RuntimeMethodFinder(CompilationContext ctxt) {
         this.ctxt = ctxt;
+        this.VMHelpers = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/VMHelpers").load();
+        this.ObjectModel = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/ObjectModel").load();
     }
 
     public static RuntimeMethodFinder get(CompilationContext ctxt) {
@@ -27,6 +32,19 @@ public class RuntimeMethodFinder {
             }
         }
         return helpers;
+    }
+
+    public MethodElement getMethod(String methodName) {
+        int idx = VMHelpers.findMethodIndex(e -> methodName.equals(e.getName()));
+        if (idx != -1) {
+            return VMHelpers.getMethod(idx);
+        }
+        idx = ObjectModel.findMethodIndex(e -> methodName.equals(e.getName()));
+        if (idx != -1) {
+            return ObjectModel.getMethod(idx);
+        }
+        ctxt.error("Can't find the runtime helper method %s", methodName);
+        return null;
     }
 
     public MethodElement getMethod(String runtimeClass, String helperName) {

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
@@ -28,6 +28,7 @@ import org.qbicc.graph.VirtualMethodElementHandle;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.plugin.coreclasses.CoreClasses;
+import org.qbicc.plugin.coreclasses.RuntimeMethodFinder;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.ClassObjectType;
@@ -191,7 +192,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
             if_(isEq(v2, zero), throwIt, goAhead);
             try {
                 begin(throwIt);
-                MethodElement helper = ctxt.getVMHelperMethod("raiseArithmeticException");
+                MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("raiseArithmeticException");
                 callNoReturn(staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of());
             } catch (BlockEarlyTermination ignored) {
                 // continue
@@ -202,12 +203,12 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
     }
 
     private void throwIncompatibleClassChangeError() {
-        MethodElement helper = ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError");
+        MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("raiseIncompatibleClassChangeError");
         throw new BlockEarlyTermination(callNoReturn(staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of()));
     }
 
     private void throwClassCastException() {
-        MethodElement helper = ctxt.getVMHelperMethod("raiseClassCastException");
+        MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("raiseClassCastException");
         throw new BlockEarlyTermination(callNoReturn(staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of()));
     }
 
@@ -336,7 +337,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
         if_(isEq(value, lf.zeroInitializerLiteralOfType(value.getType())), throwIt, goAhead);
         try {
             begin(throwIt);
-            MethodElement helper = ctxt.getVMHelperMethod("raiseNullPointerException");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("raiseNullPointerException");
             callNoReturn(staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of());
         } catch (BlockEarlyTermination ignored) {
             //continue
@@ -361,7 +362,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
         }
         try {
             begin(throwIt);
-            MethodElement helper = ctxt.getVMHelperMethod("raiseArrayIndexOutOfBoundsException");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("raiseArrayIndexOutOfBoundsException");
             callNoReturn(staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of());
         } catch (BlockEarlyTermination ignored) {
             // continue
@@ -376,7 +377,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
         if_(isLt(size, zero), throwIt, goAhead);
         try {
             begin(throwIt);
-            MethodElement helper = ctxt.getVMHelperMethod("raiseNegativeArraySizeException");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("raiseNegativeArraySizeException");
             callNoReturn(staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of());
         } catch (BlockEarlyTermination ignored) {
             // continue

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
@@ -12,6 +12,7 @@ import org.qbicc.graph.Node;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.plugin.coreclasses.RuntimeMethodFinder;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -58,7 +59,7 @@ public class LowerClassInitCheckBlockBuilder extends DelegatingBasicBlockBuilder
         if_(isEq(state, lf.literalOf(0)), callInit, goAhead);
         try {
             begin(callInit);
-            MethodElement helper = ctxt.getVMHelperMethod("initialize_class");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("initialize_class");
             BasicBlockBuilder fb = getFirstBuilder();
             fb.call(fb.staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(fb.load(fb.currentThread(), MemoryAtomicityMode.NONE), typeId));
             goto_(goAhead);

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -223,6 +223,7 @@ public final class CoreIntrinsics {
         ClassContext classContext = ctxt.getBootstrapClassContext();
         CoreClasses coreClasses = CoreClasses.get(ctxt);
         SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
+        RuntimeMethodFinder methodFinder = RuntimeMethodFinder.get(ctxt);
 
         ClassTypeDescriptor jlcDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/Class");
         ClassTypeDescriptor jlclDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/ClassLoader");
@@ -250,7 +251,7 @@ public final class CoreIntrinsics {
         InstanceIntrinsic cast = (builder, instance, target, arguments) -> {
             // TODO: Once we support java.lang.Class literals, we should add a check here to
             //  emit a CheckCast node instead of a call to the helper method if `instance` is a Class literal.
-            MethodElement helper = ctxt.getVMHelperMethod("checkcast_class");
+            MethodElement helper = methodFinder.getMethod("checkcast_class");
             builder.getFirstBuilder().call(builder.staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(arguments.get(0), instance));
 
             // Generics erasure issue. The return type of Class<T>.cast is T, but it gets wiped to Object.
@@ -266,21 +267,21 @@ public final class CoreIntrinsics {
 
         InstanceIntrinsic isArray = (builder, instance, target, arguments) -> {
             Value id = builder.load(builder.instanceFieldOf(builder.referenceHandle(instance),  coreClasses.getClassTypeIdField()), MemoryAtomicityMode.UNORDERED);
-            MethodElement isRefArray = ctxt.getOMHelperMethod("is_reference_array");
-            MethodElement isPrimArray = ctxt.getOMHelperMethod("is_prim_array");
+            MethodElement isRefArray = methodFinder.getMethod("is_reference_array");
+            MethodElement isPrimArray = methodFinder.getMethod("is_prim_array");
             return builder.or(builder.getFirstBuilder().call(builder.staticMethod(isRefArray, isRefArray.getDescriptor(), isRefArray.getType()), List.of(id)),
                               builder.getFirstBuilder().call(builder.staticMethod(isPrimArray, isPrimArray.getDescriptor(), isPrimArray.getType()), List.of(id)));
         };
 
         InstanceIntrinsic isInterface = (builder, instance, target, arguments) -> {
             Value id = builder.load(builder.instanceFieldOf(builder.referenceHandle(instance),  coreClasses.getClassTypeIdField()), MemoryAtomicityMode.UNORDERED);
-            MethodElement isIntf = ctxt.getOMHelperMethod("is_interface");
+            MethodElement isIntf = methodFinder.getMethod("is_interface");
             return builder.getFirstBuilder().call(builder.staticMethod(isIntf, isIntf.getDescriptor(), isIntf.getType()), List.of(id));
         };
 
         InstanceIntrinsic isPrimitive = (builder, instance, target, arguments) -> {
             Value id = builder.load(builder.instanceFieldOf(builder.referenceHandle(instance), coreClasses.getClassTypeIdField()), MemoryAtomicityMode.UNORDERED);
-            MethodElement isPrim = ctxt.getOMHelperMethod("is_primitive");
+            MethodElement isPrim = methodFinder.getMethod("is_primitive");
             return builder.getFirstBuilder().call(builder.staticMethod(isPrim, isPrim.getDescriptor(), isPrim.getType()), List.of(id));
         };
 
@@ -288,7 +289,7 @@ public final class CoreIntrinsics {
             Value id = builder.load(builder.instanceFieldOf(builder.referenceHandle(instance), coreClasses.getClassTypeIdField()), MemoryAtomicityMode.UNORDERED);
             LiteralFactory lf = ctxt.getLiteralFactory();
             TypeSystem ts = ctxt.getTypeSystem();
-            MethodElement helper = ctxt.getVMHelperMethod("get_superclass");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("get_superclass");
             return builder.getFirstBuilder().call(builder.staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(id));
         };
 
@@ -315,7 +316,7 @@ public final class CoreIntrinsics {
 
         StaticIntrinsic classForName0 = (builder, target, arguments) -> {
             // ignore fourth argument
-            MethodElement vmhForName = ctxt.getVMHelperMethod("classForName");
+            MethodElement vmhForName = RuntimeMethodFinder.get(ctxt).getMethod("classForName");
             return builder.call(builder.staticMethod(vmhForName, vmhForName.getDescriptor(), vmhForName.getType()), arguments.subList(0, 3));
         };
 
@@ -1029,7 +1030,7 @@ public final class CoreIntrinsics {
         MethodDescriptor getClassDesc = MethodDescriptor.synthesize(classContext, jlcDesc, List.of());
 
         InstanceIntrinsic getClassIntrinsic = (builder, instance, target, arguments) -> {
-            MethodElement helper = ctxt.getVMHelperMethod("get_class");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("get_class");
             return builder.getFirstBuilder().call(builder.staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(instance));
         };
 
@@ -1408,6 +1409,7 @@ public final class CoreIntrinsics {
         ClassContext classContext = ctxt.getBootstrapClassContext();
         CoreClasses coreClasses = CoreClasses.get(ctxt);
         SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
+        RuntimeMethodFinder methodFinder = RuntimeMethodFinder.get(ctxt);
         LiteralFactory lf = ctxt.getLiteralFactory();
 
         ClassTypeDescriptor objModDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/main/ObjectModel");
@@ -1548,7 +1550,7 @@ public final class CoreIntrinsics {
             builder.load(builder.instanceFieldOf(builder.referenceHandle(arguments.get(0)), coreClasses.getClassTypeIdField()), MemoryAtomicityMode.UNORDERED);
         intrinsics.registerIntrinsic(Phase.LOWER, objModDesc, "get_type_id_from_class", clsTypeId, getTypeIdFromClass);
 
-        MethodElement getOrCreateArrayClass = ctxt.getOMHelperMethod("get_or_create_class_for_refarray");
+        MethodElement getOrCreateArrayClass = methodFinder.getMethod("get_or_create_class_for_refarray");
         StaticIntrinsic getClassFromTypeId = (builder, target, arguments) -> {
             /** Pseudo code for this intrinsic:
              *    Class<?> componentClass = qbicc_jlc_lookup_table[typeId];

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
@@ -33,6 +33,7 @@ import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.Section;
 import org.qbicc.object.ThreadLocalMode;
 import org.qbicc.plugin.coreclasses.CoreClasses;
+import org.qbicc.plugin.coreclasses.RuntimeMethodFinder;
 import org.qbicc.plugin.dispatch.DispatchTables;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.plugin.serialization.BuildtimeHeap;
@@ -192,7 +193,7 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
         DispatchTables.ITableInfo info = dt.getITableInfo(target.getEnclosingType().load());
         if (info == null) {
             // No realized invocation targets are possible for this method!
-            MethodElement method = ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError");
+            MethodElement method = RuntimeMethodFinder.get(ctxt).getMethod("raiseIncompatibleClassChangeError");
             throw new BlockEarlyTermination(fb.callNoReturn(staticMethod(method, method.getDescriptor(), method.getType()), List.of()));
         }
 
@@ -227,7 +228,7 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
             phi.setValueForBlock(ctxt, getCurrentElement(), body, fb.add(phi, ctxt.getLiteralFactory().literalOf(1)));
 
             begin(failLabel);
-            MethodElement method = ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError");
+            MethodElement method = RuntimeMethodFinder.get(ctxt).getMethod("raiseIncompatibleClassChangeError");
             callNoReturn(staticMethod(method, method.getDescriptor(), method.getType()), List.of());
         } catch (BlockEarlyTermination ignored) {
             // ignore; continue to generate validEntry block
@@ -267,7 +268,7 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
         ctxt.getImplicitSection(originalElement).declareData(literal.getProgramObject());
         Literal arg = ctxt.getLiteralFactory().bitcastLiteral(literal, ctxt.getBootstrapClassContext().findDefinedType("java/lang/String").load().getType().getReference());
 
-        MethodElement helper = ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError");
+        MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("raiseUnsatisfiedLinkError");
         return callNoReturn(staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(arg));
     }
 }

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
@@ -16,39 +16,39 @@ public class VMHelpersSetupHook implements Consumer<CompilationContext> {
     public void accept(final CompilationContext ctxt) {
         RuntimeMethodFinder methodFinder = RuntimeMethodFinder.get(ctxt);
         // Helpers for dynamic type checking
-        ctxt.enqueue(ctxt.getVMHelperMethod("arrayStoreCheck"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("checkcast_class"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("checkcast_typeId"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("instanceof_class"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("instanceof_typeId"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("get_class"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("classof_from_typeid"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("get_superclass"));
+        ctxt.enqueue(methodFinder.getMethod("arrayStoreCheck"));
+        ctxt.enqueue(methodFinder.getMethod("checkcast_class"));
+        ctxt.enqueue(methodFinder.getMethod("checkcast_typeId"));
+        ctxt.enqueue(methodFinder.getMethod("instanceof_class"));
+        ctxt.enqueue(methodFinder.getMethod("instanceof_typeId"));
+        ctxt.enqueue(methodFinder.getMethod("get_class"));
+        ctxt.enqueue(methodFinder.getMethod("classof_from_typeid"));
+        ctxt.enqueue(methodFinder.getMethod("get_superclass"));
 
         // Helpers to create and throw common runtime exceptions
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseAbstractMethodError"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArithmeticException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArrayIndexOutOfBoundsException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseArrayStoreException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseClassCastException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseIncompatibleClassChangeError"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseNegativeArraySizeException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseNullPointerException"));
-        ctxt.registerEntryPoint(ctxt.getVMHelperMethod("raiseUnsatisfiedLinkError"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseAbstractMethodError"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseArithmeticException"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseArrayIndexOutOfBoundsException"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseArrayStoreException"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseClassCastException"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseIncompatibleClassChangeError"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseNegativeArraySizeException"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseNullPointerException"));
+        ctxt.registerEntryPoint(methodFinder.getMethod("raiseUnsatisfiedLinkError"));
 
         // Object monitors
-        ctxt.enqueue(ctxt.getVMHelperMethod("monitor_enter"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("monitor_exit"));
+        ctxt.enqueue(methodFinder.getMethod("monitor_enter"));
+        ctxt.enqueue(methodFinder.getMethod("monitor_exit"));
 
         // class initialization
-        ctxt.enqueue(ctxt.getVMHelperMethod("initialize_class"));
+        ctxt.enqueue(methodFinder.getMethod("initialize_class"));
 
         // helper to create j.l.Class instance of an array class at runtime
-        ctxt.enqueue(ctxt.getOMHelperMethod("get_or_create_class_for_refarray"));
+        ctxt.enqueue(methodFinder.getMethod("get_or_create_class_for_refarray"));
 
         // java.lang.Thread
-        ctxt.enqueue(ctxt.getVMHelperMethod("JLT_start0"));
-        ctxt.enqueue(ctxt.getVMHelperMethod("threadWrapper"));
+        ctxt.enqueue(methodFinder.getMethod("JLT_start0"));
+        ctxt.enqueue(methodFinder.getMethod("threadWrapper"));
 
         // Helpers for stack walk
         ctxt.enqueue(methodFinder.getMethod("org/qbicc/runtime/stackwalk/MethodData", "fillStackTraceElements"));

--- a/plugins/objectmonitor/pom.xml
+++ b/plugins/objectmonitor/pom.xml
@@ -24,5 +24,9 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-driver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-core-classes</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/objectmonitor/src/main/java/org/qbicc/plugin/objectmonitor/ObjectMonitorBasicBlockBuilder.java
+++ b/plugins/objectmonitor/src/main/java/org/qbicc/plugin/objectmonitor/ObjectMonitorBasicBlockBuilder.java
@@ -6,6 +6,7 @@ import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.Value;
+import org.qbicc.plugin.coreclasses.RuntimeMethodFinder;
 import org.qbicc.type.definition.element.MethodElement;
 
 /**
@@ -32,7 +33,7 @@ public class ObjectMonitorBasicBlockBuilder extends DelegatingBasicBlockBuilder 
     }
     
     private Value generateObjectMonitorFunctionCall(final Value object, String functionName) {
-        MethodElement methodElement = ctxt.getVMHelperMethod(functionName);
+        MethodElement methodElement = RuntimeMethodFinder.get(ctxt).getMethod(functionName);
         List<Value> args = List.of(object);
         return getFirstBuilder().call(getFirstBuilder().staticMethod(methodElement, methodElement.getDescriptor(), methodElement.getType()), args);
     }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -25,6 +25,7 @@ import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueHandleVisitor;
 import org.qbicc.graph.VirtualMethodElementHandle;
 import org.qbicc.graph.literal.TypeLiteral;
+import org.qbicc.plugin.coreclasses.RuntimeMethodFinder;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
@@ -212,7 +213,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, ClassOf node) {
             if (visitUnknown(param, (Node)node)) {
-                MethodElement methodElement = param.ctxt.getVMHelperMethod("classof_from_typeid");
+                MethodElement methodElement = RuntimeMethodFinder.get(param.ctxt).getMethod("classof_from_typeid");
                 param.ctxt.enqueue(methodElement);
                 if (node.getInput() instanceof TypeLiteral tl && tl.getValue() instanceof ClassObjectType cot) {
                     param.analysis.processClassInitialization(cot.getDefinition().load());


### PR DESCRIPTION
Deprecate the old methods, but leave them in place in case they are being used in people's branches.
