### PR TITLE
restructure header initialization to avoid doing it twice

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1865,7 +1865,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         VmClassLoaderImpl cl = thread.vm.getClassLoaderForContext(enclosingType.getContext());
         VmClassImpl clazz = cl.loadClass(node.getClassObjectType().getDefinition().getInternalName());
         clazz.initialize(thread);
-        return clazz.newInstance();
+        return thread.vm.manuallyInitialize(clazz.newInstance());
     }
 
     @Override
@@ -1881,7 +1881,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     private VmArrayImpl newArray(VmThreadImpl thread, ArrayObjectType arrayType, int size) {
         VmClassImpl clazz = requireClass(arrayType);
         if (clazz instanceof VmArrayClassImpl) {
-            return ((VmArrayClassImpl) clazz).newInstance(size);
+            return thread.vm.manuallyInitialize(((VmArrayClassImpl) clazz).newInstance(size));
         } else {
             throw unsupportedType();
         }

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -53,6 +53,7 @@ import org.qbicc.plugin.constants.ConstantBasicBlockBuilder;
 import org.qbicc.plugin.conversion.MethodCallFixupBasicBlockBuilder;
 import org.qbicc.plugin.conversion.NumericalConversionBasicBlockBuilder;
 import org.qbicc.plugin.core.CoreAnnotationTypeBuilder;
+import org.qbicc.plugin.coreclasses.ArrayLengthBasicBlockBuilder;
 import org.qbicc.plugin.coreclasses.BasicInitializationBasicBlockBuilder;
 import org.qbicc.plugin.coreclasses.BasicInitializationManualInitializer;
 import org.qbicc.plugin.coreclasses.CoreClasses;
@@ -394,7 +395,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ClassInitializingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ConstantDefiningBasicBlockBuilder::createIfNeeded);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ConstantBasicBlockBuilder::new);
-                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, BasicInitializationBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, ArrayLengthBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, MethodCallFixupBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ADD, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
                                 if (optMemoryTracking) {
@@ -422,7 +423,6 @@ public class Main implements Callable<DiagnosticContext> {
                                 }
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, IntrinsicBasicBlockBuilder::createForAnalyzePhase);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, InitializedStaticFieldBasicBlockBuilder::new);
-                                builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, BasicInitializationBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, ThreadLocalBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
                                 if (optMemoryTracking) {
@@ -459,6 +459,7 @@ public class Main implements Callable<DiagnosticContext> {
 
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ThrowLoweringBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, BasicInitializationBasicBlockBuilder::new);
                                 if (nogc) {
                                     builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, NoGcBasicBlockBuilder::new);
                                 }

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/ArrayLengthBasicBlockBuilder.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/ArrayLengthBasicBlockBuilder.java
@@ -1,0 +1,26 @@
+package org.qbicc.plugin.coreclasses;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.type.ArrayObjectType;
+import org.qbicc.type.ValueType;
+
+public class ArrayLengthBasicBlockBuilder extends DelegatingBasicBlockBuilder {
+    private final CompilationContext ctxt;
+
+    public ArrayLengthBasicBlockBuilder(CompilationContext ctxt, BasicBlockBuilder delegate) {
+        super(delegate);
+        this.ctxt = ctxt;
+    }
+
+    @Override
+    public ValueHandle lengthOf(ValueHandle array) {
+        ValueType arrayType = array.getValueType();
+        if (arrayType instanceof ArrayObjectType) {
+            return instanceFieldOf(array, CoreClasses.get(ctxt).getArrayLengthField());
+        }
+        return super.lengthOf(array);
+    }
+}

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/BasicInitializationBasicBlockBuilder.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/BasicInitializationBasicBlockBuilder.java
@@ -28,15 +28,6 @@ public class BasicInitializationBasicBlockBuilder extends DelegatingBasicBlockBu
     }
 
     @Override
-    public ValueHandle lengthOf(ValueHandle array) {
-        ValueType arrayType = array.getValueType();
-        if (arrayType instanceof ArrayObjectType) {
-            return instanceFieldOf(array, CoreClasses.get(ctxt).getArrayLengthField());
-        }
-        return super.lengthOf(array);
-    }
-
-    @Override
     public Value new_(ClassObjectType type) {
         Value allocated = super.new_(type);
         initializeObjectHeader(CoreClasses.get(ctxt), referenceHandle(allocated), ctxt.getLiteralFactory().literalOfType(type));

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecksBasicBlockBuilder.java
@@ -362,7 +362,7 @@ public class RuntimeChecksBasicBlockBuilder extends DelegatingBasicBlockBuilder 
         if_(isLt(index, zero), throwIt, notNegative);
         try {
             begin(notNegative);
-            final Value length = load(getFirstBuilder().lengthOf(array), MemoryAtomicityMode.UNORDERED);
+            final Value length = load(instanceFieldOf(array, CoreClasses.get(ctxt).getArrayLengthField()), MemoryAtomicityMode.UNORDERED);
             if_(isGe(index, length), throwIt, goAhead);
         } catch (BlockEarlyTermination ignored) {
             // continue


### PR DESCRIPTION
A fairly minimal change that fixes the double-initialization problem (https://github.com/qbicc/qbicc/pull/904#issuecomment-985192707).

I'm tempted to attempt a cleanup where we push `manuallyInitialize` inside of the implementation of VmClass.newInstance to DRY things up... any a priori reason that won't work?