### PR TITLE
New `AccessMode` API

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/AbstractReadModifyWriteValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/AbstractReadModifyWriteValue.java
@@ -2,6 +2,8 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -9,14 +11,16 @@ abstract class AbstractReadModifyWriteValue extends AbstractValue implements Rea
     private final Node dependency;
     private final ValueHandle target;
     private final Value updateValue;
-    private final MemoryAtomicityMode atomicityMode;
+    private final ReadAccessMode readMode;
+    private final WriteAccessMode writeMode;
 
-    AbstractReadModifyWriteValue(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
+    AbstractReadModifyWriteValue(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
         super(callSite, element, line, bci);
         this.dependency = dependency;
         this.target = target;
         this.updateValue = updateValue;
-        this.atomicityMode = atomicityMode;
+        this.readMode = readMode;
+        this.writeMode = writeMode;
         if (! target.isWritable()) {
             throw new IllegalArgumentException("Handle is not writable");
         }
@@ -46,12 +50,22 @@ abstract class AbstractReadModifyWriteValue extends AbstractValue implements Rea
         return updateValue;
     }
 
+    @Override
+    public ReadAccessMode getReadAccessMode() {
+        return readMode;
+    }
+
+    @Override
+    public WriteAccessMode getWriteAccessMode() {
+        return writeMode;
+    }
+
     public MemoryAtomicityMode getAtomicityMode() {
-        return atomicityMode;
+        return null;
     }
 
     int calcHashCode() {
-        return Objects.hash(getClass(), dependency, target, updateValue, atomicityMode);
+        return Objects.hash(getClass(), dependency, target, updateValue, readMode, writeMode);
     }
 
     public boolean equals(final Object other) {
@@ -64,14 +78,16 @@ abstract class AbstractReadModifyWriteValue extends AbstractValue implements Rea
         b.append('(');
         b.append(updateValue);
         b.append(',');
-        b.append(atomicityMode);
+        b.append(readMode);
+        b.append(',');
+        b.append(writeMode);
         b.append(')');
         return b;
     }
 
     private boolean equals(final AbstractReadModifyWriteValue other) {
         return this == other || other.getClass() == getClass() && dependency.equals(other.dependency) && target.equals(other.target)
-            && updateValue.equals(other.updateValue) && atomicityMode == other.atomicityMode;
+            && updateValue.equals(other.updateValue) && readMode.equals(other.readMode) && writeMode.equals(other.writeMode);
     }
 
     public int getValueDependencyCount() {

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -393,23 +393,68 @@ public interface BasicBlockBuilder extends Locatable {
         return load(handle, mode.getAccessMode().getReadAccess());
     }
 
-    Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    Value getAndAdd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    Value getAndBitwiseAnd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    @Deprecated
+    default Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndAdd(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
 
-    Value getAndBitwiseNand(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    Value getAndBitwiseAnd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    Value getAndBitwiseOr(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    @Deprecated
+    default Value getAndBitwiseAnd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndBitwiseAnd(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
 
-    Value getAndBitwiseXor(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    Value getAndBitwiseNand(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    Value getAndSet(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    @Deprecated
+    default Value getAndBitwiseNand(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndBitwiseNand(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
 
-    Value getAndSetMax(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    Value getAndBitwiseOr(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    Value getAndSetMin(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    @Deprecated
+    default Value getAndBitwiseOr(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndBitwiseOr(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
 
-    Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
+    Value getAndBitwiseXor(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default Value getAndBitwiseXor(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndBitwiseXor(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
+
+    Value getAndSet(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default Value getAndSet(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndSet(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
+
+    Value getAndSetMax(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default Value getAndSetMax(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndSetMax(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
+
+    Value getAndSetMin(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default Value getAndSetMin(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndSetMin(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
+
+    Value getAndSub(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+        return getAndSub(target, update, atomicityMode.getAccessMode().getReadAccess(), atomicityMode.getAccessMode().getWriteAccess());
+    }
 
     Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength);
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.qbicc.context.Locatable;
 import org.qbicc.context.Location;
+import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
@@ -405,7 +406,12 @@ public interface BasicBlockBuilder extends Locatable {
 
     Node initCheck(InitializerElement initializer);
 
-    Node fence(MemoryAtomicityMode fenceType);
+    @Deprecated
+    default Node fence(MemoryAtomicityMode fenceType) {
+        return fence(fenceType.getAccessMode().getGlobalAccess());
+    }
+
+    Node fence(GlobalAccessMode fenceType);
 
     Node monitorEnter(Value obj);
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -421,7 +421,16 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value vaArg(Value vaList, ValueType type);
 
-    Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode);
+    default Node store(ValueHandle handle, Value value) {
+        return store(handle, value, SinglePlain);
+    }
+
+    Node store(ValueHandle handle, Value value, WriteAccessMode mode);
+
+    @Deprecated
+    default Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+        return store(handle, value, mode.getAccessMode().getWriteAccess());
+    }
 
     Node initCheck(InitializerElement initializer);
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -1,11 +1,14 @@
 package org.qbicc.graph;
 
+import static org.qbicc.graph.atomic.AccessModes.*;
+
 import java.util.List;
 import java.util.Set;
 
 import org.qbicc.context.Locatable;
 import org.qbicc.context.Location;
 import org.qbicc.graph.atomic.GlobalAccessMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
@@ -378,7 +381,16 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value clone(Value object);
 
-    Value load(ValueHandle handle, MemoryAtomicityMode mode);
+    default Value load(ValueHandle handle) {
+        return load(handle, SinglePlain);
+    }
+
+    Value load(ValueHandle handle, ReadAccessMode mode);
+
+    @Deprecated
+    default Value load(ValueHandle handle, MemoryAtomicityMode mode) {
+        return load(handle, mode.getAccessMode().getReadAccess());
+    }
 
     Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -9,6 +9,7 @@ import org.qbicc.context.Locatable;
 import org.qbicc.context.Location;
 import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
@@ -410,7 +411,13 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode);
 
-    Value cmpAndSwap(ValueHandle target, Value expect, Value update, MemoryAtomicityMode successMode, MemoryAtomicityMode failureMode, CmpAndSwap.Strength strength);
+    Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength);
+
+    @Deprecated
+    default Value cmpAndSwap(ValueHandle target, Value expect, Value update, MemoryAtomicityMode successMode, MemoryAtomicityMode failureMode, CmpAndSwap.Strength strength) {
+        // not strictly correct but sufficient for the interim
+        return cmpAndSwap(target, expect, update, failureMode.getAccessMode().getReadAccess(), successMode.getAccessMode().getWriteAccess(), strength);
+    }
 
     Value vaArg(Value vaList, ValueType type);
 

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -324,40 +324,40 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().load(handle, accessMode);
     }
 
-    public Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndAdd(target, update, atomicityMode);
+    public Value getAndAdd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndAdd(target, update, readMode, writeMode);
     }
 
-    public Value getAndBitwiseAnd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndBitwiseAnd(target, update, atomicityMode);
+    public Value getAndBitwiseAnd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndBitwiseAnd(target, update, readMode, writeMode);
     }
 
-    public Value getAndBitwiseNand(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndBitwiseNand(target, update, atomicityMode);
+    public Value getAndBitwiseNand(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndBitwiseNand(target, update, readMode, writeMode);
     }
 
-    public Value getAndBitwiseOr(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndBitwiseOr(target, update, atomicityMode);
+    public Value getAndBitwiseOr(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndBitwiseOr(target, update, readMode, writeMode);
     }
 
-    public Value getAndBitwiseXor(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndBitwiseXor(target, update, atomicityMode);
+    public Value getAndBitwiseXor(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndBitwiseXor(target, update, readMode, writeMode);
     }
 
-    public Value getAndSet(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndSet(target, update, atomicityMode);
+    public Value getAndSet(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndSet(target, update, readMode, writeMode);
     }
 
-    public Value getAndSetMax(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndSetMax(target, update, atomicityMode);
+    public Value getAndSetMax(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndSetMax(target, update, readMode, writeMode);
     }
 
-    public Value getAndSetMin(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndSetMin(target, update, atomicityMode);
+    public Value getAndSetMin(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndSetMin(target, update, readMode, writeMode);
     }
 
-    public Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return getDelegate().getAndSub(target, update, atomicityMode);
+    public Value getAndSub(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return getDelegate().getAndSub(target, update, readMode, writeMode);
     }
 
     public Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength) {

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -364,8 +364,8 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().cmpAndSwap(target, expect, update, readMode, writeMode, strength);
     }
 
-    public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
-        return getDelegate().store(handle, value, mode);
+    public Node store(ValueHandle handle, Value value, WriteAccessMode accessMode) {
+        return getDelegate().store(handle, value, accessMode);
     }
 
     public Node initCheck(InitializerElement initializer) {

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.qbicc.context.Location;
 import org.qbicc.graph.atomic.GlobalAccessMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
@@ -318,8 +319,8 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().clone(object);
     }
 
-    public Value load(final ValueHandle handle, final MemoryAtomicityMode mode) {
-        return getDelegate().load(handle, mode);
+    public Value load(final ValueHandle handle, final ReadAccessMode accessMode) {
+        return getDelegate().load(handle, accessMode);
     }
 
     public Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.qbicc.context.Location;
 import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
@@ -359,8 +360,8 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().getAndSub(target, update, atomicityMode);
     }
 
-    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, MemoryAtomicityMode successMode, MemoryAtomicityMode failureMode, CmpAndSwap.Strength strength) {
-        return getDelegate().cmpAndSwap(target, expect, update, successMode, failureMode, strength);
+    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength) {
+        return getDelegate().cmpAndSwap(target, expect, update, readMode, writeMode, strength);
     }
 
     public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.qbicc.context.Location;
+import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
@@ -369,7 +370,7 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().initCheck(initializer);
     }
 
-    public Node fence(final MemoryAtomicityMode fenceType) {
+    public Node fence(final GlobalAccessMode fenceType) {
         return getDelegate().fence(fenceType);
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/Fence.java
+++ b/compiler/src/main/java/org/qbicc/graph/Fence.java
@@ -2,24 +2,25 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public class Fence extends AbstractNode implements Action, OrderedNode {
     private final Node dependency;
-    private final MemoryAtomicityMode atomicityMode;
+    private final GlobalAccessMode accessMode;
 
-    Fence(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final MemoryAtomicityMode atomicityMode) {
+    Fence(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final GlobalAccessMode accessMode) {
         super(callSite, element, line, bci);
         this.dependency = dependency;
-        this.atomicityMode = atomicityMode;
+        this.accessMode = accessMode;
     }
 
-    public MemoryAtomicityMode getAtomicityMode() {
-        return atomicityMode;
+    public GlobalAccessMode getAccessMode() {
+        return accessMode;
     }
 
     int calcHashCode() {
-        return Objects.hash(Fence.class, dependency, atomicityMode);
+        return Objects.hash(Fence.class, dependency, accessMode);
     }
 
     @Override
@@ -40,7 +41,7 @@ public class Fence extends AbstractNode implements Action, OrderedNode {
     public StringBuilder toString(StringBuilder b) {
         super.toString(b);
         b.append('(');
-        b.append(atomicityMode);
+        b.append(accessMode);
         b.append(')');
         return b;
     }
@@ -48,7 +49,7 @@ public class Fence extends AbstractNode implements Action, OrderedNode {
     public boolean equals(final Fence other) {
         return this == other || other != null
                && dependency.equals(other.dependency)
-               && atomicityMode == other.atomicityMode;
+               && accessMode == other.accessMode;
     }
 
     public <T, R> R accept(final ActionVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndAdd.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndAdd.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndAdd extends AbstractReadModifyWriteValue {
-    GetAndAdd(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndAdd(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseAnd.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseAnd.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndBitwiseAnd extends AbstractReadModifyWriteValue {
-    GetAndBitwiseAnd(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndBitwiseAnd(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseNand.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseNand.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndBitwiseNand extends AbstractReadModifyWriteValue {
-    GetAndBitwiseNand(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndBitwiseNand(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseOr.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseOr.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndBitwiseOr extends AbstractReadModifyWriteValue {
-    GetAndBitwiseOr(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndBitwiseOr(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseXor.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndBitwiseXor.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndBitwiseXor extends AbstractReadModifyWriteValue {
-    GetAndBitwiseXor(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndBitwiseXor(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndSet.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndSet.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndSet extends AbstractReadModifyWriteValue {
-    GetAndSet(final Node callSite, final ExecutableElement  element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndSet(final Node callSite, final ExecutableElement  element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndSetMax.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndSetMax.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndSetMax extends AbstractReadModifyWriteValue {
-    GetAndSetMax(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndSetMax(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndSetMin.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndSetMin.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndSetMin extends AbstractReadModifyWriteValue {
-    GetAndSetMin(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndSetMin(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/GetAndSub.java
+++ b/compiler/src/main/java/org/qbicc/graph/GetAndSub.java
@@ -1,10 +1,12 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 public final class GetAndSub extends AbstractReadModifyWriteValue {
-    GetAndSub(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, final MemoryAtomicityMode atomicityMode) {
-        super(callSite, element, line, bci, dependency, target, updateValue, atomicityMode);
+    GetAndSub(final Node callSite, final ExecutableElement element, final int line, final int bci, final Node dependency, final ValueHandle target, final Value updateValue, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        super(callSite, element, line, bci, dependency, target, updateValue, readMode, writeMode);
     }
 
     public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {

--- a/compiler/src/main/java/org/qbicc/graph/Load.java
+++ b/compiler/src/main/java/org/qbicc/graph/Load.java
@@ -2,6 +2,7 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -11,9 +12,9 @@ import org.qbicc.type.definition.element.ExecutableElement;
 public class Load extends AbstractValue implements OrderedNode {
     private final Node dependency;
     private final ValueHandle handle;
-    private final MemoryAtomicityMode mode;
+    private final ReadAccessMode mode;
 
-    Load(Node callSite, ExecutableElement element, int line, int bci, Node dependency, ValueHandle handle, MemoryAtomicityMode mode) {
+    Load(Node callSite, ExecutableElement element, int line, int bci, Node dependency, ValueHandle handle, ReadAccessMode mode) {
         super(callSite, element, line, bci);
         this.dependency = dependency;
         this.handle = handle;
@@ -54,7 +55,7 @@ public class Load extends AbstractValue implements OrderedNode {
         return handle.getValueType();
     }
 
-    public MemoryAtomicityMode getMode() {
+    public ReadAccessMode getAccessMode() {
         return mode;
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/MemoryAtomicityMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/MemoryAtomicityMode.java
@@ -1,43 +1,56 @@
 package org.qbicc.graph;
 
+import static org.qbicc.graph.atomic.AccessModes.*;
+
+import org.qbicc.graph.atomic.AccessMode;
+import org.qbicc.graph.atomic.AccessModes;
+
 /**
  * The mode for a memory access operation.
+ *
+ * @deprecated Use the modes in {@link AccessModes} instead.
  */
+@Deprecated
 public enum MemoryAtomicityMode {
     /**
      * Non-atomic access (cannot be given for fence or read-modify-write operations).
      */
-    NONE,
+    NONE(SingleUnshared),
     /**
      * Plain access (cannot be given for fence or read-modify-write operations); any value that is read was written by
      * some other operation.
      */
-    UNORDERED,
+    UNORDERED(SinglePlain),
     /**
      * Single total order for a given memory address (cannot be given for fence operations).
      */
-    MONOTONIC,
+    MONOTONIC(SingleOpaque),
     /**
      * Like {@link #MONOTONIC} but also forms a synchronization edge with a corresponding {@link #RELEASE} operation.
      */
-    ACQUIRE,
+    ACQUIRE(SingleAcquire),
     /**
      * Like {@link #MONOTONIC} but also forms a synchronization edge with a corresponding {@link #ACQUIRE} operation.
      */
-    RELEASE,
+    RELEASE(SingleRelease),
     /**
      * Acts as both {@link #ACQUIRE} and {@link #RELEASE} on one operation.
      */
-    ACQUIRE_RELEASE,
+    ACQUIRE_RELEASE(SingleAcqRel),
     /**
      * Like {@link #ACQUIRE_RELEASE} but applying a global total order.
      */
-    SEQUENTIALLY_CONSISTENT,
+    SEQUENTIALLY_CONSISTENT(SingleSeqCst),
     /**
      * Java {@code VOLATILE} access.
      */
-    VOLATILE
-    ;
+    VOLATILE(GlobalSeqCst);
+
+    private final AccessMode accessMode;
+
+    MemoryAtomicityMode(AccessMode accessMode) {
+        this.accessMode = accessMode;
+    }
 
     public static MemoryAtomicityMode max(MemoryAtomicityMode a, MemoryAtomicityMode b) {
         return a.ordinal() > b.ordinal() ? a : b;
@@ -45,6 +58,15 @@ public enum MemoryAtomicityMode {
 
     public static MemoryAtomicityMode min(MemoryAtomicityMode a, MemoryAtomicityMode b) {
         return a.ordinal() < b.ordinal() ? a : b;
+    }
+
+    /**
+     * Get the closest corresponding access mode, which may have to be transformed further before use.
+     *
+     * @return the access mode (not {@code null})
+     */
+    public AccessMode getAccessMode() {
+        return  accessMode;
     }
 
     /**

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -849,7 +849,7 @@ public interface Node {
 
             public Node visit(final Copier param, final Store node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().store(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getValue()), node.getMode());
+                return param.getBlockBuilder().store(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getValue()), node.getAccessMode());
             }
 
             public Value visit(final Copier param, final StringLiteral node) {

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -522,7 +522,7 @@ public interface Node {
             public Value visit(final Copier param, final CmpAndSwap node) {
                 param.copyNode(node.getDependency());
                 return param.getBlockBuilder().cmpAndSwap(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getExpectedValue()),
-                    param.copyValue(node.getUpdateValue()), node.getSuccessAtomicityMode(), node.getFailureAtomicityMode(), node.getStrength());
+                    param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode(), node.getStrength());
             }
 
             public Value visit(Copier param, CmpG node) {

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -351,7 +351,7 @@ public interface Node {
 
             public Node visit(Copier param, Fence node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().fence(node.getAtomicityMode());
+                return param.getBlockBuilder().fence(node.getAccessMode());
             }
 
             public BasicBlock visit(Copier param, CallNoReturn node) {

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -608,47 +608,47 @@ public interface Node {
 
             public Value visit(final Copier param, final GetAndAdd node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndAdd(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndAdd(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndBitwiseAnd node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndBitwiseAnd(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndBitwiseAnd(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndBitwiseNand node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndBitwiseNand(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndBitwiseNand(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndBitwiseOr node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndBitwiseOr(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndBitwiseOr(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndBitwiseXor node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndBitwiseXor(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndBitwiseXor(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndSet node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndSet(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndSet(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndSetMax node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndSetMax(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndSetMax(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndSetMin node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndSetMin(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndSetMin(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final GetAndSub node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().getAndSub(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getAtomicityMode());
+                return param.getBlockBuilder().getAndSub(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getUpdateValue()), node.getReadAccessMode(), node.getWriteAccessMode());
             }
 
             public Value visit(final Copier param, final InsertElement node) {

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -710,7 +710,7 @@ public interface Node {
 
             public Value visit(final Copier param, final Load node) {
                 param.copyNode(node.getDependency());
-                return param.getBlockBuilder().load(param.copyValueHandle(node.getValueHandle()), node.getMode());
+                return param.getBlockBuilder().load(param.copyValueHandle(node.getValueHandle()), node.getAccessMode());
             }
 
             public ValueHandle visit(Copier param, LocalVariable node) {

--- a/compiler/src/main/java/org/qbicc/graph/ReadModifyWriteValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/ReadModifyWriteValue.java
@@ -1,10 +1,17 @@
 package org.qbicc.graph;
 
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+
 /**
  *
  */
 public interface ReadModifyWriteValue extends Value {
     Value getUpdateValue();
+
+    ReadAccessMode getReadAccessMode();
+
+    WriteAccessMode getWriteAccessMode();
 
     MemoryAtomicityMode getAtomicityMode();
 }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.context.Location;
 import org.qbicc.graph.atomic.GlobalAccessMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.TypeLiteral;
@@ -601,7 +602,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new Clone(callSite, element, line, bci, requireDependency(), object));
     }
 
-    public Value load(final ValueHandle handle, final MemoryAtomicityMode mode) {
+    public Value load(final ValueHandle handle, final ReadAccessMode mode) {
         return asDependency(new Load(callSite, element, line, bci, requireDependency(), handle, mode));
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -607,40 +607,40 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new Load(callSite, element, line, bci, requireDependency(), handle, mode));
     }
 
-    public Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndAdd(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndAdd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndAdd(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndBitwiseAnd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndBitwiseAnd(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndBitwiseAnd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndBitwiseAnd(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndBitwiseNand(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndBitwiseNand(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndBitwiseNand(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndBitwiseNand(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndBitwiseOr(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndBitwiseOr(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndBitwiseOr(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndBitwiseOr(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndBitwiseXor(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndBitwiseXor(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndBitwiseXor(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndBitwiseXor(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndSet(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndSet(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndSet(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndSet(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndSetMax(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndSetMax(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndSetMax(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndSetMax(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndSetMin(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndSetMin(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndSetMin(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndSetMin(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
-    public Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        return asDependency(new GetAndSub(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
+    public Value getAndSub(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        return asDependency(new GetAndSub(callSite, element, line, bci, requireDependency(), target, update, readMode, writeMode));
     }
 
     public Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -648,7 +648,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new CmpAndSwap(callSite, element, line, bci, CmpAndSwap.getResultType(ctxt, target.getValueType()), requireDependency(), target, expect, update, readMode, writeMode, strength));
     }
 
-    public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+    public Node store(ValueHandle handle, Value value, WriteAccessMode mode) {
         return asDependency(new Store(callSite, element, line, bci, requireDependency(), handle, value, mode));
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -12,6 +12,7 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.context.Location;
 import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.TypeLiteral;
@@ -642,9 +643,9 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new GetAndSub(callSite, element, line, bci, requireDependency(), target, update, atomicityMode));
     }
 
-    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, MemoryAtomicityMode successMode, MemoryAtomicityMode failureMode, CmpAndSwap.Strength strength) {
+    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength) {
         CompilationContext ctxt = getCurrentElement().getEnclosingType().getContext().getCompilationContext();
-        return asDependency(new CmpAndSwap(callSite, element, line, bci, CmpAndSwap.getResultType(ctxt, target.getValueType()), requireDependency(), target, expect, update, successMode, failureMode, strength));
+        return asDependency(new CmpAndSwap(callSite, element, line, bci, CmpAndSwap.getResultType(ctxt, target.getValueType()), requireDependency(), target, expect, update, readMode, writeMode, strength));
     }
 
     public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.qbicc.context.CompilationContext;
 import org.qbicc.context.Location;
+import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.TypeLiteral;
@@ -653,7 +654,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new InitCheck(callSite, element, line, bci, requireDependency(), initializer));
     }
 
-    public Node fence(final MemoryAtomicityMode fenceType) {
+    public Node fence(final GlobalAccessMode fenceType) {
         return asDependency(new Fence(callSite, element, line, bci, requireDependency(), fenceType));
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/Store.java
+++ b/compiler/src/main/java/org/qbicc/graph/Store.java
@@ -2,6 +2,7 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
@@ -11,9 +12,9 @@ public class Store extends AbstractNode implements Action, OrderedNode {
     private final Node dependency;
     private final ValueHandle handle;
     private final Value value;
-    private final MemoryAtomicityMode mode;
+    private final WriteAccessMode mode;
 
-    Store(Node callSite, ExecutableElement element, int line, int bci, Node dependency, ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+    Store(Node callSite, ExecutableElement element, int line, int bci, Node dependency, ValueHandle handle, Value value, WriteAccessMode mode) {
         super(callSite, element, line, bci);
         this.dependency = dependency;
         this.handle = handle;
@@ -33,7 +34,7 @@ public class Store extends AbstractNode implements Action, OrderedNode {
         return value;
     }
 
-    public MemoryAtomicityMode getMode() {
+    public WriteAccessMode getAccessMode() {
         return mode;
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/atomic/AccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/AccessMode.java
@@ -1,0 +1,91 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * A memory access mode. Not all access modes are valid for all operations; this is enforced by type. Unless an
+ * access mode is global, it is only guaranteed to apply to memory directly given in the operation.
+ * <p>
+ * These interfaces exist for type safety and are not arbitrarily implementable.
+ *
+ * @see AccessModes
+ */
+public sealed interface AccessMode permits GlobalAccessMode, PureModes, ReadAccessMode, WriteAccessMode {
+
+    /**
+     * Determine whether this mode completely includes the given mode.
+     *
+     * @param other the mode that may be included (must not be {@code null})
+     * @return {@code true} if the other mode is fully included in this mode, or {@code false} otherwise
+     */
+    default boolean includes(AccessMode other) {
+        int myBits = ((AtomicTraits) this).getBits();
+        int theirBits = ((AtomicTraits) other).getBits();
+        return (myBits | theirBits) == myBits;
+    }
+
+    /**
+     * Determine whether this mode overlaps with the given mode.
+     *
+     * @param other the mode that may overlap (must not be {@code null})
+     * @return {@code true} if the other mode overlaps in any way with this mode, or {@code false} otherwise
+     */
+    default boolean overlapsWith(AccessMode other) {
+        int myBits = ((AtomicTraits) this).getBits();
+        int theirBits = ((AtomicTraits) other).getBits();
+        return (myBits & theirBits) != 0;
+    }
+
+    /**
+     * Determine whether this mode provides atomicity at the value level.  Non-atomic operations may allow safe misaligned
+     * access on some CPU architectures.
+     *
+     * @return {@code true} if the mode provides atomicity, or {@code false} otherwise
+     */
+    default boolean isAtomic() {
+        return (((AtomicTraits) this).getBits() & AtomicTraits.SINGLE_ATOMIC) != 0;
+    }
+
+    /**
+     * Get the weakest access mode that is equal to or stronger than both this access mode and the given access mode.
+     * The returned mode is not guaranteed to be usable in any particular context without being transformed by
+     * one of {@link #getReadAccess()}, {@link #getWriteAccess()}, and/or {@link #getGlobalAccess()}.
+     *
+     * @param other the other access mode (must not be {@code null})
+     * @return the combined access mode (not {@code null})
+     */
+    default AccessMode combinedWith(AccessMode other) {
+        int myBits = ((AtomicTraits) this).getBits();
+        int theirBits = ((AtomicTraits) other).getBits();
+        return AtomicTraits.fromBits(myBits | theirBits);
+    }
+
+    /**
+     * Get the weakest access mode that is equal to or stronger than both this access mode and the given access mode.
+     *
+     * @param other the other access mode (must not be {@code null})
+     * @return the combined access mode (not {@code null})
+     */
+    default GlobalAccessMode combinedWith(GlobalAccessMode other) {
+        return (GlobalAccessMode) combinedWith((AccessMode) other);
+    }
+
+    /**
+     * Get the mode which is equal to or stronger than this mode which can be used in read operations.
+     *
+     * @return the read access mode (not {@code null})
+     */
+    ReadAccessMode getReadAccess();
+
+    /**
+     * Get the mode which is equal to or stronger than this mode which can be used in write operations.
+     *
+     * @return the write access mode (not {@code null})
+     */
+    WriteAccessMode getWriteAccess();
+
+    /**
+     * Get the mode which is equal to or stronger than this mode which can be used in global memory operations.
+     *
+     * @return the global access mode (not {@code null})
+     */
+    GlobalAccessMode getGlobalAccess();
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/AccessModes.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/AccessModes.java
@@ -1,0 +1,213 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * The set of allowed access modes for various operations.
+ * <p>
+ * <h2>Access Mode Categories</h2>
+ * <p>
+ * Access modes each fall into zero or more of the following categories:
+ * <ul>
+ *     <li><em>Global access modes</em> which implement {@link GlobalAccessMode} or one of its subtypes and may be applied to fence operations</li>
+ *     <li><em>Read access modes</em>, which implement {@link ReadAccessMode} or one of its subtypes and may be applied to read operations</li>
+ *     <li><em>Write access modes</em>, which implement {@link WriteAccessMode} or one of its subtypes and may be applied to write operations</li>
+ * </ul>
+ * For any given access mode, it is possible to acquire the equivalent-or-stronger {@linkplain AccessMode#getGlobalAccess() global access mode},
+ * the equivalent-or-stronger {@linkplain AccessMode#getReadAccess() read access mode}, and the equivalent-or-stronger
+ * {@linkplain AccessMode#getWriteAccess() write access mode}.  The return type of these methods preserve the categorization of the original access mode,
+ * so for example, given a read access mode, the corresponding global access mode will also be a valid read access mode.
+ * Access modes which do not fall into any of the three basic categories may still be used to derive other usable access modes.
+ * <p>
+ * Access modes which are not global (i.e. do not implement the {@link GlobalAccessMode} interface) are considered "single".
+ * These modes are only guaranteed to affect a single location in memory (some CPUs may strengthen this guarantee to
+ * apply to some local memory <em>area</em> or <em>domain</em>).
+ * <p>
+ * <h2>Global Access Modes</h2>
+ * <p>
+ * The set of global access modes is based on definitions given {@linkplain java.lang.invoke.VarHandle in the JDK specification}
+ * as well as <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-17.html#jls-17.4">in the JLS</a>, with additional
+ * references to background material such as <a href="http://gee.cs.oswego.edu/dl/html/j9mm.html">Using JDK 9 Memory Order Modes</a>
+ * by Doug Lea and <a href="https://shipilev.net/blog/2014/jmm-pragmatics/">Java Memory Model Pragmatics</a> by Aleksey Shipilëv.
+ * <p>
+ * Most of the possible global access modes are compositions of these four fundamental modes:
+ * <ul>
+ *     <li>{@link #GlobalLoadLoad}</li>
+ *     <li>{@link #GlobalStoreLoad}</li>
+ *     <li>{@link #GlobalLoadStore}</li>
+ *     <li>{@link #GlobalStoreStore}</li>
+ * </ul>
+ * These modes are only usable in fence operations, but since they are included in all other global access modes, they can
+ * be strengthened to read or write operations using the {@link AccessMode#getReadAccess()} and {@link AccessMode#getWriteAccess()}
+ * methods.
+ * <p>
+ * The following table illustrates which of the fundamental global access modes are included in which composed global
+ * access modes:
+ * <table class="striped">
+ * <tr><th rowspan=2 align=center>Derived Access Mode</th><th colspan=4 align=center>Fundamental Access Mode</th></tr>
+ * <tr><th>{@link #GlobalStoreStore}</th><th>{@link #GlobalLoadStore}</th><th>{@link #GlobalLoadLoad}</th><th>{@link #GlobalStoreLoad}</th></tr>
+ * <tr><td align=center>{@link #GlobalAcquire}</td><td align=center></td><td align=center>●</td><td align=center>●</td><td align=center></td>
+ * <tr><td align=center>{@link #GlobalRelease}</td><td align=center>●</td><td align=center>●</td><td align=center></td><td align=center></td>
+ * <tr><td align=center>{@link #GlobalAcqRel}</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center></td>
+ * <tr><td align=center>{@link #GlobalSeqCst}</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td>
+ * </table>
+ * <p>
+ * Consequently, each fundamental barrier type can be strengthened to any of the modes which include that type.
+ * <p>
+ * The remaining global access modes — {@link #GlobalUnshared} and {@link #GlobalPlain} — are exactly equivalent to the
+ * correspondingly-named single access modes, and exist to prevent useless fences from being emitted when the corresponding
+ * single access mode is strengthened to a global access mode.
+ * <p>
+ * <h2>Single Access Modes</h2>
+ * <p>
+ * Single access modes only affect the memory directly associated with the operation that utilizes that mode, rather than
+ * applying to all program memory operations as global access modes do.  As such, they are not composed of fundamental barrier
+ * types like the global modes are, since those types are predicated on global ordering.
+ * <p>
+ * Instead, the single access types generally compose sequentially with only one exception. The following table illustrates
+ * how each mode generally includes the next-weaker mode:
+ * <p>
+ * <table class="striped">
+ * <tr><th rowspan=2 align=center>Access Mode</th><th colspan=7 align=center>Included Access Modes</th></tr>
+ * <tr><th>{@link #SingleUnshared}</th><th>{@link #SinglePlain}</th><th>{@link #SingleOpaque}</th><th>{@link #SingleAcquire}</th><th>{@link #SingleRelease}</th><th>{@link #SingleAcqRel}</th><th>{@link #SingleSeqCst}</th></tr>
+ * <tr><td align=center>{@link #SingleUnshared}</td><td align=center>●</td><td align=center></td><td align=center></td><td align=center></td><td align=center></td><td align=center></td><td align=center></td>
+ * <tr><td align=center>{@link #SinglePlain}</td><td align=center>●</td><td align=center>●</td><td align=center></td><td align=center></td><td align=center></td><td align=center></td><td align=center></td>
+ * <tr><td align=center>{@link #SingleOpaque}</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center></td><td align=center></td><td align=center></td><td align=center></td>
+ * <tr><td align=center>{@link #SingleAcquire}</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center></td><td align=center></td><td align=center></td>
+ * <tr><td align=center>{@link #SingleRelease}</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center></td><td align=center>●</td><td align=center></td><td align=center></td>
+ * <tr><td align=center>{@link #SingleAcqRel}</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center></td>
+ * <tr><td align=center>{@link #SingleSeqCst}</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td><td align=center>●</td>
+ * </table>
+ * <p>
+ * Apart from {@link #SingleAcquire} and {@link #SingleRelease} — which do not include one another — every mode includes
+ * all of the preceding modes.
+ * <p>
+ * Additionally, every single-access mode can be strengthened into a corresponding global access mode which includes at
+ * least the behavior of the single-access mode when applied to the same memory operation.
+ * <p>
+ * <table class="striped">
+ * <tr><th align=center>Single Access Mode</th><th align=center>Global Access mode</th></tr>
+ * <tr><td align=center>{@link #SingleUnshared}</td><td align=center>{@link #GlobalUnshared}</td>
+ * <tr><td align=center>{@link #SinglePlain}</td><td align=center>{@link #GlobalPlain}</td>
+ * <tr><td align=center>{@link #SingleOpaque}</td><td align=center>{@link #GlobalSeqCst}</td>
+ * <tr><td align=center>{@link #SingleAcquire}</td><td align=center>{@link #GlobalAcquire}</td>
+ * <tr><td align=center>{@link #SingleRelease}</td><td align=center>{@link #GlobalRelease}</td>
+ * <tr><td align=center>{@link #SingleAcqRel}</td><td align=center>{@link #GlobalAcqRel}</td>
+ * <tr><td align=center>{@link #SingleSeqCst}</td><td align=center>{@link #GlobalSeqCst}</td>
+ * </table>
+ * <p>
+ */
+public final class AccessModes {
+    private AccessModes() {}
+
+    /**
+     * The <em>global unshared</em> access mode.  This mode is exactly equivalent to {@link #SingleUnshared}, and
+     * does nothing when used as a fence argument.
+     */
+    public static final GlobalReadWriteAccessMode GlobalUnshared = FullFences.GlobalUnshared;
+    /**
+     * The <em>global plain</em> access mode.  This mode is exactly equivalent to {@link #SinglePlain}, and
+     * does nothing when used as a fence argument.
+     */
+    public static final GlobalReadWriteAccessMode GlobalPlain = FullFences.GlobalPlain;
+
+    /**
+     * The <em>load-load</em> global access mode.  When used as a fence, this mode
+     * prevents any loads which precede the fence from being moved after the fence, and
+     * prevents global loads which succeed the fence from being moved before the fence, as follows:
+     * <p>
+     * {@code AnyLoad ≺ GlobalLoadLoad ≺ AnyGlobalLoad}
+     */
+    public static final GlobalAccessMode GlobalLoadLoad = PureFences.GlobalLoadLoad;
+    /**
+     * The <em>store-load</em> global access mode.  When used as a fence, this mode
+     * prevents global stores which precede the fence from being moved after the fence, and
+     * prevents global loads which succeed the fence from being moved before the fence, as follows:
+     * <p>
+     * {@code AnyGlobalStore ≺ GlobalStoreLoad < AnyGlobalLoad}
+     */
+    public static final GlobalAccessMode GlobalStoreLoad = PureFences.GlobalStoreLoad;
+    /**
+     * The <em>load-store</em> global access mode.  When used as a fence, this mode
+     * prevents any loads which precede the fence from being moved after the fence, and
+     * prevents global stores which succeed the fence from being moved before the fence, as follows:
+     * <p>
+     * {@code AnyLoad ≺ GlobalLoadStore < AnyGlobalStore}
+     */
+    public static final GlobalAccessMode GlobalLoadStore = PureFences.GlobalLoadStore;
+    /**
+     * The <em>store-store</em> global access mode.  When used as a fence, this mode
+     * prevents any stores which precede the fence from being moved after the fence, and
+     * prevents any global stores which succeed the fence from being moved before the fence, as follows:
+     * <p>
+     * {@code AnyStore ≺ GlobalStoreStore < AnyGlobalStore}
+     */
+    public static final GlobalAccessMode GlobalStoreStore = PureFences.GlobalStoreStore;
+
+    /**
+     * The <em>acquire</em> global access mode.  This mode includes {@link #GlobalLoadLoad} and {@link #GlobalLoadStore} and
+     * may be used with read and fence operations.
+     */
+    public static final GlobalReadAccessMode GlobalAcquire = ReadFences.GlobalAcquire;
+    /**
+     * The <em>release</em> global access mode.  This mode includes {@link #GlobalStoreStore} and {@link #GlobalLoadStore} and
+     * may be used with write and fence operations.
+     */
+    public static final GlobalWriteAccessMode GlobalRelease = WriteFences.GlobalRelease;
+    /**
+     * The <em>acquire-release</em> global access mode.  This mode includes both {@link #GlobalAcquire} and {@link #GlobalRelease}
+     * and may be used only with fence operations.
+     */
+    public static final GlobalAccessMode GlobalAcqRel = PureFences.GlobalAcqRel;
+    /**
+     * The <em>sequentially-consistent</em> global access mode, also known as {@code volatile}.
+     * This mode includes both {@link #GlobalAcqRel} and {@link #GlobalStoreLoad}
+     * and may be used with read, write, and fence operations.
+     */
+    public static final GlobalReadWriteAccessMode GlobalSeqCst = FullFences.GlobalSeqCst;
+
+    /**
+     * The <em>unshared</em> single access mode.  This is a non-atomic mode which provides no guarantees against
+     * tearing or invalid values when not protected with an appropriate synchronization structure.
+     * This mode may be used for read and write operations.
+     */
+    public static final ReadWriteAccessMode SingleUnshared = ReadWriteModes.SingleUnshared;
+    /**
+     * The <em>plain</em> single access mode, also known as <em>unordered</em>.  This is a mode which only guarantees
+     * that the value will not be invalid in the presence of data races.
+     * This mode may be used for read and write operations.
+     */
+    public static final ReadWriteAccessMode SinglePlain = ReadWriteModes.SinglePlain;
+    /**
+     * The <em>opaque</em> single access mode, also known as <em>relaxed</em> or <em>monotonic</em>.
+     * This is a mode has all of the guarantees of {@link #SinglePlain} but also enforces a single total order
+     * for all operations on a given memory address.
+     * This mode may be used for read and write operations.
+     */
+    public static final ReadWriteAccessMode SingleOpaque = ReadWriteModes.SingleOpaque;
+    /**
+     * The <em>acquire</em> single access mode.
+     * This is a mode has all of the guarantees of {@link #SingleOpaque} but also <em>synchronizes-with</em>
+     * any <em>release</em> operation on the same memory address.
+     * This mode may only be used for read operations.
+     */
+    public static final ReadAccessMode SingleAcquire = ReadModes.SingleAcquire;
+    /**
+     * The <em>release</em> single access mode.
+     * This is a mode has all of the guarantees of {@link #SingleOpaque} but also <em>synchronizes-with</em>
+     * any <em>acquire</em> operation on the same memory address.
+     * This mode may only be used for write operations.
+     */
+    public static final WriteAccessMode SingleRelease = WriteModes.SingleRelease;
+    /**
+     * The <em>acquire-release</em> single access mode.
+     * This mode combines {@link #SingleAcquire} with {@link #SingleRelease}.  It is not usable by itself
+     * but is useful for compatibility with the previous scheme.
+     */
+    public static final AccessMode SingleAcqRel = PureModes.SingleAcqRel;
+    /**
+     * The <em>sequentially-consistent</em> single access mode.
+     * This is a mode has all of the guarantees of {@link #SingleAcquire} and {@link #SingleRelease}
+     * but also guarantees a global total order on all of the memory affected by this operation.
+     * This mode may be used for read and write operations.
+     */
+    public static final ReadWriteAccessMode SingleSeqCst = ReadWriteModes.SingleSeqCst;
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/AtomicTraits.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/AtomicTraits.java
@@ -1,0 +1,74 @@
+package org.qbicc.graph.atomic;
+
+import static org.qbicc.graph.atomic.AccessModes.*;
+
+/**
+ * A set of bits used to represent the set of capabilities that an atomic operation may have, in order to determine which
+ * operations include which other operations.
+ */
+sealed interface AtomicTraits permits FullFences, PureFences, PureModes, ReadFences, ReadModes, ReadWriteModes, WriteFences, WriteModes {
+    int getBits();
+
+    int SINGLE_ATOMIC = 1 << 0;
+    int SINGLE_OPAQUE = SINGLE_ATOMIC | 1 << 1;
+    int SINGLE_ACQUIRE = SINGLE_OPAQUE | 1 << 2;
+    int SINGLE_RELEASE = SINGLE_OPAQUE | 1 << 3;
+    int SINGLE_ACQ_REL = SINGLE_ACQUIRE | SINGLE_RELEASE;
+    int SINGLE_SEQ_CST = SINGLE_ACQ_REL | 1 << 4;
+
+    int GLOBAL = 1 << 5;
+    int GLOBAL_ATOMIC = GLOBAL | SINGLE_ATOMIC;
+    int GLOBAL_LOAD_LOAD = GLOBAL | 1 << 6;
+    int GLOBAL_LOAD_STORE = GLOBAL | 1 << 7;
+    int GLOBAL_STORE_STORE = GLOBAL | 1 << 8;
+    int GLOBAL_STORE_LOAD = GLOBAL | 1 << 9;
+    int GLOBAL_ACQUIRE = GLOBAL_LOAD_LOAD | GLOBAL_LOAD_STORE | SINGLE_ACQUIRE;
+    int GLOBAL_RELEASE = GLOBAL_STORE_STORE | GLOBAL_LOAD_STORE | SINGLE_RELEASE;
+    int GLOBAL_ACQ_REL = GLOBAL_ACQUIRE | GLOBAL_RELEASE;
+    int GLOBAL_SEQ_CST = GLOBAL_ACQ_REL | GLOBAL_STORE_LOAD | SINGLE_SEQ_CST;
+
+    static boolean matches(int bits, int test) {
+        return (bits & test) == bits;
+    }
+
+    static AccessMode fromBits(int bits) {
+        // find the most minimal mode which matches all of the given bits
+        if (matches(bits, 0)) {
+            return SingleUnshared;
+        } else if (matches(bits, SINGLE_ATOMIC)) {
+            return SinglePlain;
+        } else if (matches(bits, SINGLE_OPAQUE)) {
+            return SingleOpaque;
+        } else if (matches(bits, SINGLE_ACQUIRE)) {
+            return SingleAcquire;
+        } else if (matches(bits, SINGLE_RELEASE)) {
+            return SingleRelease;
+        } else if (matches(bits, SINGLE_ACQ_REL)) {
+            return SingleAcqRel;
+        } else if (matches(bits, SINGLE_SEQ_CST)) {
+            return SingleSeqCst;
+        } else if (matches(bits, GLOBAL)) {
+            return GlobalUnshared;
+        } else if (matches(bits, GLOBAL_ATOMIC)) {
+            return GlobalPlain;
+        } else if (matches(bits, GLOBAL_LOAD_LOAD)) {
+            return GlobalLoadLoad;
+        } else if (matches(bits, GLOBAL_LOAD_STORE)) {
+            return GlobalLoadStore;
+        } else if (matches(bits, GLOBAL_STORE_STORE)) {
+            return GlobalStoreStore;
+        } else if (matches(bits, GLOBAL_STORE_LOAD)) {
+            return GlobalStoreLoad;
+        } else if (matches(bits, GLOBAL_ACQUIRE)) {
+            return GlobalAcquire;
+        } else if (matches(bits, GLOBAL_RELEASE)) {
+            return GlobalRelease;
+        } else if (matches(bits, GLOBAL_ACQ_REL)) {
+            return GlobalAcqRel;
+        } else if (matches(bits, GLOBAL_SEQ_CST)) {
+            return GlobalSeqCst;
+        } else {
+            throw new IllegalArgumentException("Invalid access mode");
+        }
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/FullFences.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/FullFences.java
@@ -1,0 +1,18 @@
+package org.qbicc.graph.atomic;
+
+enum FullFences implements GlobalReadWriteAccessMode, AtomicTraits {
+    GlobalUnshared(GLOBAL),
+    GlobalPlain(GLOBAL_ATOMIC),
+    GlobalSeqCst(GLOBAL_SEQ_CST);
+
+    private final int bits;
+
+    FullFences(int bits) {
+        this.bits = bits;
+    }
+
+    @Override
+    public int getBits() {
+        return bits;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/GlobalAccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/GlobalAccessMode.java
@@ -1,0 +1,16 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * An access mode that applies to all of memory.  Only global access modes may be used in a general fence instruction.
+ */
+public sealed interface GlobalAccessMode extends AccessMode permits GlobalReadAccessMode, GlobalWriteAccessMode, PureFences {
+    @Override
+    default GlobalAccessMode combinedWith(AccessMode other) {
+        return (GlobalAccessMode) AccessMode.super.combinedWith(other);
+    }
+
+    @Override
+    default GlobalAccessMode getGlobalAccess() {
+        return this;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/GlobalReadAccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/GlobalReadAccessMode.java
@@ -1,0 +1,19 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * An access mode that is valid for both read and global operations.
+ */
+public sealed interface GlobalReadAccessMode extends GlobalAccessMode, ReadAccessMode permits GlobalReadWriteAccessMode, ReadFences {
+    @Override
+    default GlobalReadAccessMode getReadAccess() {
+        return this;
+    }
+
+    @Override
+    GlobalReadWriteAccessMode getWriteAccess();
+
+    @Override
+    default GlobalReadAccessMode getGlobalAccess() {
+        return this;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/GlobalReadWriteAccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/GlobalReadWriteAccessMode.java
@@ -1,0 +1,21 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * An access mode that is valid for read, write, and global operations.
+ */
+public sealed interface GlobalReadWriteAccessMode extends ReadWriteAccessMode, GlobalReadAccessMode, GlobalWriteAccessMode permits FullFences {
+    @Override
+    default GlobalReadWriteAccessMode getGlobalAccess() {
+        return this;
+    }
+
+    @Override
+    default GlobalReadWriteAccessMode getReadAccess() {
+        return this;
+    }
+
+    @Override
+    default GlobalReadWriteAccessMode getWriteAccess() {
+        return this;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/GlobalWriteAccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/GlobalWriteAccessMode.java
@@ -1,0 +1,19 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * An access mode that is valid for both write and global operations.
+ */
+public sealed interface GlobalWriteAccessMode extends GlobalAccessMode, WriteAccessMode permits GlobalReadWriteAccessMode, WriteFences {
+    @Override
+    GlobalReadWriteAccessMode getReadAccess();
+
+    @Override
+    default GlobalWriteAccessMode getWriteAccess() {
+        return this;
+    }
+
+    @Override
+    default GlobalWriteAccessMode getGlobalAccess() {
+        return this;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/PureFences.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/PureFences.java
@@ -1,0 +1,52 @@
+package org.qbicc.graph.atomic;
+
+enum PureFences implements GlobalAccessMode, AtomicTraits {
+    GlobalLoadLoad(GLOBAL_LOAD_LOAD) {
+        @Override
+        public ReadAccessMode getReadAccess() {
+            return ReadFences.GlobalAcquire;
+        }
+    },
+    GlobalLoadStore(GLOBAL_LOAD_STORE) {
+        @Override
+        public ReadAccessMode getReadAccess() {
+            return ReadFences.GlobalAcquire;
+        }
+
+        @Override
+        public WriteAccessMode getWriteAccess() {
+            return WriteFences.GlobalRelease;
+        }
+    },
+    GlobalStoreStore(GLOBAL_STORE_STORE) {
+        @Override
+        public WriteAccessMode getWriteAccess() {
+            return WriteFences.GlobalRelease;
+        }
+    },
+    GlobalStoreLoad(GLOBAL_STORE_LOAD),
+
+    GlobalAcqRel(GLOBAL_ACQ_REL),
+    ;
+
+    private final int bits;
+
+    PureFences(int bits) {
+        this.bits = bits;
+    }
+
+    @Override
+    public ReadAccessMode getReadAccess() {
+        return FullFences.GlobalSeqCst;
+    }
+
+    @Override
+    public WriteAccessMode getWriteAccess() {
+        return FullFences.GlobalSeqCst;
+    }
+
+    @Override
+    public int getBits() {
+        return bits;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/PureModes.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/PureModes.java
@@ -1,0 +1,29 @@
+package org.qbicc.graph.atomic;
+
+/**
+ *
+ */
+enum PureModes implements AccessMode, AtomicTraits {
+    SingleAcqRel,
+    ;
+
+    @Override
+    public ReadAccessMode getReadAccess() {
+        return ReadWriteModes.SingleSeqCst;
+    }
+
+    @Override
+    public WriteAccessMode getWriteAccess() {
+        return ReadWriteModes.SingleSeqCst;
+    }
+
+    @Override
+    public GlobalAccessMode getGlobalAccess() {
+        return PureFences.GlobalAcqRel;
+    }
+
+    @Override
+    public int getBits() {
+        return SINGLE_ACQ_REL;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/ReadAccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/ReadAccessMode.java
@@ -1,0 +1,17 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * An access mode that is valid for read operations.
+ */
+public sealed interface ReadAccessMode extends AccessMode permits GlobalReadAccessMode, ReadModes, ReadWriteAccessMode {
+    @Override
+    default ReadAccessMode getReadAccess() {
+        return this;
+    }
+
+    @Override
+    ReadWriteAccessMode getWriteAccess();
+
+    @Override
+    GlobalReadAccessMode getGlobalAccess();
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/ReadFences.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/ReadFences.java
@@ -1,0 +1,16 @@
+package org.qbicc.graph.atomic;
+
+enum ReadFences implements GlobalReadAccessMode, AtomicTraits {
+    GlobalAcquire,
+    ;
+
+    @Override
+    public GlobalReadWriteAccessMode getWriteAccess() {
+        return FullFences.GlobalSeqCst;
+    }
+
+    @Override
+    public int getBits() {
+        return GLOBAL_ACQUIRE;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/ReadModes.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/ReadModes.java
@@ -1,0 +1,21 @@
+package org.qbicc.graph.atomic;
+
+enum ReadModes implements ReadAccessMode, AtomicTraits {
+    SingleAcquire,
+    ;
+
+    @Override
+    public ReadWriteAccessMode getWriteAccess() {
+        return ReadWriteModes.SingleSeqCst;
+    }
+
+    @Override
+    public GlobalReadAccessMode getGlobalAccess() {
+        return ReadFences.GlobalAcquire;
+    }
+
+    @Override
+    public int getBits() {
+        return SINGLE_ACQUIRE;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/ReadWriteAccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/ReadWriteAccessMode.java
@@ -1,0 +1,19 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * An access mode that is valid for both read and write operations.
+ */
+public sealed interface ReadWriteAccessMode extends ReadAccessMode, WriteAccessMode permits GlobalReadWriteAccessMode, ReadWriteModes {
+    @Override
+    GlobalReadWriteAccessMode getGlobalAccess();
+
+    @Override
+    default ReadWriteAccessMode getWriteAccess() {
+        return this;
+    }
+
+    @Override
+    default ReadWriteAccessMode getReadAccess() {
+        return this;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/ReadWriteModes.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/ReadWriteModes.java
@@ -1,0 +1,35 @@
+package org.qbicc.graph.atomic;
+
+enum ReadWriteModes implements ReadWriteAccessMode, AtomicTraits {
+    SingleUnshared(0) {
+        @Override
+        public GlobalReadWriteAccessMode getGlobalAccess() {
+            return FullFences.GlobalUnshared;
+        }
+    },
+    SinglePlain(SINGLE_ATOMIC) {
+        @Override
+        public GlobalReadWriteAccessMode getGlobalAccess() {
+            return FullFences.GlobalPlain;
+        }
+    },
+    SingleOpaque(SINGLE_OPAQUE),
+    SingleSeqCst(SINGLE_SEQ_CST),
+    ;
+
+    private final int bits;
+
+    ReadWriteModes(int bits) {
+        this.bits = bits;
+    }
+
+    @Override
+    public GlobalReadWriteAccessMode getGlobalAccess() {
+        return FullFences.GlobalSeqCst;
+    }
+
+    @Override
+    public int getBits() {
+        return bits;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/WriteAccessMode.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/WriteAccessMode.java
@@ -1,0 +1,17 @@
+package org.qbicc.graph.atomic;
+
+/**
+ * An access mode that is valid for write operations.
+ */
+public sealed interface WriteAccessMode extends AccessMode permits GlobalWriteAccessMode, ReadWriteAccessMode, WriteModes {
+    @Override
+    ReadWriteAccessMode getReadAccess();
+
+    @Override
+    default WriteAccessMode getWriteAccess() {
+        return this;
+    }
+
+    @Override
+    GlobalWriteAccessMode getGlobalAccess();
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/WriteFences.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/WriteFences.java
@@ -1,0 +1,19 @@
+package org.qbicc.graph.atomic;
+
+/**
+ *
+ */
+enum WriteFences implements GlobalWriteAccessMode, AtomicTraits {
+    GlobalRelease,
+    ;
+
+    @Override
+    public GlobalReadWriteAccessMode getReadAccess() {
+        return FullFences.GlobalSeqCst;
+    }
+
+    @Override
+    public int getBits() {
+        return GLOBAL_RELEASE;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/atomic/WriteModes.java
+++ b/compiler/src/main/java/org/qbicc/graph/atomic/WriteModes.java
@@ -1,0 +1,21 @@
+package org.qbicc.graph.atomic;
+
+enum WriteModes implements WriteAccessMode, AtomicTraits {
+    SingleRelease,
+    ;
+
+    @Override
+    public GlobalWriteAccessMode getGlobalAccess() {
+        return WriteFences.GlobalRelease;
+    }
+
+    @Override
+    public ReadWriteAccessMode getReadAccess() {
+        return ReadWriteModes.SingleSeqCst;
+    }
+
+    @Override
+    public int getBits() {
+        return SINGLE_RELEASE;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -2,29 +2,70 @@ package org.qbicc.interpreter;
 
 
 import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.type.ValueType;
 
 /**
  * A base for a relatively-indexed piece of memory.
  */
 public interface Memory {
-    int load8(int index, MemoryAtomicityMode mode);
+    @Deprecated
+    default int load8(int index, MemoryAtomicityMode mode) {
+        return load8(index, mode.getAccessMode().getReadAccess());
+    }
 
-    int load16(int index, MemoryAtomicityMode mode);
+    int load8(int index, ReadAccessMode mode);
 
-    int load32(int index, MemoryAtomicityMode mode);
+    @Deprecated
+    default int load16(int index, MemoryAtomicityMode mode) {
+        return load16(index, mode.getAccessMode().getReadAccess());
+    }
 
+    int load16(int index, ReadAccessMode mode);
+
+    @Deprecated
+    default int load32(int index, MemoryAtomicityMode mode) {
+        return load32(index, mode.getAccessMode().getReadAccess());
+    }
+
+    int load32(int index, ReadAccessMode mode);
+
+    @Deprecated
     default float loadFloat(int index, MemoryAtomicityMode mode) {
         return Float.intBitsToFloat(load32(index, mode));
     }
 
-    long load64(int index, MemoryAtomicityMode mode);
+    default float loadFloat(int index, ReadAccessMode mode) {
+        return Float.intBitsToFloat(load32(index, mode));
+    }
 
-    VmObject loadRef(int index, MemoryAtomicityMode mode);
+    @Deprecated
+    default long load64(int index, MemoryAtomicityMode mode) {
+        return load64(index, mode.getAccessMode().getReadAccess());
+    }
 
-    ValueType loadType(int index, MemoryAtomicityMode mode);
+    long load64(int index, ReadAccessMode mode);
 
+    @Deprecated
+    default VmObject loadRef(int index, MemoryAtomicityMode mode) {
+        return loadRef(index, mode.getAccessMode().getReadAccess());
+    }
+
+    VmObject loadRef(int index, ReadAccessMode mode);
+
+    @Deprecated
+    default ValueType loadType(int index, MemoryAtomicityMode mode) {
+        return loadType(index, mode.getAccessMode().getReadAccess());
+    }
+
+    ValueType loadType(int index, ReadAccessMode mode);
+
+    @Deprecated
     default double loadDouble(int index, MemoryAtomicityMode mode) {
+        return Double.longBitsToDouble(load64(index, mode));
+    }
+
+    default double loadDouble(int index, ReadAccessMode mode) {
         return Double.longBitsToDouble(load64(index, mode));
     }
 

--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -70,29 +70,74 @@ public interface Memory {
         return Double.longBitsToDouble(load64(index, mode));
     }
 
-    void store8(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default void store8(int index, int value, MemoryAtomicityMode mode) {
+        store8(index, value, mode.getAccessMode().getWriteAccess());
+    }
 
-    void store16(int index, int value, MemoryAtomicityMode mode);
+    void store8(int index, int value, WriteAccessMode mode);
 
-    void store32(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default void store16(int index, int value, MemoryAtomicityMode mode) {
+        store16(index, value, mode.getAccessMode().getWriteAccess());
+    }
 
+    void store16(int index, int value, WriteAccessMode mode);
+
+    @Deprecated
+    default void store32(int index, int value, MemoryAtomicityMode mode) {
+        store32(index, value, mode.getAccessMode().getWriteAccess());
+    }
+
+    void store32(int index, int value, WriteAccessMode mode);
+
+    @Deprecated
     default void store32(int index, float value, MemoryAtomicityMode mode) {
         store32(index, Float.floatToRawIntBits(value), mode);
     }
 
+    default void store32(int index, float value, WriteAccessMode mode) {
+        store32(index, Float.floatToRawIntBits(value), mode);
+    }
+
+    @Deprecated
     default void store32(int index, long value, MemoryAtomicityMode mode) {
         store32(index, (int)value, mode);
     }
 
-    void store64(int index, long value, MemoryAtomicityMode mode);
+    default void store32(int index, long value, WriteAccessMode mode) {
+        store32(index, (int)value, mode);
+    }
 
+    @Deprecated
+    default void store64(int index, long value, MemoryAtomicityMode mode) {
+        store64(index, value, mode.getAccessMode().getWriteAccess());
+    }
+
+    void store64(int index, long value, WriteAccessMode mode);
+
+    @Deprecated
     default void store64(int index, double value, MemoryAtomicityMode mode) {
         store64(index, Double.doubleToRawLongBits(value), mode);
     }
 
-    void storeRef(int index, VmObject value, MemoryAtomicityMode mode);
+    default void store64(int index, double value, WriteAccessMode mode) {
+        store64(index, Double.doubleToRawLongBits(value), mode);
+    }
 
-    void storeType(int index, ValueType value, MemoryAtomicityMode mode);
+    @Deprecated
+    default void storeRef(int index, VmObject value, MemoryAtomicityMode mode) {
+        storeRef(index, value, mode.getAccessMode().getWriteAccess());
+    }
+
+    void storeRef(int index, VmObject value, WriteAccessMode mode);
+
+    @Deprecated
+    default void storeType(int index, ValueType value, MemoryAtomicityMode mode) {
+        storeType(index, value, mode.getAccessMode().getWriteAccess());
+    }
+
+    void storeType(int index, ValueType value, WriteAccessMode mode);
 
     void storeMemory(int destIndex, Memory src, int srcIndex, int size);
 

--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -185,89 +185,300 @@ public interface Memory {
 
     ValueType compareAndExchangeType(int index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndSet8(int index, int value, MemoryAtomicityMode mode);
+    int getAndSet8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndSet16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndSet8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSet8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSet32(int index, int value, MemoryAtomicityMode mode);
+    int getAndSet16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndSet64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndSet16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSet16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    VmObject getAndSetRef(int index, VmObject value, MemoryAtomicityMode mode);
+    int getAndSet32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    ValueType getAndSetType(int index, ValueType value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndSet32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSet32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndAdd8(int index, int value, MemoryAtomicityMode mode);
+    long getAndSet64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndAdd16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default long getAndSet64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndSet64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndAdd32(int index, int value, MemoryAtomicityMode mode);
+    VmObject getAndSetRef(int index, VmObject value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndAdd64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default VmObject getAndSetRef(int index, VmObject value, MemoryAtomicityMode mode) {
+        return getAndSetRef(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseAnd8(int index, int value, MemoryAtomicityMode mode);
+    ValueType getAndSetType(int index, ValueType value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndBitwiseAnd16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default ValueType getAndSetType(int index, ValueType value, MemoryAtomicityMode mode) {
+        return getAndSetType(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseAnd32(int index, int value, MemoryAtomicityMode mode);
+    int getAndAdd8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndBitwiseAnd64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndAdd8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndAdd8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseNand8(int index, int value, MemoryAtomicityMode mode);
+    int getAndAdd16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndBitwiseNand16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndAdd16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndAdd16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseNand32(int index, int value, MemoryAtomicityMode mode);
+    int getAndAdd32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndBitwiseNand64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndAdd32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndAdd32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseOr8(int index, int value, MemoryAtomicityMode mode);
+    long getAndAdd64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndBitwiseOr16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default long getAndAdd64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndAdd64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseOr32(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseAnd8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndBitwiseOr64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseAnd8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseAnd8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseXor8(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseAnd16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndBitwiseXor16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseAnd16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseAnd16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndBitwiseXor32(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseAnd32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndBitwiseXor64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseAnd32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseAnd32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMaxSigned8(int index, int value, MemoryAtomicityMode mode);
+    long getAndBitwiseAnd64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndSetMaxSigned16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default long getAndBitwiseAnd64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndBitwiseAnd64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMaxSigned32(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseNand8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndSetMaxSigned64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseNand8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseNand8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMaxUnsigned8(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseNand16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndSetMaxUnsigned16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseNand16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseNand16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMaxUnsigned32(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseNand32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndSetMaxUnsigned64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseNand32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseNand32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMinSigned8(int index, int value, MemoryAtomicityMode mode);
+    long getAndBitwiseNand64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndSetMinSigned16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default long getAndBitwiseNand64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndBitwiseNand64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMinSigned32(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseOr8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndSetMinSigned64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseOr8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseOr8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMinUnsigned8(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseOr16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int getAndSetMinUnsigned16(int index, int value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseOr16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseOr16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int getAndSetMinUnsigned32(int index, int value, MemoryAtomicityMode mode);
+    int getAndBitwiseOr32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    long getAndSetMinUnsigned64(int index, long value, MemoryAtomicityMode mode);
+    @Deprecated
+    default int getAndBitwiseOr32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseOr32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    long getAndBitwiseOr64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default long getAndBitwiseOr64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndBitwiseOr64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndBitwiseXor8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndBitwiseXor8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseXor8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndBitwiseXor16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndBitwiseXor16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseXor16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndBitwiseXor32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndBitwiseXor32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndBitwiseXor32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    long getAndBitwiseXor64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default long getAndBitwiseXor64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndBitwiseXor64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMaxSigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMaxSigned8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMaxSigned8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMaxSigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMaxSigned16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMaxSigned16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMaxSigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMaxSigned32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMaxSigned32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    long getAndSetMaxSigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default long getAndSetMaxSigned64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndSetMaxSigned64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMaxUnsigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMaxUnsigned8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMaxUnsigned8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMaxUnsigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMaxUnsigned16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMaxUnsigned16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMaxUnsigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMaxUnsigned32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMaxUnsigned32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    long getAndSetMaxUnsigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default long getAndSetMaxUnsigned64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndSetMaxUnsigned64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMinSigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMinSigned8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMinSigned8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMinSigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMinSigned16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMinSigned16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMinSigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMinSigned32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMinSigned32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    long getAndSetMinSigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default long getAndSetMinSigned64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndSetMinSigned64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMinUnsigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMinUnsigned8(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMinUnsigned8(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMinUnsigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMinUnsigned16(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMinUnsigned16(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    int getAndSetMinUnsigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default int getAndSetMinUnsigned32(int index, int value, MemoryAtomicityMode mode) {
+        return getAndSetMinUnsigned32(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    long getAndSetMinUnsigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default long getAndSetMinUnsigned64(int index, long value, MemoryAtomicityMode mode) {
+        return getAndSetMinUnsigned64(index, value, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
 
     Memory copy(int newSize);
 }

--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -3,6 +3,7 @@ package org.qbicc.interpreter;
 
 import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.ValueType;
 
 /**
@@ -97,17 +98,47 @@ public interface Memory {
 
     void storeMemory(int destIndex, byte[] src, int srcIndex, int size);
 
-    int compareAndExchange8(int index, int expect, int update, MemoryAtomicityMode mode);
+    @Deprecated
+    default int compareAndExchange8(int index, int expect, int update, MemoryAtomicityMode mode) {
+        return compareAndExchange8(index, expect, update, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    int compareAndExchange16(int index, int expect, int update, MemoryAtomicityMode mode);
+    int compareAndExchange8(int index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    int compareAndExchange32(int index, int expect, int update, MemoryAtomicityMode mode);
+    @Deprecated
+    default int compareAndExchange16(int index, int expect, int update, MemoryAtomicityMode mode) {
+        return compareAndExchange16(index, expect, update, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    long compareAndExchange64(int index, long expect, long update, MemoryAtomicityMode mode);
+    int compareAndExchange16(int index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
-    VmObject compareAndExchangeRef(int index, VmObject expect, VmObject update, MemoryAtomicityMode mode);
+    @Deprecated
+    default int compareAndExchange32(int index, int expect, int update, MemoryAtomicityMode mode) {
+        return compareAndExchange32(index, expect, update, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
 
-    ValueType compareAndExchangeType(int index, ValueType expect, ValueType update, MemoryAtomicityMode mode);
+    int compareAndExchange32(int index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default long compareAndExchange64(int index, long expect, long update, MemoryAtomicityMode mode) {
+        return compareAndExchange64(index, expect, update, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    long compareAndExchange64(int index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default VmObject compareAndExchangeRef(int index, VmObject expect, VmObject update, MemoryAtomicityMode mode) {
+        return compareAndExchangeRef(index, expect, update, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    VmObject compareAndExchangeRef(int index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode);
+
+    @Deprecated
+    default ValueType compareAndExchangeType(int index, ValueType expect, ValueType update, MemoryAtomicityMode mode) {
+        return compareAndExchangeType(index, expect, update, mode.getAccessMode().getReadAccess(), mode.getAccessMode().getWriteAccess());
+    }
+
+    ValueType compareAndExchangeType(int index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode);
 
     int getAndSet8(int index, int value, MemoryAtomicityMode mode);
 

--- a/compiler/src/test/java/org/qbicc/graph/atomic/AccessModeTests.java
+++ b/compiler/src/test/java/org/qbicc/graph/atomic/AccessModeTests.java
@@ -1,0 +1,32 @@
+package org.qbicc.graph.atomic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.qbicc.graph.atomic.AccessModes.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class AccessModeTests {
+
+    @Test
+    public void testCombinedWithUpgrade() {
+        assertSame(SinglePlain, SingleUnshared.combinedWith(SinglePlain));
+        assertSame(SingleOpaque, SinglePlain.combinedWith(SingleOpaque));
+        assertSame(SingleAcquire, SingleOpaque.combinedWith(SingleAcquire));
+        assertSame(SingleRelease, SingleOpaque.combinedWith(SingleRelease));
+        assertSame(SingleAcqRel, SingleAcquire.combinedWith(SingleRelease));
+
+        assertSame(GlobalPlain, GlobalUnshared.combinedWith(GlobalPlain));
+        assertSame(GlobalAcquire, GlobalLoadStore.combinedWith(GlobalLoadLoad));
+        assertSame(GlobalRelease, GlobalLoadStore.combinedWith(GlobalStoreStore));
+        assertSame(GlobalAcquire, GlobalPlain.combinedWith(GlobalAcquire));
+        assertSame(GlobalRelease, GlobalPlain.combinedWith(GlobalRelease));
+        assertSame(GlobalAcqRel, GlobalAcquire.combinedWith(GlobalRelease));
+        assertSame(GlobalSeqCst, GlobalAcqRel.combinedWith(GlobalStoreLoad));
+        assertSame(GlobalSeqCst, GlobalLoadLoad.combinedWith(GlobalStoreLoad));
+        assertSame(GlobalSeqCst, GlobalLoadStore.combinedWith(GlobalStoreLoad));
+        assertSame(GlobalSeqCst, GlobalStoreStore.combinedWith(GlobalStoreLoad));
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
@@ -155,10 +155,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndSet16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndSet16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndSetAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndSetRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndSet(data, index, (short) value);
@@ -166,10 +170,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndSet32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndSet32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndSetAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndSetRelease(data, index, value);
         } else {
             return (int) h32.getAndSet(data, index, value);
@@ -177,10 +185,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndSet64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndSet64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndSetAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndSetRelease(data, index, value);
         } else {
             return (long) h64.getAndSet(data, index, value);
@@ -188,10 +200,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndAdd16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndAdd16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value + val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndAddAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndAddRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndAdd(data, index, (short) value);
@@ -199,10 +215,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndAdd32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndAdd32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value + val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndAddAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndAddRelease(data, index, value);
         } else {
             return (int) h32.getAndAdd(data, index, value);
@@ -210,10 +230,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndAdd64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndAdd64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value + val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndAddAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndAddRelease(data, index, value);
         } else {
             return (long) h64.getAndAdd(data, index, value);
@@ -221,10 +245,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseAnd16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseAnd16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value & val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndBitwiseAndAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndBitwiseAndRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndBitwiseAnd(data, index, (short) value);
@@ -232,10 +260,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseAnd32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseAnd32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value & val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndBitwiseAndAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndBitwiseAndRelease(data, index, value);
         } else {
             return (int) h32.getAndBitwiseAnd(data, index, value);
@@ -243,10 +275,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndBitwiseAnd64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndBitwiseAnd64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value & val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndBitwiseAndAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndBitwiseAndRelease(data, index, value);
         } else {
             return (long) h64.getAndBitwiseAnd(data, index, value);
@@ -254,10 +290,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseOr16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseOr16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value | val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndBitwiseOrAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndBitwiseOrRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndBitwiseOr(data, index, (short) value);
@@ -265,10 +305,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseOr32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseOr32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value | val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndBitwiseOrAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndBitwiseOrRelease(data, index, value);
         } else {
             return (int) h32.getAndBitwiseOr(data, index, value);
@@ -276,10 +320,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndBitwiseOr64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndBitwiseOr64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value | val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndBitwiseOrAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndBitwiseOrRelease(data, index, value);
         } else {
             return (long) h64.getAndBitwiseOr(data, index, value);
@@ -287,10 +335,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseXor16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseXor16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value ^ val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndBitwiseXorAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndBitwiseXorRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndBitwiseXor(data, index, (short) value);
@@ -298,10 +350,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseXor32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseXor32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value ^ val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndBitwiseXorAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndBitwiseXorRelease(data, index, value);
         } else {
             return (int) h32.getAndBitwiseXor(data, index, value);
@@ -309,10 +365,14 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndBitwiseXor64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndBitwiseXor64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value ^ val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndBitwiseXorAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndBitwiseXorRelease(data, index, value);
         } else {
             return (long) h64.getAndBitwiseXor(data, index, value);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
@@ -1,11 +1,13 @@
 package org.qbicc.interpreter.impl;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
+import static org.qbicc.graph.atomic.AccessModes.*;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
 import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 
 final class BigEndianMemoryImpl extends MemoryImpl {
     static final BigEndianMemoryImpl EMPTY = new BigEndianMemoryImpl(0);
@@ -23,10 +25,12 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int load16(int index, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public int load16(int index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             return (int) h16.get(data, index);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h16.getOpaque(data, index);
+        } else if (GlobalAcquire.includes(mode)) {
             return (int) h16.getAcquire(data, index);
         } else {
             return (int) h16.getVolatile(data, index);
@@ -34,10 +38,12 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int load32(int index, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public int load32(int index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             return (int) h32.get(data, index);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h32.getOpaque(data, index);
+        } else if (GlobalAcquire.includes(mode)) {
             return (int) h32.getAcquire(data, index);
         } else {
             return (int) h32.getVolatile(data, index);
@@ -45,10 +51,12 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long load64(int index, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public long load64(int index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             return (long) h64.get(data, index);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (long) h64.getOpaque(data, index);
+        } else if (GlobalAcquire.includes(mode)) {
             return (long) h64.getAcquire(data, index);
         } else {
             return (long) h64.getVolatile(data, index);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
@@ -65,10 +65,12 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public void store16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public void store16(int index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             h16.set(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (SingleOpaque.includes(mode)) {
+            h16.setOpaque(data, index, (short) value);
+        } else if (GlobalRelease.includes(mode)) {
             h16.setRelease(data, index, (short) value);
         } else {
             h16.setVolatile(data, index, (short) value);
@@ -76,10 +78,12 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public void store32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public void store32(int index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             h32.set(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (SingleOpaque.includes(mode)) {
+            h32.setOpaque(data, index, value);
+        } else if (GlobalRelease.includes(mode)) {
             h32.setRelease(data, index, value);
         } else {
             h32.setVolatile(data, index, value);
@@ -87,10 +91,12 @@ final class BigEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public void store64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public void store64(int index, long value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             h64.set(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (SingleOpaque.includes(mode)) {
+            h64.setOpaque(data, index, value);
+        } else if (GlobalRelease.includes(mode)) {
             h64.setRelease(data, index, value);
         } else {
             h64.setVolatile(data, index, value);
@@ -102,7 +108,7 @@ final class BigEndianMemoryImpl extends MemoryImpl {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = load16(index, readMode) & 0xffff;
             if (val == (expect & 0xffff)) {
-                store16(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+                store16(index, update, writeMode);
             }
             return val;
         } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
@@ -119,7 +125,7 @@ final class BigEndianMemoryImpl extends MemoryImpl {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = load32(index, readMode);
             if (val == expect) {
-                store32(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+                store32(index, update, writeMode);
             }
             return val;
         } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
@@ -136,7 +142,7 @@ final class BigEndianMemoryImpl extends MemoryImpl {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             long val = load64(index, readMode);
             if (val == expect) {
-                store64(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+                store64(index, update, writeMode);
             }
             return val;
         } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1302,7 +1302,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         long elementSize = node.getType().getElementSize();
         for (int i = 0; i < nodeValues.size(); i++) {
             Literal value = nodeValues.get(i);
-            store(memory, (int) (elementSize * i), elementType, value, MemoryAtomicityMode.NONE);
+            store(memory, (int) (elementSize * i), elementType, value, SingleUnshared);
         }
         return memory;
     }
@@ -1968,7 +1968,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     public Void visit(VmThreadImpl thread, Store node) {
         ValueHandle valueHandle = node.getValueHandle();
         Value value = node.getValue();
-        MemoryAtomicityMode mode = node.getMode();
+        WriteAccessMode mode = node.getAccessMode();
         if (valueHandle instanceof StaticField sf) {
             ((VmClassImpl)sf.getVariableElement().getEnclosingType().load().getVmClass()).initialize(thread);
         }
@@ -1983,14 +1983,14 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
      * @param value the value to store
      * @param mode the atomicity mode (must not be {@code null})
      */
-    void store(final ValueHandle valueHandle, final Value value, final MemoryAtomicityMode mode) {
+    void store(final ValueHandle valueHandle, final Value value, final WriteAccessMode mode) {
         Memory memory = getMemory(valueHandle);
         int offset = getOffset(valueHandle);
         ValueType type = valueHandle.getValueType();
         store(memory, offset, type, value, mode);
     }
 
-    void store(final Memory memory, final int offset, final ValueType type, final Value value, final MemoryAtomicityMode mode) {
+    void store(final Memory memory, final int offset, final ValueType type, final Value value, final WriteAccessMode mode) {
         if (isInt8(type)) {
             memory.store8(offset, unboxInt(value), mode);
         } else if (isInt16(type)) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -124,6 +124,7 @@ import org.qbicc.graph.ValueVisitor;
 import org.qbicc.graph.VirtualMethodElementHandle;
 import org.qbicc.graph.Xor;
 import org.qbicc.graph.atomic.GlobalAccessMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.ArrayLiteral;
 import org.qbicc.graph.literal.BitCastLiteral;
 import org.qbicc.graph.literal.BooleanLiteral;
@@ -1815,7 +1816,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         Memory memory = getMemory(valueHandle);
         int offset = getOffset(valueHandle);
         ValueType type = valueHandle.getValueType();
-        MemoryAtomicityMode mode = node.getMode();
+        ReadAccessMode mode = node.getAccessMode();
         if (isInt8(type)) {
             return Byte.valueOf((byte) memory.load8(offset, mode));
         } else if (isInt16(type)) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1556,15 +1556,16 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isInt8(type)) {
-            return Byte.valueOf((byte) memory.getAndAdd8(offset, unboxInt(update), mode));
+            return Byte.valueOf((byte) memory.getAndAdd8(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt16(type)) {
-            return Short.valueOf((short) memory.getAndAdd16(offset, unboxInt(update), mode));
+            return Short.valueOf((short) memory.getAndAdd16(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt32(type)) {
-            return Integer.valueOf(memory.getAndAdd32(offset, unboxInt(update), mode));
+            return Integer.valueOf(memory.getAndAdd32(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt64(type)) {
-            return Long.valueOf(memory.getAndAdd64(offset, unboxLong(update), mode));
+            return Long.valueOf(memory.getAndAdd64(offset, unboxLong(update), readAccessMode, writeAccessMode));
         } else {
             throw unsupportedType();
         }
@@ -1580,17 +1581,18 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isInt8(type)) {
-            return Byte.valueOf((byte) memory.getAndBitwiseAnd8(offset, unboxInt(update), mode));
+            return Byte.valueOf((byte) memory.getAndBitwiseAnd8(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt16(type)) {
-            return Short.valueOf((short) memory.getAndBitwiseAnd16(offset, unboxInt(update), mode));
+            return Short.valueOf((short) memory.getAndBitwiseAnd16(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt32(type)) {
-            return Integer.valueOf(memory.getAndBitwiseAnd32(offset, unboxInt(update), mode));
+            return Integer.valueOf(memory.getAndBitwiseAnd32(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt64(type)) {
-            return Long.valueOf(memory.getAndBitwiseAnd64(offset, unboxLong(update), mode));
+            return Long.valueOf(memory.getAndBitwiseAnd64(offset, unboxLong(update), readAccessMode, writeAccessMode));
         } else if (isBool(type)) {
-            return Boolean.valueOf((memory.getAndBitwiseAnd8(offset, unboxBool(update) ? 1 : 0, mode) & 1) != 0);
+            return Boolean.valueOf((memory.getAndBitwiseAnd8(offset, unboxBool(update) ? 1 : 0, readAccessMode, writeAccessMode) & 1) != 0);
         } else {
             throw unsupportedType();
         }
@@ -1606,17 +1608,18 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isInt8(type)) {
-            return Byte.valueOf((byte) memory.getAndBitwiseNand8(offset, unboxInt(update), mode));
+            return Byte.valueOf((byte) memory.getAndBitwiseNand8(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt16(type)) {
-            return Short.valueOf((short) memory.getAndBitwiseNand16(offset, unboxInt(update), mode));
+            return Short.valueOf((short) memory.getAndBitwiseNand16(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt32(type)) {
-            return Integer.valueOf(memory.getAndBitwiseNand32(offset, unboxInt(update), mode));
+            return Integer.valueOf(memory.getAndBitwiseNand32(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt64(type)) {
-            return Long.valueOf(memory.getAndBitwiseNand64(offset, unboxLong(update), mode));
+            return Long.valueOf(memory.getAndBitwiseNand64(offset, unboxLong(update), readAccessMode, writeAccessMode));
         } else if (isBool(type)) {
-            return Boolean.valueOf((memory.getAndBitwiseNand8(offset, unboxBool(update) ? 1 : 0, mode) & 1) != 0);
+            return Boolean.valueOf((memory.getAndBitwiseNand8(offset, unboxBool(update) ? 1 : 0, readAccessMode, writeAccessMode) & 1) != 0);
         } else {
             throw unsupportedType();
         }
@@ -1632,17 +1635,18 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isInt8(type)) {
-            return Byte.valueOf((byte) memory.getAndBitwiseOr8(offset, unboxInt(update), mode));
+            return Byte.valueOf((byte) memory.getAndBitwiseOr8(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt16(type)) {
-            return Short.valueOf((short) memory.getAndBitwiseOr16(offset, unboxInt(update), mode));
+            return Short.valueOf((short) memory.getAndBitwiseOr16(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt32(type)) {
-            return Integer.valueOf(memory.getAndBitwiseOr32(offset, unboxInt(update), mode));
+            return Integer.valueOf(memory.getAndBitwiseOr32(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt64(type)) {
-            return Long.valueOf(memory.getAndBitwiseOr64(offset, unboxLong(update), mode));
+            return Long.valueOf(memory.getAndBitwiseOr64(offset, unboxLong(update), readAccessMode, writeAccessMode));
         } else if (isBool(type)) {
-            return Boolean.valueOf((memory.getAndBitwiseOr8(offset, unboxBool(update) ? 1 : 0, mode) & 1) != 0);
+            return Boolean.valueOf((memory.getAndBitwiseOr8(offset, unboxBool(update) ? 1 : 0, readAccessMode, writeAccessMode) & 1) != 0);
         } else {
             throw unsupportedType();
         }
@@ -1658,17 +1662,18 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isInt8(type)) {
-            return Byte.valueOf((byte) memory.getAndBitwiseXor8(offset, unboxInt(update), mode));
+            return Byte.valueOf((byte) memory.getAndBitwiseXor8(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt16(type)) {
-            return Short.valueOf((short) memory.getAndBitwiseXor16(offset, unboxInt(update), mode));
+            return Short.valueOf((short) memory.getAndBitwiseXor16(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt32(type)) {
-            return Integer.valueOf(memory.getAndBitwiseXor32(offset, unboxInt(update), mode));
+            return Integer.valueOf(memory.getAndBitwiseXor32(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt64(type)) {
-            return Long.valueOf(memory.getAndBitwiseXor64(offset, unboxLong(update), mode));
+            return Long.valueOf(memory.getAndBitwiseXor64(offset, unboxLong(update), readAccessMode, writeAccessMode));
         } else if (isBool(type)) {
-            return Boolean.valueOf((memory.getAndBitwiseXor8(offset, unboxBool(update) ? 1 : 0, mode) & 1) != 0);
+            return Boolean.valueOf((memory.getAndBitwiseXor8(offset, unboxBool(update) ? 1 : 0, readAccessMode, writeAccessMode) & 1) != 0);
         } else {
             throw unsupportedType();
         }
@@ -1684,23 +1689,24 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isBool(type)) {
-            return Boolean.valueOf(memory.getAndSet8(offset, unboxBool(update) ? 1 : 0, mode) != 0);
+            return Boolean.valueOf(memory.getAndSet8(offset, unboxBool(update) ? 1 : 0, readAccessMode, writeAccessMode) != 0);
         } else if (isInt8(type)) {
-            return Byte.valueOf((byte) memory.getAndSet8(offset, unboxInt(update), mode));
+            return Byte.valueOf((byte) memory.getAndSet8(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt16(type)) {
-            return Short.valueOf((short) memory.getAndSet16(offset, unboxInt(update), mode));
+            return Short.valueOf((short) memory.getAndSet16(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt32(type)) {
-            return Integer.valueOf(memory.getAndSet32(offset, unboxInt(update), mode));
+            return Integer.valueOf(memory.getAndSet32(offset, unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt64(type)) {
-            return Long.valueOf(memory.getAndSet64(offset, unboxLong(update), mode));
+            return Long.valueOf(memory.getAndSet64(offset, unboxLong(update), readAccessMode, writeAccessMode));
         } else if (isFloat32(type)) {
-            return Float.valueOf(Float.intBitsToFloat(memory.getAndSet32(offset, Float.floatToRawIntBits(unboxFloat(update)), mode)));
+            return Float.valueOf(Float.intBitsToFloat(memory.getAndSet32(offset, Float.floatToRawIntBits(unboxFloat(update)), readAccessMode, writeAccessMode)));
         } else if (isFloat64(type)) {
-            return Double.valueOf(Double.longBitsToDouble(memory.getAndSet64(offset, Double.doubleToRawLongBits(unboxDouble(update)), mode)));
+            return Double.valueOf(Double.longBitsToDouble(memory.getAndSet64(offset, Double.doubleToRawLongBits(unboxDouble(update)), readAccessMode, writeAccessMode)));
         } else if (isRef(type)) {
-            return memory.getAndSetRef(offset, (VmObject) require(update), mode);
+            return memory.getAndSetRef(offset, (VmObject) require(update), readAccessMode, writeAccessMode);
         } else {
             throw unsupportedType();
         }
@@ -1716,28 +1722,29 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isSigned(type)) {
             if (isInt8(type)) {
-                return Byte.valueOf((byte) memory.getAndSetMaxSigned8(offset, unboxInt(update), mode));
+                return Byte.valueOf((byte) memory.getAndSetMaxSigned8(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt16(type)) {
-                return Short.valueOf((short) memory.getAndSetMaxSigned16(offset, unboxInt(update), mode));
+                return Short.valueOf((short) memory.getAndSetMaxSigned16(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt32(type)) {
-                return Integer.valueOf(memory.getAndSetMaxSigned32(offset, unboxInt(update), mode));
+                return Integer.valueOf(memory.getAndSetMaxSigned32(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt64(type)) {
-                return Long.valueOf(memory.getAndSetMaxSigned64(offset, unboxLong(update), mode));
+                return Long.valueOf(memory.getAndSetMaxSigned64(offset, unboxLong(update), readAccessMode, writeAccessMode));
             } else {
                 throw unsupportedType();
             }
         } else {
             if (isInt8(type)) {
-                return Byte.valueOf((byte) memory.getAndSetMaxUnsigned8(offset, unboxInt(update), mode));
+                return Byte.valueOf((byte) memory.getAndSetMaxUnsigned8(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt16(type)) {
-                return Short.valueOf((short) memory.getAndSetMaxUnsigned16(offset, unboxInt(update), mode));
+                return Short.valueOf((short) memory.getAndSetMaxUnsigned16(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt32(type)) {
-                return Integer.valueOf(memory.getAndSetMaxUnsigned32(offset, unboxInt(update), mode));
+                return Integer.valueOf(memory.getAndSetMaxUnsigned32(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt64(type)) {
-                return Long.valueOf(memory.getAndSetMaxUnsigned64(offset, unboxLong(update), mode));
+                return Long.valueOf(memory.getAndSetMaxUnsigned64(offset, unboxLong(update), readAccessMode, writeAccessMode));
             } else {
                 throw unsupportedType();
             }
@@ -1754,28 +1761,29 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isSigned(type)) {
             if (isInt8(type)) {
-                return Byte.valueOf((byte) memory.getAndSetMinSigned8(offset, unboxInt(update), mode));
+                return Byte.valueOf((byte) memory.getAndSetMinSigned8(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt16(type)) {
-                return Short.valueOf((short) memory.getAndSetMinSigned16(offset, unboxInt(update), mode));
+                return Short.valueOf((short) memory.getAndSetMinSigned16(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt32(type)) {
-                return Integer.valueOf(memory.getAndSetMinSigned32(offset, unboxInt(update), mode));
+                return Integer.valueOf(memory.getAndSetMinSigned32(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt64(type)) {
-                return Long.valueOf(memory.getAndSetMinSigned64(offset, unboxLong(update), mode));
+                return Long.valueOf(memory.getAndSetMinSigned64(offset, unboxLong(update), readAccessMode, writeAccessMode));
             } else {
                 throw unsupportedType();
             }
         } else {
             if (isInt8(type)) {
-                return Byte.valueOf((byte) memory.getAndSetMinUnsigned8(offset, unboxInt(update), mode));
+                return Byte.valueOf((byte) memory.getAndSetMinUnsigned8(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt16(type)) {
-                return Short.valueOf((short) memory.getAndSetMinUnsigned16(offset, unboxInt(update), mode));
+                return Short.valueOf((short) memory.getAndSetMinUnsigned16(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt32(type)) {
-                return Integer.valueOf(memory.getAndSetMinUnsigned32(offset, unboxInt(update), mode));
+                return Integer.valueOf(memory.getAndSetMinUnsigned32(offset, unboxInt(update), readAccessMode, writeAccessMode));
             } else if (isInt64(type)) {
-                return Long.valueOf(memory.getAndSetMinUnsigned64(offset, unboxLong(update), mode));
+                return Long.valueOf(memory.getAndSetMinUnsigned64(offset, unboxLong(update), readAccessMode, writeAccessMode));
             } else {
                 throw unsupportedType();
             }
@@ -1792,15 +1800,16 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         int offset = getOffset(valueHandle);
         ValueType type = node.getValueHandle().getValueType();
         Value update = node.getUpdateValue();
-        MemoryAtomicityMode mode = node.getAtomicityMode();
+        ReadAccessMode readAccessMode = node.getReadAccessMode();
+        WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         if (isInt8(type)) {
-            return Byte.valueOf((byte) memory.getAndAdd8(offset, -unboxInt(update), mode));
+            return Byte.valueOf((byte) memory.getAndAdd8(offset, -unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt16(type)) {
-            return Short.valueOf((short) memory.getAndAdd16(offset, -unboxInt(update), mode));
+            return Short.valueOf((short) memory.getAndAdd16(offset, -unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt32(type)) {
-            return Integer.valueOf(memory.getAndAdd32(offset, -unboxInt(update), mode));
+            return Integer.valueOf(memory.getAndAdd32(offset, -unboxInt(update), readAccessMode, writeAccessMode));
         } else if (isInt64(type)) {
-            return Long.valueOf(memory.getAndAdd64(offset, -unboxLong(update), mode));
+            return Long.valueOf(memory.getAndAdd64(offset, -unboxLong(update), readAccessMode, writeAccessMode));
         } else {
             throw unsupportedType();
         }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
@@ -65,10 +65,12 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public void store16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public void store16(int index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             h16.set(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (SingleOpaque.includes(mode)) {
+            h16.setOpaque(data, index, (short) value);
+        } else if (GlobalRelease.includes(mode)) {
             h16.setRelease(data, index, (short) value);
         } else {
             h16.setVolatile(data, index, (short) value);
@@ -76,10 +78,12 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public void store32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public void store32(int index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             h32.set(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (SingleOpaque.includes(mode)) {
+            h32.setOpaque(data, index, value);
+        } else if (GlobalRelease.includes(mode)) {
             h32.setRelease(data, index, value);
         } else {
             h32.setVolatile(data, index, value);
@@ -87,10 +91,12 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public void store64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public void store64(int index, long value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             h64.set(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (SingleOpaque.includes(mode)) {
+            h64.setOpaque(data, index, value);
+        } else if (GlobalRelease.includes(mode)) {
             h64.setRelease(data, index, value);
         } else {
             h64.setVolatile(data, index, value);
@@ -102,7 +108,7 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = load16(index, readMode) & 0xffff;
             if (val == (expect & 0xffff)) {
-                store16(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+                store16(index, update, writeMode);
             }
             return val;
         } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
@@ -119,7 +125,7 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = load32(index, readMode);
             if (val == expect) {
-                store32(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+                store32(index, update, writeMode);
             }
             return val;
         } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
@@ -136,7 +142,7 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             long val = load64(index, readMode);
             if (val == expect) {
-                store64(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+                store64(index, update, writeMode);
             }
             return val;
         } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
@@ -155,10 +155,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndSet16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndSet16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndSetAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndSetRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndSet(data, index, (short) value);
@@ -166,10 +170,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndSet32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndSet32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndSetAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndSetRelease(data, index, value);
         } else {
             return (int) h32.getAndSet(data, index, value);
@@ -177,10 +185,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndSet64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndSet64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndSetAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndSetRelease(data, index, value);
         } else {
             return (long) h64.getAndSet(data, index, value);
@@ -188,10 +200,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndAdd16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndAdd16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value + val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndAddAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndAddRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndAdd(data, index, (short) value);
@@ -199,10 +215,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndAdd32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndAdd32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value + val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndAddAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndAddRelease(data, index, value);
         } else {
             return (int) h32.getAndAdd(data, index, value);
@@ -210,10 +230,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndAdd64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndAdd64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value + val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndAddAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndAddRelease(data, index, value);
         } else {
             return (long) h64.getAndAdd(data, index, value);
@@ -221,10 +245,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseAnd16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseAnd16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value & val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndBitwiseAndAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndBitwiseAndRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndBitwiseAnd(data, index, (short) value);
@@ -232,10 +260,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseAnd32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseAnd32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value & val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndBitwiseAndAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndBitwiseAndRelease(data, index, value);
         } else {
             return (int) h32.getAndBitwiseAnd(data, index, value);
@@ -243,10 +275,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndBitwiseAnd64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndBitwiseAnd64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value & val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndBitwiseAndAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndBitwiseAndRelease(data, index, value);
         } else {
             return (long) h64.getAndBitwiseAnd(data, index, value);
@@ -254,10 +290,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseOr16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseOr16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value | val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndBitwiseOrAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndBitwiseOrRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndBitwiseOr(data, index, (short) value);
@@ -265,10 +305,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseOr32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseOr32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value | val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndBitwiseOrAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndBitwiseOrRelease(data, index, value);
         } else {
             return (int) h32.getAndBitwiseOr(data, index, value);
@@ -276,10 +320,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndBitwiseOr64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndBitwiseOr64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value | val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndBitwiseOrAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndBitwiseOrRelease(data, index, value);
         } else {
             return (long) h64.getAndBitwiseOr(data, index, value);
@@ -287,10 +335,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseXor16(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseXor16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode);
+            store16(index, value ^ val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.getAndBitwiseXorAcquire(data, index, (short) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.getAndBitwiseXorRelease(data, index, (short) value);
         } else {
             return (int) h16.getAndBitwiseXor(data, index, (short) value);
@@ -298,10 +350,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int getAndBitwiseXor32(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseXor32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            store32(index, value ^ val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.getAndBitwiseXorAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.getAndBitwiseXorRelease(data, index, value);
         } else {
             return (int) h32.getAndBitwiseXor(data, index, value);
@@ -309,10 +365,14 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long getAndBitwiseXor64(int index, long value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long getAndBitwiseXor64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            store64(index, value ^ val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.getAndBitwiseXorAcquire(data, index, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.getAndBitwiseXorRelease(data, index, value);
         } else {
             return (long) h64.getAndBitwiseXor(data, index, value);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
@@ -1,11 +1,13 @@
 package org.qbicc.interpreter.impl;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.qbicc.graph.atomic.AccessModes.*;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
 import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 
 final class LittleEndianMemoryImpl extends MemoryImpl {
     static final LittleEndianMemoryImpl EMPTY = new LittleEndianMemoryImpl(0);
@@ -23,10 +25,12 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int load16(int index, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public int load16(int index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             return (int) h16.get(data, index);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h16.getOpaque(data, index);
+        } else if (GlobalAcquire.includes(mode)) {
             return (int) h16.getAcquire(data, index);
         } else {
             return (int) h16.getVolatile(data, index);
@@ -34,10 +38,12 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int load32(int index, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public int load32(int index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             return (int) h32.get(data, index);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h32.getOpaque(data, index);
+        } else if (GlobalAcquire.includes(mode)) {
             return (int) h32.getAcquire(data, index);
         } else {
             return (int) h32.getVolatile(data, index);
@@ -45,10 +51,12 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long load64(int index, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public long load64(int index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             return (long) h64.get(data, index);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (long) h64.getOpaque(data, index);
+        } else if (GlobalAcquire.includes(mode)) {
             return (long) h64.getAcquire(data, index);
         } else {
             return (long) h64.getVolatile(data, index);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
@@ -8,6 +8,7 @@ import java.lang.invoke.VarHandle;
 
 import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 
 final class LittleEndianMemoryImpl extends MemoryImpl {
     static final LittleEndianMemoryImpl EMPTY = new LittleEndianMemoryImpl(0);
@@ -97,10 +98,16 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int compareAndExchange16(int index, int expect, int update, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int compareAndExchange16(int index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode) & 0xffff;
+            if (val == (expect & 0xffff)) {
+                store16(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h16.compareAndExchangeAcquire(data, index, (short) expect, (short) update);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h16.compareAndExchangeRelease(data, index, (short) expect, (short) update);
         } else {
             return (int) h16.compareAndExchange(data, index, (short) expect, (short) update);
@@ -108,10 +115,16 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public int compareAndExchange32(int index, int expect, int update, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int compareAndExchange32(int index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            if (val == expect) {
+                store32(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h32.compareAndExchangeAcquire(data, index, expect, update);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h32.compareAndExchangeRelease(data, index, expect, update);
         } else {
             return (int) h32.compareAndExchange(data, index, expect, update);
@@ -119,10 +132,16 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
     }
 
     @Override
-    public long compareAndExchange64(int index, long expect, long update, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public long compareAndExchange64(int index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            if (val == expect) {
+                store64(index, update, MemoryAtomicityMode.VOLATILE /* writeMode */);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (long) h64.compareAndExchangeAcquire(data, index, expect, update);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (long) h64.compareAndExchangeRelease(data, index, expect, update);
         } else {
             return (long) h64.compareAndExchange(data, index, expect, update);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
@@ -216,10 +216,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public final int getAndSet8(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public final int getAndSet8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load8(index, readMode);
+            store8(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h8.getAndSetAcquire(data, index, (byte) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h8.getAndSetRelease(data, index, (byte) value);
         } else {
             return (int) h8.getAndSet(data, index, (byte) value);
@@ -227,19 +231,23 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public abstract int getAndSet16(int index, int value, MemoryAtomicityMode mode);
+    public abstract int getAndSet16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
     @Override
-    public abstract int getAndSet32(int index, int value, MemoryAtomicityMode mode);
+    public abstract int getAndSet32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
     @Override
-    public abstract long getAndSet64(int index, long value, MemoryAtomicityMode mode);
+    public abstract long getAndSet64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
     @Override
-    public VmObject getAndSetRef(int index, VmObject value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public VmObject getAndSetRef(int index, VmObject value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            VmObject val = loadRef(index, readMode);
+            storeRef(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (VmObject) ht.getAndSetAcquire(things, index >> 1, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (VmObject) ht.getAndSetRelease(things, index >> 1, value);
         } else {
             return (VmObject) ht.getAndSet(things, index >> 1, value);
@@ -247,10 +255,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public ValueType getAndSetType(int index, ValueType value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public ValueType getAndSetType(int index, ValueType value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            ValueType val = loadType(index, readMode);
+            storeType(index, value, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (ValueType) ht.getAndSetAcquire(things, index >> 1, value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (ValueType) ht.getAndSetRelease(things, index >> 1, value);
         } else {
             return (ValueType) ht.getAndSet(things, index >> 1, value);
@@ -258,10 +270,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public final int getAndAdd8(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public final int getAndAdd8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load8(index, readMode);
+            store8(index, value + val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h8.getAndAddAcquire(data, index, (byte) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h8.getAndAddRelease(data, index, (byte) value);
         } else {
             return (int) h8.getAndAdd(data, index, (byte) value);
@@ -269,19 +285,23 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public abstract int getAndAdd16(int index, int value, MemoryAtomicityMode mode);
+    public abstract int getAndAdd16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
     @Override
-    public abstract int getAndAdd32(int index, int value, MemoryAtomicityMode mode);
+    public abstract int getAndAdd32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
     @Override
-    public abstract long getAndAdd64(int index, long value, MemoryAtomicityMode mode);
+    public abstract long getAndAdd64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode);
 
     @Override
-    public int getAndBitwiseAnd8(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseAnd8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load8(index, readMode);
+            store8(index, value & val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h8.getAndBitwiseAndAcquire(data, index, (byte) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h8.getAndBitwiseAndRelease(data, index, (byte) value);
         } else {
             return (int) h8.getAndBitwiseAnd(data, index, (byte) value);
@@ -289,10 +309,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndBitwiseOr8(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseOr8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load8(index, readMode);
+            store8(index, value | val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h8.getAndBitwiseOrAcquire(data, index, (byte) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h8.getAndBitwiseOrRelease(data, index, (byte) value);
         } else {
             return (int) h8.getAndBitwiseOr(data, index, (byte) value);
@@ -300,10 +324,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndBitwiseXor8(int index, int value, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.ACQUIRE) {
+    public int getAndBitwiseXor8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load8(index, readMode);
+            store8(index, value ^ val, writeMode);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
             return (int) h8.getAndBitwiseXorAcquire(data, index, (byte) value);
-        } else if (mode == MemoryAtomicityMode.RELEASE) {
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
             return (int) h8.getAndBitwiseXorRelease(data, index, (byte) value);
         } else {
             return (int) h8.getAndBitwiseXor(data, index, (byte) value);
@@ -311,15 +339,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndBitwiseNand8(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndBitwiseNand8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal, newVal;
         for (;;) {
-            oldVal = load8(index, mode.read()) & 0xff;
+            oldVal = load8(index, readMode) & 0xff;
             newVal = (oldVal & value & 0xff) ^ 0xff;
             if (oldVal == newVal) {
                 return oldVal;
             }
-            int witness = compareAndExchange8(index, oldVal, newVal, mode);
+            int witness = compareAndExchange8(index, oldVal, newVal, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -327,15 +355,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndBitwiseNand16(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndBitwiseNand16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal, newVal;
         for (;;) {
-            oldVal = load16(index, mode.read()) & 0xffff;
+            oldVal = load16(index, readMode) & 0xffff;
             newVal = (oldVal & value & 0xffff) ^ 0xffff;
             if (oldVal == newVal) {
                 return oldVal;
             }
-            int witness = compareAndExchange16(index, oldVal, newVal, mode);
+            int witness = compareAndExchange16(index, oldVal, newVal, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -343,15 +371,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndBitwiseNand32(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndBitwiseNand32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal, newVal;
         for (;;) {
-            oldVal = load32(index, mode.read());
+            oldVal = load32(index, readMode);
             newVal = ~(oldVal & value);
             if (oldVal == newVal) {
                 return oldVal;
             }
-            int witness = compareAndExchange32(index, oldVal, newVal, mode);
+            int witness = compareAndExchange32(index, oldVal, newVal, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -359,15 +387,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public long getAndBitwiseNand64(int index, long value, MemoryAtomicityMode mode) {
+    public long getAndBitwiseNand64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         long oldVal, newVal;
         for (;;) {
-            oldVal = load64(index, mode.read());
+            oldVal = load64(index, readMode);
             newVal = ~(oldVal & value);
             if (oldVal == newVal) {
                 return oldVal;
             }
-            long witness = compareAndExchange64(index, oldVal, newVal, mode);
+            long witness = compareAndExchange64(index, oldVal, newVal, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -375,14 +403,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMaxSigned8(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMaxSigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load8(index, mode.read());
+            oldVal = load8(index, readMode);
             if (oldVal >= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange8(index, oldVal, value, mode);
+            int witness = compareAndExchange8(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -390,14 +418,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMaxSigned16(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMaxSigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load16(index, mode.read());
+            oldVal = load16(index, readMode);
             if (oldVal >= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange16(index, oldVal, value, mode);
+            int witness = compareAndExchange16(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -405,14 +433,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMaxSigned32(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMaxSigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load32(index, mode.read());
+            oldVal = load32(index, readMode);
             if (oldVal >= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange32(index, oldVal, value, mode);
+            int witness = compareAndExchange32(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -420,14 +448,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public long getAndSetMaxSigned64(int index, long value, MemoryAtomicityMode mode) {
+    public long getAndSetMaxSigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         long oldVal;
         for (;;) {
-            oldVal = load64(index, mode.read());
+            oldVal = load64(index, readMode);
             if (oldVal >= value) {
                 return oldVal;
             }
-            long witness = compareAndExchange64(index, oldVal, value, mode);
+            long witness = compareAndExchange64(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -435,15 +463,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMaxUnsigned8(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMaxUnsigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         value &= 0xff;
         for (;;) {
-            oldVal = load8(index, mode.read()) & 0xff;
+            oldVal = load8(index, readMode) & 0xff;
             if (oldVal >= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange8(index, oldVal, value, mode);
+            int witness = compareAndExchange8(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -451,15 +479,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMaxUnsigned16(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMaxUnsigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         value &= 0xffff;
         for (;;) {
-            oldVal = load16(index, mode.read()) & 0xffff;
+            oldVal = load16(index, readMode) & 0xffff;
             if (oldVal >= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange16(index, oldVal, value, mode);
+            int witness = compareAndExchange16(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -467,14 +495,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMaxUnsigned32(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMaxUnsigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load32(index, mode.read());
+            oldVal = load32(index, readMode);
             if (Integer.compareUnsigned(oldVal, value) >= 0) {
                 return oldVal;
             }
-            int witness = compareAndExchange32(index, oldVal, value, mode);
+            int witness = compareAndExchange32(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -482,14 +510,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public long getAndSetMaxUnsigned64(int index, long value, MemoryAtomicityMode mode) {
+    public long getAndSetMaxUnsigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         long oldVal;
         for (;;) {
-            oldVal = load64(index, mode.read());
+            oldVal = load64(index, readMode);
             if (Long.compareUnsigned(oldVal, value) >= 0) {
                 return oldVal;
             }
-            long witness = compareAndExchange64(index, oldVal, value, mode);
+            long witness = compareAndExchange64(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -497,14 +525,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMinSigned8(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMinSigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load8(index, mode.read());
+            oldVal = load8(index, readMode);
             if (oldVal <= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange8(index, oldVal, value, mode);
+            int witness = compareAndExchange8(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -512,14 +540,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMinSigned16(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMinSigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load16(index, mode.read());
+            oldVal = load16(index, readMode);
             if (oldVal <= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange8(index, oldVal, value, mode);
+            int witness = compareAndExchange8(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -527,14 +555,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMinSigned32(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMinSigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load32(index, mode.read());
+            oldVal = load32(index, readMode);
             if (oldVal <= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange32(index, oldVal, value, mode);
+            int witness = compareAndExchange32(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -542,14 +570,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public long getAndSetMinSigned64(int index, long value, MemoryAtomicityMode mode) {
+    public long getAndSetMinSigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         long oldVal;
         for (;;) {
-            oldVal = load64(index, mode.read());
+            oldVal = load64(index, readMode);
             if (oldVal <= value) {
                 return oldVal;
             }
-            long witness = compareAndExchange64(index, oldVal, value, mode);
+            long witness = compareAndExchange64(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -557,15 +585,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMinUnsigned8(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMinUnsigned8(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         value &= 0xff;
         for (;;) {
-            oldVal = load8(index, mode.read()) & 0xff;
+            oldVal = load8(index, readMode) & 0xff;
             if (oldVal <= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange8(index, oldVal, value, mode);
+            int witness = compareAndExchange8(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -573,15 +601,15 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMinUnsigned16(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMinUnsigned16(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         value &= 0xffff;
         for (;;) {
-            oldVal = load16(index, mode.read()) & 0xffff;
+            oldVal = load16(index, readMode) & 0xffff;
             if (oldVal <= value) {
                 return oldVal;
             }
-            int witness = compareAndExchange16(index, oldVal, value, mode);
+            int witness = compareAndExchange16(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -589,14 +617,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public int getAndSetMinUnsigned32(int index, int value, MemoryAtomicityMode mode) {
+    public int getAndSetMinUnsigned32(int index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int oldVal;
         for (;;) {
-            oldVal = load32(index, mode.read());
+            oldVal = load32(index, readMode);
             if (Integer.compareUnsigned(oldVal, value) <= 0) {
                 return oldVal;
             }
-            int witness = compareAndExchange32(index, oldVal, value, mode);
+            int witness = compareAndExchange32(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }
@@ -604,14 +632,14 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public long getAndSetMinUnsigned64(int index, long value, MemoryAtomicityMode mode) {
+    public long getAndSetMinUnsigned64(int index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         long oldVal;
         for (;;) {
-            oldVal = load64(index, mode.read());
+            oldVal = load64(index, readMode);
             if (Long.compareUnsigned(oldVal, value) <= 0) {
                 return oldVal;
             }
-            long witness = compareAndExchange64(index, oldVal, value, mode);
+            long witness = compareAndExchange64(index, oldVal, value, readMode, writeMode);
             if (witness == oldVal) {
                 return value;
             }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
@@ -1,10 +1,13 @@
 package org.qbicc.interpreter.impl;
 
+import static org.qbicc.graph.atomic.AccessModes.*;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.Arrays;
 
 import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.type.ValueType;
@@ -50,10 +53,12 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public final int load8(int index, MemoryAtomicityMode mode) {
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+    public final int load8(int index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
             return (int) h8.get(data, index);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h8.getOpaque(data, index);
+        } else if (GlobalAcquire.includes(mode)) {
             return (int) h8.getAcquire(data, index);
         } else {
             return (int) h8.getVolatile(data, index);
@@ -61,20 +66,22 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public abstract int load16(int index, MemoryAtomicityMode mode);
+    public abstract int load16(int index, ReadAccessMode mode);
 
     @Override
-    public abstract int load32(int index, MemoryAtomicityMode mode);
+    public abstract int load32(int index, ReadAccessMode mode);
 
     @Override
-    public abstract long load64(int index, MemoryAtomicityMode mode);
+    public abstract long load64(int index, ReadAccessMode mode);
 
     @Override
-    public VmObject loadRef(int index, MemoryAtomicityMode mode) {
+    public VmObject loadRef(int index, ReadAccessMode mode) {
         checkAlign(index, 2);
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+        if (GlobalPlain.includes(mode)) {
             return (VmObject) ht.get(things, index >> 1);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (VmObject) ht.getOpaque(things, index >> 1);
+        } else if (GlobalAcquire.includes(mode)) {
             return (VmObject) ht.getAcquire(things, index >> 1);
         } else {
             return (VmObject) ht.getVolatile(things, index >> 1);
@@ -82,11 +89,13 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public ValueType loadType(int index, MemoryAtomicityMode mode) {
+    public ValueType loadType(int index, ReadAccessMode mode) {
         checkAlign(index, 2);
-        if (mode == MemoryAtomicityMode.NONE || mode == MemoryAtomicityMode.UNORDERED) {
+        if (GlobalPlain.includes(mode)) {
             return (ValueType) ht.get(things, index >> 1);
-        } else if (mode == MemoryAtomicityMode.ACQUIRE) {
+        } else if (SingleOpaque.includes(mode)) {
+            return (ValueType) ht.getOpaque(things, index >> 1);
+        } else if (GlobalAcquire.includes(mode)) {
             return (ValueType) ht.getAcquire(things, index >> 1);
         } else {
             return (ValueType) ht.getVolatile(things, index >> 1);

--- a/plugins/constants/src/main/java/org/qbicc/plugin/constants/ConstantBasicBlockBuilder.java
+++ b/plugins/constants/src/main/java/org/qbicc/plugin/constants/ConstantBasicBlockBuilder.java
@@ -16,6 +16,7 @@ import org.qbicc.graph.StaticMethodElementHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.BooleanLiteral;
 import org.qbicc.graph.literal.ConstantLiteral;
 import org.qbicc.graph.literal.FloatLiteral;
@@ -69,7 +70,7 @@ public class ConstantBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     @Override
-    public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+    public Node store(ValueHandle handle, Value value, WriteAccessMode accessMode) {
         if (getRootElement() instanceof InitializerElement) {
             if (handle instanceof StaticField) {
                 final FieldElement fieldElement = ((StaticField) handle).getVariableElement();
@@ -80,7 +81,7 @@ public class ConstantBasicBlockBuilder extends DelegatingBasicBlockBuilder {
                 }
             }
         }
-        return super.store(handle, value, mode);
+        return super.store(handle, value, accessMode);
     }
 
     @Override

--- a/plugins/constants/src/main/java/org/qbicc/plugin/constants/ConstantBasicBlockBuilder.java
+++ b/plugins/constants/src/main/java/org/qbicc/plugin/constants/ConstantBasicBlockBuilder.java
@@ -15,6 +15,7 @@ import org.qbicc.graph.StaticField;
 import org.qbicc.graph.StaticMethodElementHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.BooleanLiteral;
 import org.qbicc.graph.literal.ConstantLiteral;
 import org.qbicc.graph.literal.FloatLiteral;
@@ -50,7 +51,7 @@ public class ConstantBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     @Override
-    public Value load(ValueHandle handle, MemoryAtomicityMode mode) {
+    public Value load(ValueHandle handle, ReadAccessMode accessMode) {
         if (handle instanceof StaticField) {
             final FieldElement fieldElement = ((StaticField) handle).getVariableElement();
             Value constantValue = Constants.get(ctxt).getConstantValue(fieldElement);
@@ -64,7 +65,7 @@ public class ConstantBasicBlockBuilder extends DelegatingBasicBlockBuilder {
                 }
             }
         }
-        return getDelegate().load(handle, mode);
+        return getDelegate().load(handle, accessMode);
     }
 
     @Override

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
@@ -25,6 +25,7 @@ import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueHandleVisitor;
 import org.qbicc.graph.VirtualMethodElementHandle;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.plugin.coreclasses.CoreClasses;
@@ -62,9 +63,9 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
     }
 
     @Override
-    public Value load(ValueHandle handle, MemoryAtomicityMode mode) {
+    public Value load(ValueHandle handle, ReadAccessMode accessMode) {
         check(handle);
-        return super.load(handle, mode);
+        return super.load(handle, accessMode);
     }
 
     @Override

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
@@ -26,6 +26,7 @@ import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueHandleVisitor;
 import org.qbicc.graph.VirtualMethodElementHandle;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.plugin.coreclasses.CoreClasses;
@@ -69,9 +70,9 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
     }
 
     @Override
-    public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+    public Node store(ValueHandle handle, Value value, WriteAccessMode accessMode) {
         Value narrowedValue = check(handle, value);
-        return super.store(handle, narrowedValue != null ? narrowedValue : value, mode);
+        return super.store(handle, narrowedValue != null ? narrowedValue : value, accessMode);
     }
 
     @Override

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -322,123 +322,251 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
     }
 
     @Override
-    public Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndAdd(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.add(super.load(target, atomicityMode), update);
-            super.store(target, result, atomicityMode);
-            return result;
+    public Value getAndAdd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, fb.add(result, update), writeMode);
         } else {
-            return super.getAndAdd(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override
-    public Value getAndBitwiseAnd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndBitwiseAnd(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.and(super.load(target, atomicityMode), update);
-            super.store(target, result, atomicityMode);
-            return result;
+    public Value getAndBitwiseAnd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, fb.and(result, update), writeMode);
         } else {
-            return super.getAndBitwiseAnd(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override
-    public Value getAndBitwiseOr(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndBitwiseOr(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.or(super.load(target, atomicityMode), update);
-            super.store(target, result, atomicityMode);
-            return result;
+    public Value getAndBitwiseOr(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, fb.or(result, update), writeMode);
         } else {
-            return super.getAndBitwiseOr(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override
-    public Value getAndBitwiseXor(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndBitwiseXor(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.xor(super.load(target, atomicityMode), update);
-            super.store(target, result, atomicityMode);
-            return result;
+    public Value getAndBitwiseXor(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, fb.xor(result, update), writeMode);
         } else {
-            return super.getAndBitwiseXor(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override
-    public Value getAndSet(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndSet(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.load(target, atomicityMode);
-            super.store(target, update, atomicityMode);
-            return result;
+    public Value getAndSet(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, update, writeMode);
         } else {
-            return super.getAndSet(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override
-    public Value getAndSetMax(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndSetMax(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.max(super.load(target, atomicityMode), update);
-            super.store(target, result, atomicityMode);
-            return result;
+    public Value getAndSetMax(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, fb.max(result, update), writeMode);
         } else {
-            return super.getAndSetMax(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override
-    public Value getAndSetMin(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndSetMin(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.min(super.load(target, atomicityMode), update);
-            super.store(target, result, atomicityMode);
-            return result;
+    public Value getAndSetMin(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, fb.min(result, update), writeMode);
         } else {
-            return super.getAndSetMin(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override
-    public Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
-        if (atomicityMode == MemoryAtomicityMode.VOLATILE) {
-            Value result = super.getAndSub(target, update, MemoryAtomicityMode.ACQUIRE_RELEASE);
-            fence(MemoryAtomicityMode.SEQUENTIALLY_CONSISTENT);
-            return result;
-        } else if (atomicityMode == MemoryAtomicityMode.UNORDERED || atomicityMode == MemoryAtomicityMode.NONE) {
-            Value result = super.sub(super.load(target, atomicityMode), update);
-            super.store(target, result, atomicityMode);
-            return result;
+    public Value getAndSub(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        BasicBlockBuilder fb = getFirstBuilder();
+        ReadAccessMode lowerReadMode = readMode;
+        WriteAccessMode lowerWriteMode = writeMode;
+        Value result;
+        if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+            // not actually atomic!
+            // emit fences via load and store logic.
+            result = fb.load(target, readMode);
+            fb.store(target, fb.sub(result, update), writeMode);
         } else {
-            return super.getAndSub(target, update, atomicityMode);
+            boolean readRequiresFence = readMode.includes(GlobalAcquire);
+            if (readRequiresFence) {
+                lowerReadMode = SingleAcquire;
+            }
+            boolean writeRequiresFence = writeMode.includes(GlobalRelease);
+            if (writeRequiresFence) {
+                lowerWriteMode = SingleRelease;
+            }
+            result = super.getAndAdd(target, update, lowerReadMode, lowerWriteMode);
+            if (readRequiresFence) {
+                fence(readMode.getGlobalAccess());
+            }
+            if (writeRequiresFence) {
+                fb.fence(writeMode.getGlobalAccess());
+            }
         }
+        return result;
     }
 
     @Override

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -613,7 +613,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         LLValue ptr = valueHandle.accept(GET_HANDLE_POINTER_VALUE, this);
         AtomicRmw insn = builder.atomicrmw(map(valueHandle.getPointerType()), map(node.getUpdateValue()), map(node.getUpdateValue().getType()), ptr).add();
         insn.align(valueHandle.getValueType().getAlign());
-        insn.ordering(getOC(node.getAtomicityMode()));
+        insn.ordering(getOC(node.getReadAccessMode().combinedWith(node.getWriteAccessMode())));
         return insn.asLocal();
     }
 
@@ -623,7 +623,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         LLValue ptr = valueHandle.accept(GET_HANDLE_POINTER_VALUE, this);
         AtomicRmw insn = builder.atomicrmw(map(valueHandle.getPointerType()), map(node.getUpdateValue()), map(node.getUpdateValue().getType()), ptr).and();
         insn.align(valueHandle.getValueType().getAlign());
-        insn.ordering(getOC(node.getAtomicityMode()));
+        insn.ordering(getOC(node.getReadAccessMode().combinedWith(node.getWriteAccessMode())));
         return insn.asLocal();
     }
 
@@ -633,7 +633,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         LLValue ptr = valueHandle.accept(GET_HANDLE_POINTER_VALUE, this);
         AtomicRmw insn = builder.atomicrmw(map(valueHandle.getPointerType()), map(node.getUpdateValue()), map(node.getUpdateValue().getType()), ptr).or();
         insn.align(valueHandle.getValueType().getAlign());
-        insn.ordering(getOC(node.getAtomicityMode()));
+        insn.ordering(getOC(node.getReadAccessMode().combinedWith(node.getWriteAccessMode())));
         return insn.asLocal();
     }
 
@@ -643,7 +643,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         LLValue ptr = valueHandle.accept(GET_HANDLE_POINTER_VALUE, this);
         AtomicRmw insn = builder.atomicrmw(map(valueHandle.getPointerType()), map(node.getUpdateValue()), map(node.getUpdateValue().getType()), ptr).xor();
         insn.align(valueHandle.getValueType().getAlign());
-        insn.ordering(getOC(node.getAtomicityMode()));
+        insn.ordering(getOC(node.getReadAccessMode().combinedWith(node.getWriteAccessMode())));
         return insn.asLocal();
     }
 
@@ -653,7 +653,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         LLValue ptr = valueHandle.accept(GET_HANDLE_POINTER_VALUE, this);
         AtomicRmw insn = builder.atomicrmw(map(valueHandle.getPointerType()), map(node.getUpdateValue()), map(node.getUpdateValue().getType()), ptr).xchg();
         insn.align(valueHandle.getValueType().getAlign());
-        insn.ordering(getOC(node.getAtomicityMode()));
+        insn.ordering(getOC(node.getReadAccessMode().combinedWith(node.getWriteAccessMode())));
         return insn.asLocal();
     }
 

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
@@ -97,9 +97,9 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         BasicBlockBuilder b = param.getBlockBuilder();
         Value copiedUpdate = param.copyValue(node.getUpdateValue());
         if (origHandle.getValueType() instanceof BooleanType bt && copyHandle.getValueType() instanceof IntegerType it) {
-            return b.truncate(b.getAndBitwiseAnd(copyHandle, b.extend(copiedUpdate, it), node.getAtomicityMode()), bt);
+            return b.truncate(b.getAndBitwiseAnd(copyHandle, b.extend(copiedUpdate, it), node.getReadAccessMode(), node.getWriteAccessMode()), bt);
         } else {
-            return b.getAndBitwiseAnd(copyHandle, copiedUpdate, node.getAtomicityMode());
+            return b.getAndBitwiseAnd(copyHandle, copiedUpdate, node.getReadAccessMode(), node.getWriteAccessMode());
         }
     }
 
@@ -111,9 +111,9 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         BasicBlockBuilder b = param.getBlockBuilder();
         Value copiedUpdate = param.copyValue(node.getUpdateValue());
         if (origHandle.getValueType() instanceof BooleanType bt && copyHandle.getValueType() instanceof IntegerType it) {
-            return b.truncate(b.getAndBitwiseNand(copyHandle, b.extend(copiedUpdate, it), node.getAtomicityMode()), bt);
+            return b.truncate(b.getAndBitwiseNand(copyHandle, b.extend(copiedUpdate, it), node.getReadAccessMode(), node.getWriteAccessMode()), bt);
         } else {
-            return b.getAndBitwiseNand(copyHandle, copiedUpdate, node.getAtomicityMode());
+            return b.getAndBitwiseNand(copyHandle, copiedUpdate, node.getReadAccessMode(), node.getWriteAccessMode());
         }
     }
 
@@ -125,9 +125,9 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         BasicBlockBuilder b = param.getBlockBuilder();
         Value copiedUpdate = param.copyValue(node.getUpdateValue());
         if (origHandle.getValueType() instanceof BooleanType bt && copyHandle.getValueType() instanceof IntegerType it) {
-            return b.truncate(b.getAndBitwiseOr(copyHandle, b.extend(copiedUpdate, it), node.getAtomicityMode()), bt);
+            return b.truncate(b.getAndBitwiseOr(copyHandle, b.extend(copiedUpdate, it), node.getReadAccessMode(), node.getWriteAccessMode()), bt);
         } else {
-            return b.getAndBitwiseOr(copyHandle, copiedUpdate, node.getAtomicityMode());
+            return b.getAndBitwiseOr(copyHandle, copiedUpdate, node.getReadAccessMode(), node.getWriteAccessMode());
         }
     }
 
@@ -139,9 +139,9 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         BasicBlockBuilder b = param.getBlockBuilder();
         Value copiedUpdate = param.copyValue(node.getUpdateValue());
         if (origHandle.getValueType() instanceof BooleanType bt && copyHandle.getValueType() instanceof IntegerType it) {
-            return b.truncate(b.getAndBitwiseXor(copyHandle, b.extend(copiedUpdate, it), node.getAtomicityMode()), bt);
+            return b.truncate(b.getAndBitwiseXor(copyHandle, b.extend(copiedUpdate, it), node.getReadAccessMode(), node.getWriteAccessMode()), bt);
         } else {
-            return b.getAndBitwiseXor(copyHandle, copiedUpdate, node.getAtomicityMode());
+            return b.getAndBitwiseXor(copyHandle, copiedUpdate, node.getReadAccessMode(), node.getWriteAccessMode());
         }
     }
 
@@ -153,9 +153,9 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         BasicBlockBuilder b = param.getBlockBuilder();
         Value copiedUpdate = param.copyValue(node.getUpdateValue());
         if (origHandle.getValueType() instanceof BooleanType bt && copyHandle.getValueType() instanceof IntegerType it) {
-            return b.truncate(b.getAndSet(copyHandle, b.extend(copiedUpdate, it), node.getAtomicityMode()), bt);
+            return b.truncate(b.getAndSet(copyHandle, b.extend(copiedUpdate, it), node.getReadAccessMode(), node.getWriteAccessMode()), bt);
         } else {
-            return b.getAndSet(copyHandle, copiedUpdate, node.getAtomicityMode());
+            return b.getAndSet(copyHandle, copiedUpdate, node.getReadAccessMode(), node.getWriteAccessMode());
         }
     }
 }

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
@@ -73,7 +73,7 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         Value copiedUpdate = param.copyValue(node.getUpdateValue());
         BasicBlockBuilder b = param.getBlockBuilder();
         if (origHandle.getValueType() instanceof BooleanType bt && copyHandle.getValueType() instanceof IntegerType it) {
-            Value result = b.cmpAndSwap(copyHandle, b.extend(copiedExpect, it), b.extend(copiedUpdate, it), node.getSuccessAtomicityMode(), node.getFailureAtomicityMode(), node.getStrength());
+            Value result = b.cmpAndSwap(copyHandle, b.extend(copiedExpect, it), b.extend(copiedUpdate, it), node.getReadAccessMode(), node.getWriteAccessMode(), node.getStrength());
             // the result is a { i8, i1 } if the field is boolean
             // we need to change to a { i1, i1 }
             LiteralFactory lf = ctxt.getLiteralFactory();
@@ -85,7 +85,7 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
             result = b.insertMember(result, newType.getMember(1), resultFlag);
             return result;
         } else {
-            return b.cmpAndSwap(copyHandle, copiedExpect, copiedUpdate, node.getSuccessAtomicityMode(), node.getFailureAtomicityMode(), node.getStrength());
+            return b.cmpAndSwap(copyHandle, copiedExpect, copiedUpdate, node.getReadAccessMode(), node.getWriteAccessMode(), node.getStrength());
         }
     }
 

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
@@ -56,7 +56,7 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         ValueHandle origHandle = node.getValueHandle();
         ValueHandle copyHandle = param.copyValueHandle(origHandle);
         BasicBlockBuilder b = param.getBlockBuilder();
-        Value loaded = b.load(copyHandle, node.getMode());
+        Value loaded = b.load(copyHandle, node.getAccessMode());
         if (origHandle.getValueType() instanceof BooleanType bt && copyHandle.getValueType() instanceof IntegerType) {
             return b.truncate(loaded, bt);
         } else {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
@@ -47,7 +47,7 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
         if (origHandle.getValueType() instanceof BooleanType && copyHandle.getValueType() instanceof IntegerType it) {
             copiedValue = b.extend(copiedValue, it);
         }
-        return b.store(copyHandle, copiedValue, node.getMode());
+        return b.store(copyHandle, copiedValue, node.getAccessMode());
     }
 
     @Override

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
@@ -22,6 +22,7 @@ import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueHandleVisitor;
 import org.qbicc.graph.VirtualMethodElementHandle;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
@@ -58,11 +59,11 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
     }
 
     @Override
-    public Value load(ValueHandle handle, MemoryAtomicityMode mode) {
+    public Value load(ValueHandle handle, ReadAccessMode accessMode) {
         if (handle instanceof CurrentThread ct) {
             return parameter(ct.getValueType(), "thr", 0);
         }
-        return super.load(handle, mode);
+        return super.load(handle, accessMode);
     }
 
     @Override

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstantDefiningBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstantDefiningBasicBlockBuilder.java
@@ -9,11 +9,11 @@ import org.qbicc.driver.Driver;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.CastValue;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
-import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.StaticField;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.ConstantLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.machine.probe.CProbe;
@@ -51,7 +51,7 @@ public class ConstantDefiningBasicBlockBuilder extends DelegatingBasicBlockBuild
     }
 
     @Override
-    public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+    public Node store(ValueHandle handle, Value value, WriteAccessMode accessMode) {
         Value test = value;
         while (test instanceof CastValue) {
             test = ((CastValue) test).getInput();
@@ -69,7 +69,7 @@ public class ConstantDefiningBasicBlockBuilder extends DelegatingBasicBlockBuild
             ctxt.error(getLocation(), "Compilation constants must be static final fields");
             return nop();
         }
-        return super.store(handle, value, mode);
+        return super.store(handle, value, accessMode);
     }
 
     private void processConstant(final FieldElement fieldElement) {

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/InitializedStaticFieldBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/InitializedStaticFieldBasicBlockBuilder.java
@@ -3,10 +3,10 @@ package org.qbicc.plugin.opt;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
-import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.StaticField;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.type.definition.element.FieldElement;
 
@@ -19,7 +19,7 @@ public class InitializedStaticFieldBasicBlockBuilder extends DelegatingBasicBloc
     }
 
     @Override
-    public Value load(ValueHandle handle, MemoryAtomicityMode mode) {
+    public Value load(ValueHandle handle, ReadAccessMode accessMode) {
         if (handle instanceof StaticField) {
             final FieldElement fieldElement = ((StaticField) handle).getVariableElement();
             if (fieldElement.isReallyFinal()) {
@@ -30,6 +30,6 @@ public class InitializedStaticFieldBasicBlockBuilder extends DelegatingBasicBloc
                 }
             }
         }
-        return getDelegate().load(handle, mode);
+        return getDelegate().load(handle, accessMode);
     }
 }

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
@@ -14,7 +14,6 @@ import org.qbicc.graph.CmpAndSwap;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.ElementOf;
 import org.qbicc.graph.MemberOf;
-import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
@@ -68,57 +67,57 @@ public class LocalMemoryTrackingBasicBlockBuilder extends DelegatingBasicBlockBu
     }
 
     @Override
-    public Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndAdd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndAdd(target, update, atomicityMode);
+        return super.getAndAdd(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseAnd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseAnd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndBitwiseAnd(target, update, atomicityMode);
+        return super.getAndBitwiseAnd(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseNand(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseNand(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndBitwiseNand(target, update, atomicityMode);
+        return super.getAndBitwiseNand(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseOr(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseOr(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndBitwiseOr(target, update, atomicityMode);
+        return super.getAndBitwiseOr(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseXor(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseXor(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndBitwiseXor(target, update, atomicityMode);
+        return super.getAndBitwiseXor(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSet(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSet(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndSet(target, update, atomicityMode);
+        return super.getAndSet(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSetMax(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSetMax(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndSetMax(target, update, atomicityMode);
+        return super.getAndSetMax(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSetMin(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSetMin(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndSetMin(target, update, atomicityMode);
+        return super.getAndSetMin(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSub(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         knownValues.clear();
-        return super.getAndSub(target, update, atomicityMode);
+        return super.getAndSub(target, update, readMode, writeMode);
     }
 
     @Override

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
@@ -60,11 +60,11 @@ public class LocalMemoryTrackingBasicBlockBuilder extends DelegatingBasicBlockBu
     }
 
     @Override
-    public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+    public Node store(ValueHandle handle, Value value, WriteAccessMode accessMode) {
         ValueHandle root = findRoot(handle);
         knownValues.keySet().removeIf(k -> ! hasSameRoot(k, root));
         knownValues.put(handle, value);
-        return super.store(handle, value, mode);
+        return super.store(handle, value, accessMode);
     }
 
     @Override

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
@@ -17,6 +17,7 @@ import org.qbicc.graph.Node;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueHandleVisitor;
+import org.qbicc.graph.atomic.GlobalAccessMode;
 
 /**
  *
@@ -122,7 +123,7 @@ public class LocalMemoryTrackingBasicBlockBuilder extends DelegatingBasicBlockBu
     }
 
     @Override
-    public Node fence(MemoryAtomicityMode fenceType) {
+    public Node fence(GlobalAccessMode fenceType) {
         knownValues.clear();
         return super.fence(fenceType);
     }

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
@@ -22,6 +22,7 @@ import org.qbicc.graph.ValueHandleVisitor;
 import org.qbicc.graph.atomic.AccessMode;
 import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 
 /**
  *
@@ -121,9 +122,9 @@ public class LocalMemoryTrackingBasicBlockBuilder extends DelegatingBasicBlockBu
     }
 
     @Override
-    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, MemoryAtomicityMode successMode, MemoryAtomicityMode failureMode, CmpAndSwap.Strength strength) {
+    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength) {
         knownValues.clear();
-        return super.cmpAndSwap(target, expect, update, successMode, failureMode, strength);
+        return super.cmpAndSwap(target, expect, update, readMode, writeMode, strength);
     }
 
     @Override

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
@@ -13,6 +13,7 @@ import org.qbicc.graph.StaticField;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.type.definition.element.FieldElement;
@@ -77,9 +78,9 @@ public class AccessorBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     @Override
-    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, MemoryAtomicityMode successMode, MemoryAtomicityMode failureMode, CmpAndSwap.Strength strength) {
+    public Value cmpAndSwap(ValueHandle target, Value expect, Value update, ReadAccessMode readMode, WriteAccessMode writeMode, CmpAndSwap.Strength strength) {
         checkAtomicAccessor(target);
-        return super.cmpAndSwap(target, expect, update, successMode, failureMode, strength);
+        return super.cmpAndSwap(target, expect, update, readMode, writeMode, strength);
     }
 
     @Override

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
@@ -1,5 +1,7 @@
 package org.qbicc.plugin.patcher;
 
+import static org.qbicc.graph.atomic.AccessModes.*;
+
 import java.util.List;
 import java.util.Map;
 
@@ -7,7 +9,6 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.CmpAndSwap;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
-import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.StaticField;
 import org.qbicc.graph.Value;
@@ -84,65 +85,65 @@ public class AccessorBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     @Override
-    public Value getAndAdd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndAdd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndAdd(target, update, atomicityMode);
+        return super.getAndAdd(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseAnd(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseAnd(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndBitwiseAnd(target, update, atomicityMode);
+        return super.getAndBitwiseAnd(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseNand(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseNand(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndBitwiseNand(target, update, atomicityMode);
+        return super.getAndBitwiseNand(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseOr(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseOr(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndBitwiseOr(target, update, atomicityMode);
+        return super.getAndBitwiseOr(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndBitwiseXor(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndBitwiseXor(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndBitwiseXor(target, update, atomicityMode);
+        return super.getAndBitwiseXor(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSet(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSet(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (target instanceof StaticField sf && getAccessor(sf.getVariableElement()) != null) {
-            if (atomicityMode == MemoryAtomicityMode.NONE || atomicityMode == MemoryAtomicityMode.UNORDERED) {
-                Value loaded = load(target, atomicityMode);
-                store(target, update, atomicityMode);
+            if (GlobalPlain.includes(readMode) || GlobalPlain.includes(writeMode)) {
+                Value loaded = load(target, readMode);
+                store(target, update, writeMode);
                 return loaded;
             } else {
                 atomicNotAllowed();
             }
         }
-        return super.getAndSet(target, update, atomicityMode);
+        return super.getAndSet(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSetMax(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSetMax(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndSetMax(target, update, atomicityMode);
+        return super.getAndSetMax(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSetMin(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSetMin(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndSetMin(target, update, atomicityMode);
+        return super.getAndSetMin(target, update, readMode, writeMode);
     }
 
     @Override
-    public Value getAndSub(ValueHandle target, Value update, MemoryAtomicityMode atomicityMode) {
+    public Value getAndSub(ValueHandle target, Value update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         checkAtomicAccessor(target);
-        return super.getAndSub(target, update, atomicityMode);
+        return super.getAndSub(target, update, readMode, writeMode);
     }
 
     private void checkAtomicAccessor(final ValueHandle target) {

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
@@ -12,6 +12,7 @@ import org.qbicc.graph.Node;
 import org.qbicc.graph.StaticField;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.type.definition.element.FieldElement;
@@ -42,7 +43,7 @@ public class AccessorBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     @Override
-    public Value load(ValueHandle handle, MemoryAtomicityMode mode) {
+    public Value load(ValueHandle handle, ReadAccessMode accessMode) {
         if (handle instanceof StaticField staticField) {
             FieldElement field = staticField.getVariableElement();
             VmObject accessor = getAccessor(field);
@@ -56,7 +57,7 @@ public class AccessorBasicBlockBuilder extends DelegatingBasicBlockBuilder {
                 return fb.call(fb.virtualMethodOf(lf.literalOf(accessor), accessor.getVmClass().getTypeDefinition().getDescriptor(), getter, desc), List.of());
             }
         }
-        return super.load(handle, mode);
+        return super.load(handle, accessMode);
     }
 
     @Override

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorBasicBlockBuilder.java
@@ -62,7 +62,7 @@ public class AccessorBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     @Override
-    public Node store(ValueHandle handle, Value value, MemoryAtomicityMode mode) {
+    public Node store(ValueHandle handle, Value value, WriteAccessMode accessMode) {
         if (handle instanceof StaticField staticField) {
             FieldElement field = staticField.getVariableElement();
             VmObject accessor = getAccessor(field);
@@ -74,7 +74,7 @@ public class AccessorBasicBlockBuilder extends DelegatingBasicBlockBuilder {
                 return fb.call(fb.virtualMethodOf(lf.literalOf(accessor), accessor.getVmClass().getTypeDefinition().getDescriptor(), "set", desc), List.of(value));
             }
         }
-        return super.store(handle, value, mode);
+        return super.store(handle, value, accessMode);
     }
 
     @Override


### PR DESCRIPTION
Our current usage of access modes are heavily based on what is provided by LLVM and follow a rather haphazard mix of Java and LLVM memory model semantics.  This is an attempt to clean up and organize the access modes, as a prelude to not only the corresponding cleanup in the LLVM-compatible BBB, but also as a prelude to correctly implementing the various `Unsafe`/`VarHandle`/`Atomic*` classes by way of new methods coming on to `ptr` that @theresa-m's PR #772 alludes to.

A more detailed writeup is forthcoming in a discussion topic but I wanted to get the starter code posted in a draft PR to start to socialize the concepts a bit.  The primary feature of this code change is using Java's type system to enforce usage of specific  categories of access modes in specific situations; for example, a `load` operation would require a mode that implements at least `ReadAccessMode`.

As a final note, right now, `CmpAndSwap` is specified in terms of a "success" mode and "failure" mode, and `GetAndSet*` are specified in terms of a single mode that implicitly applies (in different ways) to both the read and write operation. However, the JMM specification (at least the parts defined in the JDK) generally specify CAS and RMW operations in terms of the read and (conditional in the case of CAS) write side.  So the expectation is that we'd do the same here, and (in the RMW case) interpret the combination of read and write operation mode to emit the correct equivalent-or-next-strongest LLVM mode.  In the CAS case this generally amounts to translating the combination of `XxxAcquire` and `XxxRelease` to `XxxAcqRel`.