### PR TITLE
use camelCase names for runtime helper methods and intrinsics

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -444,7 +444,7 @@ public final class VmImpl implements Vm {
             // VMHelpers
             VmClassImpl vmHelpersClass = bootstrapClassLoader.loadClass("org/qbicc/runtime/main/VMHelpers");
 
-            vmHelpersClass.registerInvokable("getClass", (thread, target, args) -> ((VmObjectImpl) args.get(0)).getVmClass());
+            vmHelpersClass.registerInvokable("getClass", 1, (thread, target, args) -> ((VmObjectImpl) args.get(0)).getVmClass());
             vmHelpersClass.registerInvokable("classForName", (thread, target, args) -> {
                 VmClassLoaderImpl classLoader = (VmClassLoaderImpl) args.get(2);
                 if (classLoader == null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -444,7 +444,7 @@ public final class VmImpl implements Vm {
             // VMHelpers
             VmClassImpl vmHelpersClass = bootstrapClassLoader.loadClass("org/qbicc/runtime/main/VMHelpers");
 
-            vmHelpersClass.registerInvokable("get_class", (thread, target, args) -> ((VmObjectImpl) args.get(0)).getVmClass());
+            vmHelpersClass.registerInvokable("getClass", (thread, target, args) -> ((VmObjectImpl) args.get(0)).getVmClass());
             vmHelpersClass.registerInvokable("classForName", (thread, target, args) -> {
                 VmClassLoaderImpl classLoader = (VmClassLoaderImpl) args.get(2);
                 if (classLoader == null) {
@@ -477,8 +477,8 @@ public final class VmImpl implements Vm {
             // ObjectModel
             VmClassImpl compIntr = bootstrapClassLoader.loadClass("org/qbicc/runtime/main/CompilerIntrinsics");
 
-            compIntr.registerInvokable("type_id_of", (thread, target, args) -> ((VmObjectImpl) args.get(0)).getObjectTypeId());
-            compIntr.registerInvokable("get_type_id_from_class", (thread, target, args) -> ((VmClassImpl) args.get(0)).getInstanceObjectTypeId());
+            compIntr.registerInvokable("typeIdOf", (thread, target, args) -> ((VmObjectImpl) args.get(0)).getObjectTypeId());
+            compIntr.registerInvokable("getTypeIdFromClass", (thread, target, args) -> ((VmClassImpl) args.get(0)).getInstanceObjectTypeId());
 
             // Unsafe
             VmClassImpl unsafeClass = bootstrapClassLoader.loadClass("jdk/internal/misc/Unsafe");

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -444,7 +444,7 @@ public final class VmImpl implements Vm {
             // VMHelpers
             VmClassImpl vmHelpersClass = bootstrapClassLoader.loadClass("org/qbicc/runtime/main/VMHelpers");
 
-            vmHelpersClass.registerInvokable("getClass", 1, (thread, target, args) -> ((VmObjectImpl) args.get(0)).getVmClass());
+            vmHelpersClass.registerInvokable("getClassFromObject", 1, (thread, target, args) -> ((VmObjectImpl) args.get(0)).getVmClass());
             vmHelpersClass.registerInvokable("classForName", (thread, target, args) -> {
                 VmClassLoaderImpl classLoader = (VmClassLoaderImpl) args.get(2);
                 if (classLoader == null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -475,10 +475,10 @@ public final class VmImpl implements Vm {
             });
 
             // ObjectModel
-            VmClassImpl objectModelClass = bootstrapClassLoader.loadClass("org/qbicc/runtime/main/ObjectModel");
+            VmClassImpl compIntr = bootstrapClassLoader.loadClass("org/qbicc/runtime/main/CompilerIntrinsics");
 
-            objectModelClass.registerInvokable("type_id_of", (thread, target, args) -> ((VmObjectImpl) args.get(0)).getObjectTypeId());
-            objectModelClass.registerInvokable("get_type_id_from_class", (thread, target, args) -> ((VmClassImpl) args.get(0)).getInstanceObjectTypeId());
+            compIntr.registerInvokable("type_id_of", (thread, target, args) -> ((VmObjectImpl) args.get(0)).getObjectTypeId());
+            compIntr.registerInvokable("get_type_id_from_class", (thread, target, args) -> ((VmClassImpl) args.get(0)).getInstanceObjectTypeId());
 
             // Unsafe
             VmClassImpl unsafeClass = bootstrapClassLoader.loadClass("jdk/internal/misc/Unsafe");

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/RuntimeMethodFinder.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/RuntimeMethodFinder.java
@@ -15,11 +15,13 @@ public class RuntimeMethodFinder {
 
     final LoadedTypeDefinition VMHelpers;
     final LoadedTypeDefinition ObjectModel;
+    final LoadedTypeDefinition CompilerIntrinsics;
 
     private RuntimeMethodFinder(CompilationContext ctxt) {
         this.ctxt = ctxt;
         this.VMHelpers = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/VMHelpers").load();
         this.ObjectModel = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/ObjectModel").load();
+        this.CompilerIntrinsics = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/CompilerIntrinsics").load();
     }
 
     public static RuntimeMethodFinder get(CompilationContext ctxt) {
@@ -42,6 +44,10 @@ public class RuntimeMethodFinder {
         idx = ObjectModel.findMethodIndex(e -> methodName.equals(e.getName()));
         if (idx != -1) {
             return ObjectModel.getMethod(idx);
+        }
+        idx = CompilerIntrinsics.findMethodIndex(e -> methodName.equals(e.getName()));
+        if (idx != -1) {
+            return CompilerIntrinsics.getMethod(idx);
         }
         ctxt.error("Can't find the runtime helper method %s", methodName);
         return null;

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/InstanceOfCheckCastBasicBlockBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/InstanceOfCheckCastBasicBlockBuilder.java
@@ -138,7 +138,7 @@ public class InstanceOfCheckCastBasicBlockBuilder extends DelegatingBasicBlockBu
             if (!inlinedTest) {
                 String helperName;
                 if (kind.equals(CheckCast.CastType.Cast)) {
-                    helperName = toType instanceof TypeLiteral ? "checkcast_typeId" : "checkcast_class";
+                    helperName = toType instanceof TypeLiteral ? "checkcastTypeId" : "checkcastClass";
                 } else {
                     helperName = "arrayStoreCheck";
                 }
@@ -202,7 +202,7 @@ public class InstanceOfCheckCastBasicBlockBuilder extends DelegatingBasicBlockBu
             final BlockLabel passInline = new BlockLabel();
             boolean inlinedTest = generateTypeTest(input, expectedType, expectedDimensions, passInline, fail);
             if (!inlinedTest) {
-                MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("instanceof_typeId");
+                MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("instanceofTypeId");
                 passResult = getFirstBuilder().call(getFirstBuilder().staticMethod(helper, helper.getDescriptor(), helper.getType()),
                     List.of(input, lf.literalOfType(expectedType), lf.literalOf(ctxt.getTypeSystem().getUnsignedInteger8Type(), expectedDimensions)));
                 passLabel = notNull;
@@ -233,10 +233,10 @@ public class InstanceOfCheckCastBasicBlockBuilder extends DelegatingBasicBlockBu
         RuntimeMethodFinder methodFinder = RuntimeMethodFinder.get(ctxt);
         if (dimensions.isDefEq(ctxt.getLiteralFactory().literalOf(ctxt.getTypeSystem().getUnsignedInteger8Type(), 0))) {
             // call the intrinsic directly, inlining the calculation
-            methodElement = methodFinder.getMethod("get_class_from_type_id_simple");
+            methodElement = methodFinder.getMethod("getClassFromTypeIdSimple");
             return notNull(getFirstBuilder().call(getFirstBuilder().staticMethod(methodElement, methodElement.getDescriptor(), methodElement.getType()), List.of(typeId)));
         } else {
-            methodElement = methodFinder.getMethod("classof_from_typeid");
+            methodElement = methodFinder.getMethod("getClassFromTypeId");
             return notNull(getFirstBuilder().call(getFirstBuilder().staticMethod(methodElement, methodElement.getDescriptor(), methodElement.getType()), List.of(typeId, dimensions)));
         }
     }

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/LowerClassInitCheckBlockBuilder.java
@@ -59,7 +59,7 @@ public class LowerClassInitCheckBlockBuilder extends DelegatingBasicBlockBuilder
         if_(isEq(state, lf.literalOf(0)), callInit, goAhead);
         try {
             begin(callInit);
-            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("initialize_class");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("initializeClass");
             BasicBlockBuilder fb = getFirstBuilder();
             fb.call(fb.staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(fb.load(fb.currentThread(), MemoryAtomicityMode.NONE), typeId));
             goto_(goAhead);

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -313,7 +313,7 @@ public final class CoreIntrinsics {
         intrinsics.registerIntrinsic(jlcDesc, "desiredAssertionStatus", emptyToBool, desiredAssertionStatus);
         intrinsics.registerIntrinsic(jlcDesc, "initClassName", emptyToString, initClassName);
         intrinsics.registerIntrinsic(jlcDesc, "getPrimitiveClass", stringToClass, getPrimitiveClass);
-        intrinsics.registerIntrinsic(Phase.LOWER, jlcDesc, "getSuperClass", emptyToClass, getSuperclass);
+        intrinsics.registerIntrinsic(Phase.LOWER, jlcDesc, "getSuperclass", emptyToClass, getSuperclass);
         intrinsics.registerIntrinsic(Phase.LOWER, jlcDesc, "isArray", emptyToBool, isArray);
         intrinsics.registerIntrinsic(Phase.LOWER, jlcDesc, "isInterface", emptyToBool, isInterface);
         intrinsics.registerIntrinsic(Phase.LOWER, jlcDesc, "isPrimitive", emptyToBool, isPrimitive);
@@ -1035,7 +1035,7 @@ public final class CoreIntrinsics {
         MethodDescriptor getClassDesc = MethodDescriptor.synthesize(classContext, jlcDesc, List.of());
 
         InstanceIntrinsic getClassIntrinsic = (builder, instance, target, arguments) -> {
-            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("getClass");
+            MethodElement helper = RuntimeMethodFinder.get(ctxt).getMethod("getClassFromObject");
             return builder.getFirstBuilder().call(builder.staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(instance));
         };
 

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -638,7 +638,7 @@ public final class CoreIntrinsics {
 
             /* pass threadWrapper as function_ptr - TODO this will eventually be replaced by a call to CNative.addr_of_function */
             MethodDescriptor threadWrapperDesc = MethodDescriptor.synthesize(classContext, voidPtrDesc, List.of(voidPtrDesc));
-            ValueHandle threadWrapperValueHandle = builder.staticMethod(vmHelpersDesc, "threadWrapper", threadWrapperDesc);
+            ValueHandle threadWrapperValueHandle = builder.staticMethod(vmHelpersDesc, "threadWrapper", threadWrapperDesc); // TODO: Once qbicc 0.3.0 comes out, change vmHelpersDesc to compIntrDesc
             Value threadWrapperFunctionPointer = builder.addressOf(threadWrapperValueHandle);
 
             /* call threadWrapper with null parameter so it does nothing - TODO this is a workaround to create a declares statement for threadWrapper in java.lang.Thread */

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
@@ -17,13 +17,13 @@ public class VMHelpersSetupHook implements Consumer<CompilationContext> {
         RuntimeMethodFinder methodFinder = RuntimeMethodFinder.get(ctxt);
         // Helpers for dynamic type checking
         ctxt.enqueue(methodFinder.getMethod("arrayStoreCheck"));
-        ctxt.enqueue(methodFinder.getMethod("checkcast_class"));
-        ctxt.enqueue(methodFinder.getMethod("checkcast_typeId"));
-        ctxt.enqueue(methodFinder.getMethod("instanceof_class"));
-        ctxt.enqueue(methodFinder.getMethod("instanceof_typeId"));
-        ctxt.enqueue(methodFinder.getMethod("get_class"));
-        ctxt.enqueue(methodFinder.getMethod("classof_from_typeid"));
-        ctxt.enqueue(methodFinder.getMethod("get_superclass"));
+        ctxt.enqueue(methodFinder.getMethod("checkcastClass"));
+        ctxt.enqueue(methodFinder.getMethod("checkcastTypeId"));
+        ctxt.enqueue(methodFinder.getMethod("instanceofClass"));
+        ctxt.enqueue(methodFinder.getMethod("instanceofTypeId"));
+        ctxt.enqueue(methodFinder.getMethod("getClass"));
+        ctxt.enqueue(methodFinder.getMethod("getClassFromTypeId"));
+        ctxt.enqueue(methodFinder.getMethod("getSuperClass"));
 
         // Helpers to create and throw common runtime exceptions
         ctxt.registerEntryPoint(methodFinder.getMethod("raiseAbstractMethodError"));
@@ -37,14 +37,14 @@ public class VMHelpersSetupHook implements Consumer<CompilationContext> {
         ctxt.registerEntryPoint(methodFinder.getMethod("raiseUnsatisfiedLinkError"));
 
         // Object monitors
-        ctxt.enqueue(methodFinder.getMethod("monitor_enter"));
-        ctxt.enqueue(methodFinder.getMethod("monitor_exit"));
+        ctxt.enqueue(methodFinder.getMethod("monitorEnter"));
+        ctxt.enqueue(methodFinder.getMethod("monitorExit"));
 
         // class initialization
-        ctxt.enqueue(methodFinder.getMethod("initialize_class"));
+        ctxt.enqueue(methodFinder.getMethod("initializeClass"));
 
         // helper to create j.l.Class instance of an array class at runtime
-        ctxt.enqueue(methodFinder.getMethod("get_or_create_class_for_refarray"));
+        ctxt.enqueue(methodFinder.getMethod("getOrCreateClassForRefArray"));
 
         // java.lang.Thread
         ctxt.enqueue(methodFinder.getMethod("JLT_start0"));

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/VMHelpersSetupHook.java
@@ -21,7 +21,7 @@ public class VMHelpersSetupHook implements Consumer<CompilationContext> {
         ctxt.enqueue(methodFinder.getMethod("checkcastTypeId"));
         ctxt.enqueue(methodFinder.getMethod("instanceofClass"));
         ctxt.enqueue(methodFinder.getMethod("instanceofTypeId"));
-        ctxt.enqueue(methodFinder.getMethod("getClass"));
+        ctxt.enqueue(methodFinder.getMethod("getClassFromObject"));
         ctxt.enqueue(methodFinder.getMethod("getClassFromTypeId"));
         ctxt.enqueue(methodFinder.getMethod("getSuperClass"));
 

--- a/plugins/objectmonitor/src/main/java/org/qbicc/plugin/objectmonitor/ObjectMonitorBasicBlockBuilder.java
+++ b/plugins/objectmonitor/src/main/java/org/qbicc/plugin/objectmonitor/ObjectMonitorBasicBlockBuilder.java
@@ -16,8 +16,8 @@ import org.qbicc.type.definition.element.MethodElement;
 public class ObjectMonitorBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     private final CompilationContext ctxt;
 
-    private final String monitorEnterFunctionName = "monitor_enter";
-    private final String monitorExitFunctionName = "monitor_exit";
+    private final String monitorEnterFunctionName = "monitorEnter";
+    private final String monitorExitFunctionName = "monitorExit";
 
     public ObjectMonitorBasicBlockBuilder(CompilationContext ctxt, BasicBlockBuilder delegate) {
         super(delegate);

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -212,7 +212,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, ClassOf node) {
             if (visitUnknown(param, (Node)node)) {
-                MethodElement methodElement = RuntimeMethodFinder.get(param.ctxt).getMethod("classof_from_typeid");
+                MethodElement methodElement = RuntimeMethodFinder.get(param.ctxt).getMethod("getClassFromTypeId");
                 param.ctxt.enqueue(methodElement);
                 if (node.getInput() instanceof TypeLiteral tl && tl.getValue() instanceof ClassObjectType cot) {
                     param.analysis.processClassInitialization(cot.getDefinition().load());

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
@@ -2,9 +2,274 @@ package org.qbicc.runtime.main;
 
 import org.qbicc.runtime.CNative.*;
 import org.qbicc.runtime.Hidden;
+import org.qbicc.runtime.posix.PThread;
 import org.qbicc.runtime.stdc.Stdint.*;
 
+/**
+ * Intrinsics for emitting inline-asm like code sequences and
+ * for accessing implementation-dependent object header fields and
+ * compiler-generated global structures.
+ */
+@SuppressWarnings("unused")
 public class CompilerIntrinsics {
     @Hidden
     public static native Object emit_new_ref_array(type_id elemTypeId, uint8_t dimensions, int size);
+
+    /**
+     * TODO
+     * @param thread
+     * @param pthreadPtr
+     * @return
+     */
+    public static native boolean saveNativeThread(void_ptr thread, PThread.pthread_t_ptr pthreadPtr);
+
+    /**
+     * This intrinsic sets up and executes the `public void run()` of threadParam.
+     * @param threadParam - java.lang.Thread object that has been cast to a void pointer to be compatible with pthread_create
+     * @return null - this return value will not be used
+     */
+    public static native void_ptr threadWrapperNative(void_ptr threadParam);
+
+    /**
+     * Get the dimensionality for the represented type from a java.lang.Class instance.
+     * Classes and interfaces have dimensionality 0.
+     */
+    @Hidden
+    public static native uint8_t get_dimensions_from_class(Class<?> cls);
+
+    /**
+     * Get the concrete type ID for the represented type from a java.lang.Class instance.
+     */
+    @Hidden
+    public static native type_id get_type_id_from_class(Class<?> cls);
+
+    /**
+     * Get the java.lang.Class instance for the type ID.
+     */
+    @Hidden
+    public static native Class<?> get_class_from_type_id(type_id typeId, uint8_t dimensions);
+
+    /**
+     * Get the java.lang.Class instance for the type ID for non-array classes.
+     */
+    @Hidden
+    public static native Class<?> get_class_from_type_id_simple(type_id typeId);
+
+    /**
+     * Returns java.lang.Class instance representing array class of a given class
+     *
+     * @param componentClass
+     * @return instance of java.lang.Class
+     */
+    @Hidden
+    public static native Class<?> get_array_class_of(Class<?> componentClass);
+
+    /**
+     * Tries to atomically set the java.lang.Class#arrayClass field of a component class
+     * to a given array class
+     *
+     * @param componentClass
+     * @param arrayClass
+     * @return boolean true if atomic operation succeeds, false otherwise
+     */
+    @Hidden
+    public static native boolean set_array_class(Class<?> componentClass, Class<?> arrayClass);
+
+    /**
+     * Is the argument typeId the typeId for java.lang.Object?
+     */
+    @Hidden
+    public static native boolean is_java_lang_object(type_id typeId);
+
+    /**
+     * Is the argument typeId the typeId for java.lang.Cloneable?
+     */
+    @Hidden
+    public static native boolean is_java_lang_cloneable(type_id typeId);
+
+    /**
+     * Is the argument typeId the typeId for java.io.Serializable?
+     */
+    @Hidden
+    public static native boolean is_java_io_serializable(type_id typeId);
+
+    /**
+     * Is the argument typeId the typeId of a Class?
+     */
+    @Hidden
+    public static native boolean is_class(type_id typeId);
+
+    /**
+     * Is the argument typeId the typeId of an Interface?
+     */
+    @Hidden
+    public static native boolean is_interface(type_id typeId);
+
+    /**
+     * Is the argument typeId the typeId of a primitive array?
+     */
+    @Hidden
+    public static native boolean is_prim_array(type_id typeId);
+
+    /**
+     * Is the argument typeId the typeId of a primitive?
+     */
+    @Hidden
+    public static native boolean is_primitive(type_id typeId);
+
+    /**
+     * Is the argument typeId the typeId use for reference arrays?
+     */
+    @Hidden
+    public static native boolean is_reference_array(type_id typeId);
+
+    /**
+     * Returns the typeId used for reference arrays
+     */
+    @Hidden
+    public static native type_id get_reference_array_typeid();
+
+    /**
+     * Get the number of typeIds in the system.
+     * This will be 1 higher than the highest typeid
+     */
+    @Hidden
+    public static native type_id get_number_of_typeids();
+
+    /**
+     * Allocates an instance of java.lang.Class in the runtime heap
+     *
+     * @param name class name
+     * @param id class's type id
+     * @param dimension array dimension if the class is an array class, 0 otherwise
+     * @return instance of java.lang.Class
+     */
+    @Hidden
+    public static native Class<?> create_class(String name, type_id id, uint8_t dimension);
+
+    /**
+     * Get the concrete type ID value from the referenced object.  Note that all reference arrays will have the same
+     * type ID, which does not reflect the element type.
+     *
+     * @param reference the object reference (must not be {@code null})
+     * @return the type ID of the object
+     */
+    @Hidden
+    public static native type_id type_id_of(Object reference);
+
+    /**
+     * Get the dimensionality of the referenced array.
+     *
+     * @param arrayReference the array reference (must not be {@code null} and must be an Object[])
+     * @return the dimensionality of the array
+     */
+    @Hidden
+    public static native uint8_t dimensions_of(Object arrayReference); // Object not Object[] because we use this in the impl of cast
+
+    /**
+     * Get the element type ID value of the referenced array.
+     *
+     * @param arrayReference the array reference (must not be {@code null} and must be an Object[])
+     * @return the array element type ID
+     */
+    @Hidden
+    public static native type_id element_type_id_of(Object arrayReference); // Object not Object[] because we use this in the impl of cast
+
+    /**
+     * Get the maxTypeId assigned to subclasses of the argument typeId
+     */
+    @Hidden
+    public static native type_id max_subclass_type_id_of(type_id typeId);
+
+    /**
+     * Does a typeId implement the argument interface?
+     */
+    @Hidden
+    public static native boolean does_implement(type_id valueTypeId, type_id interfaceTypeId);
+
+    /**
+     * Call the class initializer for this class if it hasn't already been
+     * called.
+     *
+     * This operation is racy as the locking is managed by the ClinitState
+     * object in VMHelpers#initialize_class and should only be called by
+     * that method.
+     *
+     * @param typeId the class to initialize
+     */
+    @Hidden
+    public static native void call_class_initializer(type_id typeId);
+
+    /**
+     * Get the `flags` field from the qbicc_typeid_array for the given
+     * typeid.
+     *
+     * Flags are:
+     * 1 - has clinit method
+     * 2 - declares default methods
+     * 4 - has default methods
+     * See SupersDisplayTables.calculateTypeIdFlags() for definitive list.
+     *
+     * @param typeId the class to read the flags for
+     * @return the flags value
+     */
+    @Hidden
+    public static native int get_typeid_flags(type_id typeId);
+
+    /**
+     * Fetch the superclass `type_id` from the current `type_id`
+     * @param typeId an existing type_id, don't call this on Object's typeid
+     * @return superclass's type_id
+     */
+    @Hidden
+    public static native type_id get_superclass_typeid(type_id typeId);
+
+    @Hidden
+    public static native type_id get_first_interface_typeid();
+
+    @Hidden
+    public static native int get_number_of_bytes_in_interface_bits_array();
+
+    @Hidden
+    public static native byte get_byte_of_interface_bits(type_id typeId, int index);
+
+    /**
+     * Check the `clinit_states` native structure to see if this typeid is initialized.
+     *
+     * This is a fast check reading a bit in the structure.  A "true" value can be trusted
+     * as a fast path check while a "false" value requires the state-machine defined in
+     * VMHelpers.initialize_class() to validate the result and handle the transition.
+     *
+     * @return true if initialized.  False if the state machine needs to validate.
+     */
+    @Hidden
+    public static native boolean is_initialized(type_id typdId);
+
+    /**
+     * Set the class initialized.
+     *
+     * This should only be done by the MHelpers.initialize_class() statemachine
+     * @param typdId the class to mark initialized
+     */
+    @Hidden
+    public static native void set_initialized(type_id typdId);
+
+    /**
+     * Get the native object monitor (mutex) slot from the referenced object. These are intended for object monitor synchronization.
+     *
+     * @param reference the object reference (must not be {@code null})
+     * @return the pthread mutex of the object
+     */
+    @Hidden
+    public static native PThread.pthread_mutex_t_ptr get_nativeObjectMonitor(Object reference);
+
+    /**
+     * Set the native object monitor (mutex) for the referenced object. This method is atomic and will return true on success.
+     *
+     * @param reference the object reference (must not be {@code null})
+     * @param nom mutex for the referenced object (must not be {@code null})
+     * @return true if successful
+     */
+    @Hidden
+    public static native boolean set_nativeObjectMonitor(Object reference, PThread.pthread_mutex_t_ptr nom);
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
@@ -13,7 +13,7 @@ import org.qbicc.runtime.stdc.Stdint.*;
 @SuppressWarnings("unused")
 public class CompilerIntrinsics {
     @Hidden
-    public static native Object emit_new_ref_array(type_id elemTypeId, uint8_t dimensions, int size);
+    public static native Object emitNewReferenceArray(type_id elemTypeId, uint8_t dimensions, int size);
 
     /**
      * TODO
@@ -35,25 +35,25 @@ public class CompilerIntrinsics {
      * Classes and interfaces have dimensionality 0.
      */
     @Hidden
-    public static native uint8_t get_dimensions_from_class(Class<?> cls);
+    public static native uint8_t getDimensionsFromClass(Class<?> cls);
 
     /**
      * Get the concrete type ID for the represented type from a java.lang.Class instance.
      */
     @Hidden
-    public static native type_id get_type_id_from_class(Class<?> cls);
+    public static native type_id getTypeIdFromClass(Class<?> cls);
 
     /**
      * Get the java.lang.Class instance for the type ID.
      */
     @Hidden
-    public static native Class<?> get_class_from_type_id(type_id typeId, uint8_t dimensions);
+    public static native Class<?> getClassFromTypeId(type_id typeId, uint8_t dimensions);
 
     /**
      * Get the java.lang.Class instance for the type ID for non-array classes.
      */
     @Hidden
-    public static native Class<?> get_class_from_type_id_simple(type_id typeId);
+    public static native Class<?> getClassFromTypeIdSimple(type_id typeId);
 
     /**
      * Returns java.lang.Class instance representing array class of a given class
@@ -62,7 +62,7 @@ public class CompilerIntrinsics {
      * @return instance of java.lang.Class
      */
     @Hidden
-    public static native Class<?> get_array_class_of(Class<?> componentClass);
+    public static native Class<?> getArrayClassOf(Class<?> componentClass);
 
     /**
      * Tries to atomically set the java.lang.Class#arrayClass field of a component class
@@ -73,68 +73,68 @@ public class CompilerIntrinsics {
      * @return boolean true if atomic operation succeeds, false otherwise
      */
     @Hidden
-    public static native boolean set_array_class(Class<?> componentClass, Class<?> arrayClass);
+    public static native boolean setArrayClass(Class<?> componentClass, Class<?> arrayClass);
 
     /**
      * Is the argument typeId the typeId for java.lang.Object?
      */
     @Hidden
-    public static native boolean is_java_lang_object(type_id typeId);
+    public static native boolean isJavaLangObject(type_id typeId);
 
     /**
      * Is the argument typeId the typeId for java.lang.Cloneable?
      */
     @Hidden
-    public static native boolean is_java_lang_cloneable(type_id typeId);
+    public static native boolean isJavaLangCloneable(type_id typeId);
 
     /**
      * Is the argument typeId the typeId for java.io.Serializable?
      */
     @Hidden
-    public static native boolean is_java_io_serializable(type_id typeId);
+    public static native boolean isJavaIoSerializable(type_id typeId);
 
     /**
      * Is the argument typeId the typeId of a Class?
      */
     @Hidden
-    public static native boolean is_class(type_id typeId);
+    public static native boolean isClass(type_id typeId);
 
     /**
      * Is the argument typeId the typeId of an Interface?
      */
     @Hidden
-    public static native boolean is_interface(type_id typeId);
+    public static native boolean isInterface(type_id typeId);
 
     /**
      * Is the argument typeId the typeId of a primitive array?
      */
     @Hidden
-    public static native boolean is_prim_array(type_id typeId);
+    public static native boolean isPrimArray(type_id typeId);
 
     /**
      * Is the argument typeId the typeId of a primitive?
      */
     @Hidden
-    public static native boolean is_primitive(type_id typeId);
+    public static native boolean isPrimitive(type_id typeId);
 
     /**
      * Is the argument typeId the typeId use for reference arrays?
      */
     @Hidden
-    public static native boolean is_reference_array(type_id typeId);
+    public static native boolean isReferenceArray(type_id typeId);
 
     /**
      * Returns the typeId used for reference arrays
      */
     @Hidden
-    public static native type_id get_reference_array_typeid();
+    public static native type_id getReferenceArrayTypeId();
 
     /**
      * Get the number of typeIds in the system.
      * This will be 1 higher than the highest typeid
      */
     @Hidden
-    public static native type_id get_number_of_typeids();
+    public static native type_id getNumberOfTypeIds();
 
     /**
      * Allocates an instance of java.lang.Class in the runtime heap
@@ -145,7 +145,7 @@ public class CompilerIntrinsics {
      * @return instance of java.lang.Class
      */
     @Hidden
-    public static native Class<?> create_class(String name, type_id id, uint8_t dimension);
+    public static native Class<?> createClass(String name, type_id id, uint8_t dimension);
 
     /**
      * Get the concrete type ID value from the referenced object.  Note that all reference arrays will have the same
@@ -155,7 +155,7 @@ public class CompilerIntrinsics {
      * @return the type ID of the object
      */
     @Hidden
-    public static native type_id type_id_of(Object reference);
+    public static native type_id typeIdOf(Object reference);
 
     /**
      * Get the dimensionality of the referenced array.
@@ -164,7 +164,7 @@ public class CompilerIntrinsics {
      * @return the dimensionality of the array
      */
     @Hidden
-    public static native uint8_t dimensions_of(Object arrayReference); // Object not Object[] because we use this in the impl of cast
+    public static native uint8_t dimensionsOf(Object arrayReference); // Object not Object[] because we use this in the impl of cast
 
     /**
      * Get the element type ID value of the referenced array.
@@ -173,19 +173,19 @@ public class CompilerIntrinsics {
      * @return the array element type ID
      */
     @Hidden
-    public static native type_id element_type_id_of(Object arrayReference); // Object not Object[] because we use this in the impl of cast
+    public static native type_id elementTypeIdOf(Object arrayReference); // Object not Object[] because we use this in the impl of cast
 
     /**
      * Get the maxTypeId assigned to subclasses of the argument typeId
      */
     @Hidden
-    public static native type_id max_subclass_type_id_of(type_id typeId);
+    public static native type_id maxSubClassTypeIdOf(type_id typeId);
 
     /**
      * Does a typeId implement the argument interface?
      */
     @Hidden
-    public static native boolean does_implement(type_id valueTypeId, type_id interfaceTypeId);
+    public static native boolean doesImplement(type_id valueTypeId, type_id interfaceTypeId);
 
     /**
      * Call the class initializer for this class if it hasn't already been
@@ -198,7 +198,7 @@ public class CompilerIntrinsics {
      * @param typeId the class to initialize
      */
     @Hidden
-    public static native void call_class_initializer(type_id typeId);
+    public static native void callClassInitializer(type_id typeId);
 
     /**
      * Get the `flags` field from the qbicc_typeid_array for the given
@@ -214,7 +214,7 @@ public class CompilerIntrinsics {
      * @return the flags value
      */
     @Hidden
-    public static native int get_typeid_flags(type_id typeId);
+    public static native int getTypeIdFlags(type_id typeId);
 
     /**
      * Fetch the superclass `type_id` from the current `type_id`
@@ -222,16 +222,16 @@ public class CompilerIntrinsics {
      * @return superclass's type_id
      */
     @Hidden
-    public static native type_id get_superclass_typeid(type_id typeId);
+    public static native type_id getSuperClassTypeId(type_id typeId);
 
     @Hidden
-    public static native type_id get_first_interface_typeid();
+    public static native type_id getFirstInterfaceTypeId();
 
     @Hidden
-    public static native int get_number_of_bytes_in_interface_bits_array();
+    public static native int getNumberOfBytesInInterfaceBitsArray();
 
     @Hidden
-    public static native byte get_byte_of_interface_bits(type_id typeId, int index);
+    public static native byte getByteOfInterfaceBits(type_id typeId, int index);
 
     /**
      * Check the `clinit_states` native structure to see if this typeid is initialized.
@@ -243,7 +243,7 @@ public class CompilerIntrinsics {
      * @return true if initialized.  False if the state machine needs to validate.
      */
     @Hidden
-    public static native boolean is_initialized(type_id typdId);
+    public static native boolean isInitialized(type_id typdId);
 
     /**
      * Set the class initialized.
@@ -252,7 +252,7 @@ public class CompilerIntrinsics {
      * @param typdId the class to mark initialized
      */
     @Hidden
-    public static native void set_initialized(type_id typdId);
+    public static native void setInitialized(type_id typdId);
 
     /**
      * Get the native object monitor (mutex) slot from the referenced object. These are intended for object monitor synchronization.
@@ -261,7 +261,7 @@ public class CompilerIntrinsics {
      * @return the pthread mutex of the object
      */
     @Hidden
-    public static native PThread.pthread_mutex_t_ptr get_nativeObjectMonitor(Object reference);
+    public static native PThread.pthread_mutex_t_ptr getNativeObjectMonitor(Object reference);
 
     /**
      * Set the native object monitor (mutex) for the referenced object. This method is atomic and will return true on success.
@@ -271,5 +271,5 @@ public class CompilerIntrinsics {
      * @return true if successful
      */
     @Hidden
-    public static native boolean set_nativeObjectMonitor(Object reference, PThread.pthread_mutex_t_ptr nom);
+    public static native boolean setNativeObjectMonitor(Object reference, PThread.pthread_mutex_t_ptr nom);
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/Monitor.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/Monitor.java
@@ -11,6 +11,7 @@ import org.qbicc.runtime.Hidden;
  * the actual monitor implementation for some targets. This implementation is guaranteed to be based on
  * {@link java.util.concurrent.locks.LockSupport LockSupport}'s {@code park} mechanism.
  */
+@SuppressWarnings("unused")
 public final class Monitor {
     private static final long MAX_MILLIS = Long.MAX_VALUE / 1_000_000L;
 

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -4,7 +4,6 @@ import org.qbicc.runtime.CNative;
 import org.qbicc.runtime.Hidden;
 
 import static org.qbicc.runtime.CNative.*;
-import static org.qbicc.runtime.posix.PThread.*;
 import static org.qbicc.runtime.stdc.Stdint.*;
 
 /**
@@ -22,20 +21,20 @@ public class ObjectModel {
      * @return instance of java.lang.Class
      */
     @Hidden
-    public static Class<?> get_or_create_array_class(Class<?> componentClass, uint8_t dimensions) {
-        Class<?> arrayClass = CompilerIntrinsics.get_array_class_of(componentClass);
+    public static Class<?> getOrCreateArrayClass(Class<?> componentClass, uint8_t dimensions) {
+        Class<?> arrayClass = CompilerIntrinsics.getArrayClassOf(componentClass);
         if (arrayClass == null) {
             String className;
-            type_id componentTypeId = CompilerIntrinsics.get_type_id_from_class(componentClass);
-            if (CompilerIntrinsics.is_reference_array(componentTypeId) || CompilerIntrinsics.is_prim_array(componentTypeId)) {
+            type_id componentTypeId = CompilerIntrinsics.getTypeIdFromClass(componentClass);
+            if (CompilerIntrinsics.isReferenceArray(componentTypeId) || CompilerIntrinsics.isPrimArray(componentTypeId)) {
                 className = "[" + componentClass.getName();
-                arrayClass = CompilerIntrinsics.create_class(className, CompilerIntrinsics.get_reference_array_typeid(), dimensions);
+                arrayClass = CompilerIntrinsics.createClass(className, CompilerIntrinsics.getReferenceArrayTypeId(), dimensions);
             } else {
                 className = "[L" + componentClass.getName() + ";";
-                arrayClass = CompilerIntrinsics.create_class(className, CompilerIntrinsics.get_reference_array_typeid(), dimensions);
+                arrayClass = CompilerIntrinsics.createClass(className, CompilerIntrinsics.getReferenceArrayTypeId(), dimensions);
             }
-            if (!CompilerIntrinsics.set_array_class(componentClass, arrayClass)) {
-                arrayClass = CompilerIntrinsics.get_array_class_of(componentClass);
+            if (!CompilerIntrinsics.setArrayClass(componentClass, arrayClass)) {
+                arrayClass = CompilerIntrinsics.getArrayClassOf(componentClass);
             }
         }
         return arrayClass;
@@ -49,12 +48,12 @@ public class ObjectModel {
      * @return instance of java.lang.Class
      */
     @Hidden
-    public static Class<?> get_array_class_of_dimension(Class<?> leafClass, uint8_t dimensions) {
+    public static Class<?> getArrayClassOfDimension(Class<?> leafClass, uint8_t dimensions) {
         if (dimensions.intValue() == 1) {
-            return get_or_create_array_class(leafClass, dimensions);
+            return getOrCreateArrayClass(leafClass, dimensions);
         }
-        Class<?> cls = get_array_class_of_dimension(leafClass, CNative.word(dimensions.intValue()-1));
-        return get_or_create_array_class(cls, dimensions);
+        Class<?> cls = getArrayClassOfDimension(leafClass, CNative.word(dimensions.intValue()-1));
+        return getOrCreateArrayClass(cls, dimensions);
     }
 
     /**
@@ -65,9 +64,9 @@ public class ObjectModel {
      * @return boolean
      */
     @Hidden
-    public static boolean is_reference_array_class(Class<?> cls) {
-        type_id typeId = CompilerIntrinsics.get_type_id_from_class(cls);
-        return CompilerIntrinsics.is_reference_array(typeId);
+    public static boolean isReferenceArrayClass(Class<?> cls) {
+        type_id typeId = CompilerIntrinsics.getTypeIdFromClass(cls);
+        return CompilerIntrinsics.isReferenceArray(typeId);
     }
 
     /**
@@ -78,8 +77,8 @@ public class ObjectModel {
      * @return instance of java.lang.Class
      */
     @Hidden
-    public static Class<?> get_or_create_class_for_refarray(Class<?> leafClass, uint8_t dimensions) {
-        return get_array_class_of_dimension(leafClass, dimensions);
+    public static Class<?> getOrCreateClassForRefArray(Class<?> leafClass, uint8_t dimensions) {
+        return getArrayClassOfDimension(leafClass, dimensions);
     }
 
     static final int Flag_typeid_has_clinit = 1;
@@ -87,17 +86,19 @@ public class ObjectModel {
     static final int Flag_typeid_has_default_methods = 4;
 
     @Hidden
-    public static boolean has_class_initializer(type_id typeId) {
-        return (CompilerIntrinsics.get_typeid_flags(typeId) & Flag_typeid_has_clinit) == Flag_typeid_has_clinit;
+    public static boolean hasClassInitializer(type_id typeId) {
+        return (CompilerIntrinsics.getTypeIdFlags(typeId) & Flag_typeid_has_clinit) == Flag_typeid_has_clinit;
     }
 
     @Hidden
-    public static boolean declares_default_methods(type_id typeId) {
-        return (CompilerIntrinsics.get_typeid_flags(typeId) & Flag_typeid_declares_default_methods) == Flag_typeid_declares_default_methods;
+    public static boolean declaresDefaultMethods(type_id typeId) {
+        return (CompilerIntrinsics.getTypeIdFlags(typeId) & Flag_typeid_declares_default_methods) == Flag_typeid_declares_default_methods;
     }
 
     @Hidden
-    public static boolean has_default_methods(type_id typeId) {
-        return (CompilerIntrinsics.get_typeid_flags(typeId) & Flag_typeid_has_default_methods) == Flag_typeid_has_default_methods;
+    public static boolean hasDefaultMethods(type_id typeId) {
+        return (CompilerIntrinsics.getTypeIdFlags(typeId) & Flag_typeid_has_default_methods) == Flag_typeid_has_default_methods;
     }
+
+    public static native void_ptr threadWrapperNative(void_ptr threadParam);
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -99,6 +99,4 @@ public class ObjectModel {
     public static boolean hasDefaultMethods(type_id typeId) {
         return (CompilerIntrinsics.getTypeIdFlags(typeId) & Flag_typeid_has_default_methods) == Flag_typeid_has_default_methods;
     }
-
-    public static native void_ptr threadWrapperNative(void_ptr threadParam);
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/ObjectModel.java
@@ -8,72 +8,12 @@ import static org.qbicc.runtime.posix.PThread.*;
 import static org.qbicc.runtime.stdc.Stdint.*;
 
 /**
- * Intrinsics for accessing implementation-dependent object header fields
- * and compiler-generated global object model structures.
  *
  * These APIs are primarily intended for use in methods of VMHelper
  * and are subject to change as the runtime object model evolves.
  */
 @SuppressWarnings("unused")
 public class ObjectModel {
-
-    /**
-     * Get the dimensionality for the represented type from a java.lang.Class instance.
-     * Classes and interfaces have dimensionality 0.
-     */
-    @Hidden
-    public static native uint8_t get_dimensions_from_class(Class<?> cls);
-
-    /**
-     * Get the concrete type ID for the represented type from a java.lang.Class instance.
-     */
-    @Hidden
-    public static native type_id get_type_id_from_class(Class<?> cls);
-
-    /**
-     * Get the java.lang.Class instance for the type ID.
-     */
-    @Hidden
-    public static native Class<?> get_class_from_type_id(type_id typeId, uint8_t dimensions);
-
-    /**
-     * Get the java.lang.Class instance for the type ID for non-array classes.
-     */
-    @Hidden
-    public static native Class<?> get_class_from_type_id_simple(type_id typeId);
-
-    /**
-     * Returns java.lang.Class instance representing array class of a given class
-     *
-     * @param componentClass
-     * @return instance of java.lang.Class
-     */
-    @Hidden
-    public static native Class<?> get_array_class_of(Class<?> componentClass);
-
-    /**
-     * Tries to atomically set the java.lang.Class#arrayClass field of a component class
-     * to a given array class
-     *
-     * @param componentClass
-     * @param arrayClass
-     * @return boolean true if atomic operation succeeds, false otherwise
-     */
-    @Hidden
-    public static native boolean set_array_class(Class<?> componentClass, Class<?> arrayClass);
-
-    /**
-     * Checks if the java.lang.Class instance represents reference array class.
-     * Reference array class have dimension greater than 0.
-     *
-     * @param cls
-     * @return boolean
-     */
-    @Hidden
-    public static boolean is_reference_array_class(Class<?> cls) {
-        type_id typeId = get_type_id_from_class(cls);
-        return is_reference_array(typeId);
-    }
 
     /**
      * Returns java.lang.Class instance representing the array class of a given component class
@@ -83,19 +23,19 @@ public class ObjectModel {
      */
     @Hidden
     public static Class<?> get_or_create_array_class(Class<?> componentClass, uint8_t dimensions) {
-        Class<?> arrayClass = get_array_class_of(componentClass);
+        Class<?> arrayClass = CompilerIntrinsics.get_array_class_of(componentClass);
         if (arrayClass == null) {
             String className;
-            type_id componentTypeId = get_type_id_from_class(componentClass);
-            if (is_reference_array(componentTypeId) || is_prim_array(componentTypeId)) {
+            type_id componentTypeId = CompilerIntrinsics.get_type_id_from_class(componentClass);
+            if (CompilerIntrinsics.is_reference_array(componentTypeId) || CompilerIntrinsics.is_prim_array(componentTypeId)) {
                 className = "[" + componentClass.getName();
-                arrayClass = create_class(className, get_reference_array_typeid(), dimensions);
+                arrayClass = CompilerIntrinsics.create_class(className, CompilerIntrinsics.get_reference_array_typeid(), dimensions);
             } else {
                 className = "[L" + componentClass.getName() + ";";
-                arrayClass = create_class(className, get_reference_array_typeid(), dimensions);
+                arrayClass = CompilerIntrinsics.create_class(className, CompilerIntrinsics.get_reference_array_typeid(), dimensions);
             }
-            if (!set_array_class(componentClass, arrayClass)) {
-                arrayClass = get_array_class_of(componentClass);
+            if (!CompilerIntrinsics.set_array_class(componentClass, arrayClass)) {
+                arrayClass = CompilerIntrinsics.get_array_class_of(componentClass);
             }
         }
         return arrayClass;
@@ -118,6 +58,19 @@ public class ObjectModel {
     }
 
     /**
+     * Checks if the java.lang.Class instance represents reference array class.
+     * Reference array class have dimension greater than 0.
+     *
+     * @param cls
+     * @return boolean
+     */
+    @Hidden
+    public static boolean is_reference_array_class(Class<?> cls) {
+        type_id typeId = CompilerIntrinsics.get_type_id_from_class(cls);
+        return CompilerIntrinsics.is_reference_array(typeId);
+    }
+
+    /**
      * Creates java.lang.Class instance for array class
      *
      * @param leafClass leaf element of the array
@@ -129,220 +82,22 @@ public class ObjectModel {
         return get_array_class_of_dimension(leafClass, dimensions);
     }
 
-    /**
-     * Allocates an instance of java.lang.Class in the runtime heap
-     *
-     * @param name class name
-     * @param id class's type id
-     * @param dimension array dimension if the class is an array class, 0 otherwise
-     * @return instance of java.lang.Class
-     */
-    @Hidden
-    public static native Class<?> create_class(String name, type_id id, uint8_t dimension);
-
-    /**
-     * Get the concrete type ID value from the referenced object.  Note that all reference arrays will have the same
-     * type ID, which does not reflect the element type.
-     *
-     * @param reference the object reference (must not be {@code null})
-     * @return the type ID of the object
-     */
-    @Hidden
-    public static native type_id type_id_of(Object reference);
-
-    /**
-     * Get the dimensionality of the referenced array.
-     *
-     * @param arrayReference the array reference (must not be {@code null} and must be an Object[])
-     * @return the dimensionality of the array
-     */
-    @Hidden
-    public static native uint8_t dimensions_of(Object arrayReference); // Object not Object[] because we use this in the impl of cast
-
-    /**
-     * Get the element type ID value of the referenced array.
-     *
-     * @param arrayReference the array reference (must not be {@code null} and must be an Object[])
-     * @return the array element type ID
-     */
-    @Hidden
-    public static native type_id element_type_id_of(Object arrayReference); // Object not Object[] because we use this in the impl of cast
-
-    /**
-     * Get the maxTypeId assigned to subclasses of the argument typeId
-     */
-    @Hidden
-    public static native type_id max_subclass_type_id_of(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId for java.lang.Object?
-     */
-    @Hidden
-    public static native boolean is_java_lang_object(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId for java.lang.Cloneable?
-     */
-    @Hidden
-    public static native boolean is_java_lang_cloneable(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId for java.io.Serializable?
-     */
-    @Hidden
-    public static native boolean is_java_io_serializable(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId of a Class?
-     */
-    @Hidden
-    public static native boolean is_class(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId of an Interface?
-     */
-    @Hidden
-    public static native boolean is_interface(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId of a primitive array?
-     */
-    @Hidden
-    public static native boolean is_prim_array(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId of a primitive?
-     */
-    @Hidden
-    public static native boolean is_primitive(type_id typeId);
-
-    /**
-     * Is the argument typeId the typeId use for reference arrays?
-     */
-    @Hidden
-    public static native boolean is_reference_array(type_id typeId);
-
-    /**
-     * Returns the typeId used for reference arrays
-     */
-    @Hidden
-    public static native type_id get_reference_array_typeid();
-
-    /**
-     * Does a typeId implement the argument interface?
-     */
-    @Hidden
-    public static native boolean does_implement(type_id valueTypeId, type_id interfaceTypeId);
-
-    /**
-     * Get the number of typeIds in the system.
-     * This will be 1 higher than the highest typeid
-     */
-    @Hidden
-    public static native type_id get_number_of_typeids();
-
-    /**
-     * Call the class initializer for this class if it hasn't already been
-     * called.
-     * 
-     * This operation is racy as the locking is managed by the ClinitState
-     * object in VMHelpers#initialize_class and should only be called by
-     * that method.
-     * 
-     * @param typeId the class to initialize
-     */
-    @Hidden
-    public static native void call_class_initializer(type_id typeId);
-
     static final int Flag_typeid_has_clinit = 1;
     static final int Flag_typeid_declares_default_methods = 2;
     static final int Flag_typeid_has_default_methods = 4;
 
-    /**
-     * Get the `flags` field from the qbicc_typeid_array for the given
-     * typeid.
-     * 
-     * Flags are:
-     * 1 - has clinit method
-     * 2 - declares default methods
-     * 4 - has default methods
-     * See SupersDisplayTables.calculateTypeIdFlags() for definitive list.
-     * 
-     * @param typeId the class to read the flags for
-     * @return the flags value
-     */
-    @Hidden
-    public static native int get_typeid_flags(type_id typeId);
-
     @Hidden
     public static boolean has_class_initializer(type_id typeId) {
-        return (get_typeid_flags(typeId) & Flag_typeid_has_clinit) == Flag_typeid_has_clinit;
+        return (CompilerIntrinsics.get_typeid_flags(typeId) & Flag_typeid_has_clinit) == Flag_typeid_has_clinit;
     }
 
     @Hidden
     public static boolean declares_default_methods(type_id typeId) {
-        return (get_typeid_flags(typeId) & Flag_typeid_declares_default_methods) == Flag_typeid_declares_default_methods;
+        return (CompilerIntrinsics.get_typeid_flags(typeId) & Flag_typeid_declares_default_methods) == Flag_typeid_declares_default_methods;
     }
 
     @Hidden
     public static boolean has_default_methods(type_id typeId) {
-        return (get_typeid_flags(typeId) & Flag_typeid_has_default_methods) == Flag_typeid_has_default_methods;
+        return (CompilerIntrinsics.get_typeid_flags(typeId) & Flag_typeid_has_default_methods) == Flag_typeid_has_default_methods;
     }
-
-    /** 
-     * Fetch the superclass `type_id` from the current `type_id`
-     * @param typeId an existing type_id, don't call this on Object's typeid
-     * @return superclass's type_id
-     */
-    @Hidden
-    public static native type_id get_superclass_typeid(type_id typeId);
-
-    @Hidden
-    public static native type_id get_first_interface_typeid();
-
-    @Hidden
-    public static native int get_number_of_bytes_in_interface_bits_array();
-
-    @Hidden
-    public static native byte get_byte_of_interface_bits(type_id typeId, int index);
-
-    /**
-     * Check the `clinit_states` native structure to see if this typeid is initialized.
-     * 
-     * This is a fast check reading a bit in the structure.  A "true" value can be trusted
-     * as a fast path check while a "false" value requires the state-machine defined in
-     * VMHelpers.initialize_class() to validate the result and handle the transition.
-     * 
-     * @return true if initialized.  False if the state machine needs to validate.
-     */
-    @Hidden
-    public static native boolean is_initialized(type_id typdId);
-
-    /**
-     * Set the class initialized.  
-     * 
-     * This should only be done by the MHelpers.initialize_class() statemachine
-     * @param typdId the class to mark initialized
-     */
-    @Hidden
-    public static native void set_initialized(type_id typdId);
-
-    /**
-     * Get the native object monitor (mutex) slot from the referenced object. These are intended for object monitor synchronization.
-     *
-     * @param reference the object reference (must not be {@code null})
-     * @return the pthread mutex of the object
-     */
-    @Hidden
-    public static native pthread_mutex_t_ptr get_nativeObjectMonitor(Object reference);
-
-    /**
-     * Set the native object monitor (mutex) for the referenced object. This method is atomic and will return true on success.
-     *
-     * @param reference the object reference (must not be {@code null})
-     * @param nom mutex for the referenced object (must not be {@code null})
-     * @return true if successful
-     */
-    @Hidden
-    public static native boolean set_nativeObjectMonitor(Object reference, pthread_mutex_t_ptr nom);
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -619,10 +619,7 @@ public final class VMHelpers {
         }
     }
 
-    // TODO: Class library compatibility kludge; remove once qbicc 0.3.0 is released
-    public static boolean saveNativeThread(void_ptr thread, PThread.pthread_t_ptr pthreadPtr) {
-        return CompilerIntrinsics.saveNativeThread(thread, pthreadPtr);
-    }
+    // TODO: Class library compatibility kludge; remove once qbicc 0.3.0 is released and CoreIntrnsic for Thread.start0 is updated.
     public static void_ptr threadWrapperNative(void_ptr threadParam) {
         return CompilerIntrinsics.threadWrapperNative(threadParam);
     }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -21,11 +21,11 @@ public final class VMHelpers {
 
     @Hidden
     public static Class<?> get_class(Object instance) {
-        type_id typeId = ObjectModel.type_id_of(instance);
+        type_id typeId = CompilerIntrinsics.type_id_of(instance);
         uint8_t dims = word(0);
-        if (ObjectModel.is_reference_array(typeId)) {
-            typeId = ObjectModel.element_type_id_of(instance);
-            dims = ObjectModel.dimensions_of(instance);
+        if (CompilerIntrinsics.is_reference_array(typeId)) {
+            typeId = CompilerIntrinsics.element_type_id_of(instance);
+            dims = CompilerIntrinsics.dimensions_of(instance);
         }
         return classof_from_typeid(typeId, dims);
     }
@@ -36,8 +36,8 @@ public final class VMHelpers {
         if (instance == null) {
             return false;
         }
-        type_id toTypeId = ObjectModel.get_type_id_from_class(cls);
-        uint8_t toDim = ObjectModel.get_dimensions_from_class(cls);
+        type_id toTypeId = CompilerIntrinsics.get_type_id_from_class(cls);
+        uint8_t toDim = CompilerIntrinsics.get_dimensions_from_class(cls);
         return isAssignableTo(instance, toTypeId, toDim);
     }
 
@@ -60,8 +60,8 @@ public final class VMHelpers {
 
     @Hidden
     public static void checkcast_class (Object value, Class<?> cls) {
-        type_id toTypeId = ObjectModel.get_type_id_from_class(cls);
-        uint8_t toDim = ObjectModel.get_dimensions_from_class(cls);
+        type_id toTypeId = CompilerIntrinsics.get_type_id_from_class(cls);
+        uint8_t toDim = CompilerIntrinsics.get_dimensions_from_class(cls);
         checkcast_typeId(value, toTypeId, toDim);
     }
 
@@ -77,9 +77,9 @@ public final class VMHelpers {
     @NoSideEffects
     @Hidden
     public static boolean isAssignableTo(Object value, type_id toTypeId, uint8_t toDimensions) {
-        type_id fromTypeId = ObjectModel.type_id_of(value);
-        if (ObjectModel.is_reference_array(fromTypeId)) {
-            return isTypeIdAssignableTo(ObjectModel.element_type_id_of(value), ObjectModel.dimensions_of(value), toTypeId, toDimensions);
+        type_id fromTypeId = CompilerIntrinsics.type_id_of(value);
+        if (CompilerIntrinsics.is_reference_array(fromTypeId)) {
+            return isTypeIdAssignableTo(CompilerIntrinsics.element_type_id_of(value), CompilerIntrinsics.dimensions_of(value), toTypeId, toDimensions);
         } else {
             return isTypeIdAssignableTo(fromTypeId, zero(), toTypeId, toDimensions);
         }
@@ -89,19 +89,19 @@ public final class VMHelpers {
     @Hidden
     public static boolean isTypeIdAssignableTo(type_id fromTypeId, uint8_t fromDimensions, type_id toTypeId, uint8_t toDimensions) {
         return fromDimensions == toDimensions && isAssignableToLeaf(fromTypeId, toTypeId)
-            || fromDimensions.isGt(toDimensions) && isAssignableToLeaf(ObjectModel.get_reference_array_typeid(), toTypeId);
+            || fromDimensions.isGt(toDimensions) && isAssignableToLeaf(CompilerIntrinsics.get_reference_array_typeid(), toTypeId);
     }
 
     @NoSideEffects
     @Hidden
     private static boolean isAssignableToLeaf(type_id fromTypeId, type_id toTypeId) {
-        if (ObjectModel.is_primitive(toTypeId) || ObjectModel.is_primitive(fromTypeId)) {
+        if (CompilerIntrinsics.is_primitive(toTypeId) || CompilerIntrinsics.is_primitive(fromTypeId)) {
             return false;
-        } else if (ObjectModel.is_interface(toTypeId)) {
-            return ObjectModel.does_implement(fromTypeId, toTypeId);
+        } else if (CompilerIntrinsics.is_interface(toTypeId)) {
+            return CompilerIntrinsics.does_implement(fromTypeId, toTypeId);
         } else {
             // in the physical type range
-            return toTypeId.isLe(fromTypeId) && fromTypeId.isLe(ObjectModel.max_subclass_type_id_of(toTypeId));
+            return toTypeId.isLe(fromTypeId) && fromTypeId.isLe(CompilerIntrinsics.max_subclass_type_id_of(toTypeId));
         }
     }
 
@@ -109,15 +109,15 @@ public final class VMHelpers {
     @Hidden
     @Inline(InlineCondition.NEVER)
     static Class<?> classof_from_typeid(type_id typeId, uint8_t dimensions) {
-        return ObjectModel.get_class_from_type_id(typeId, dimensions);
+        return CompilerIntrinsics.get_class_from_type_id(typeId, dimensions);
     }
 
     @Hidden
     static Class<?> get_superclass(type_id typeId) {
-        if (ObjectModel.is_java_lang_object(typeId) || ObjectModel.is_primitive(typeId) || ObjectModel.is_interface(typeId)) {
+        if (CompilerIntrinsics.is_java_lang_object(typeId) || CompilerIntrinsics.is_primitive(typeId) || CompilerIntrinsics.is_interface(typeId)) {
             return null;
         }
-        type_id superTypeId = ObjectModel.get_superclass_typeid(typeId);
+        type_id superTypeId = CompilerIntrinsics.get_superclass_typeid(typeId);
         uint8_t dims = word(0);
         return classof_from_typeid(superTypeId, dims);
     }
@@ -131,7 +131,7 @@ public final class VMHelpers {
                 classof_from_typeid is not currently implemented. */
             return;
         }
-        pthread_mutex_t_ptr nom = ObjectModel.get_nativeObjectMonitor(object);
+        pthread_mutex_t_ptr nom = CompilerIntrinsics.get_nativeObjectMonitor(object);
         if (nom == null) {
             ptr<?> attrVoid = malloc(sizeof(pthread_mutexattr_t.class));
             if (attrVoid.isNull()) {
@@ -167,11 +167,11 @@ public final class VMHelpers {
                     }
 
                     nom = (pthread_mutex_t_ptr) m;
-                    if (!ObjectModel.set_nativeObjectMonitor(object, nom)) {
+                    if (!CompilerIntrinsics.set_nativeObjectMonitor(object, nom)) {
                         /* atomic assignment failed, mutex has already been initialized for object. */
                         pthread_mutex_destroy(nom);
                         free(mVoid);
-                        nom = ObjectModel.get_nativeObjectMonitor(object);
+                        nom = CompilerIntrinsics.get_nativeObjectMonitor(object);
                     }
                 } finally {
                     pthread_mutexattr_destroy((pthread_mutexattr_t_ptr) attr);
@@ -194,7 +194,7 @@ public final class VMHelpers {
                 classof_from_typeid is not currently implemented. */
             return;
         }
-        pthread_mutex_t_ptr nom = ObjectModel.get_nativeObjectMonitor(object);
+        pthread_mutex_t_ptr nom = CompilerIntrinsics.get_nativeObjectMonitor(object);
         if (nom == null) {
             throw new IllegalMonitorStateException("native monitor could not be found for monitor_exit");
         }
@@ -356,7 +356,7 @@ public final class VMHelpers {
 
     static void ensureClinitStatesArray() {
         if (clinitStates == null) {
-            type_id size = ObjectModel.get_number_of_typeids();
+            type_id size = CompilerIntrinsics.get_number_of_typeids();
             synchronized(ClinitState.class) {
                 if (clinitStates == null) {
                     clinitStates = new ClinitState[size.intValue()];
@@ -395,7 +395,7 @@ public final class VMHelpers {
         // putchar('>');
         // putchar('\n');
         ensureClinitStatesArray();
-        if (ObjectModel.is_initialized(typeid)) {
+        if (CompilerIntrinsics.is_initialized(typeid)) {
             // early exit - is this right for getting the correct memory effects?
             return;
         }
@@ -437,11 +437,11 @@ public final class VMHelpers {
             }
             // LC is released at this point, and in-progress by current thread
             // Static field preparation happens at build time
-            if (ObjectModel.is_class(typeid)) {
+            if (CompilerIntrinsics.is_class(typeid)) {
                 try {
                     // Initialize the super class (and its superclasses if not already initialized)
-                    if (!ObjectModel.is_java_lang_object(typeid)) {
-                        initialize_class(currentThread, ObjectModel.get_superclass_typeid(typeid));
+                    if (!CompilerIntrinsics.is_java_lang_object(typeid)) {
+                        initialize_class(currentThread, CompilerIntrinsics.get_superclass_typeid(typeid));
                     }
                     // Initialize the super interfaces, at least those that declare default methods
                     // We calculate if a class has default methods during image build and we elide
@@ -451,9 +451,9 @@ public final class VMHelpers {
                     if (ObjectModel.has_default_methods(typeid)) {
                         // TODO: The ordering of superinterface intialization isn't correct here as it should start 
                         // recursively based on the directly declared interfaces.  This does all interfaces implemented.
-                        type_id interfaceId = ObjectModel.get_first_interface_typeid();
-                        for (int i = 0; i < ObjectModel.get_number_of_bytes_in_interface_bits_array(); i++) {
-                            byte b = ObjectModel.get_byte_of_interface_bits(typeid, i);
+                        type_id interfaceId = CompilerIntrinsics.get_first_interface_typeid();
+                        for (int i = 0; i < CompilerIntrinsics.get_number_of_bytes_in_interface_bits_array(); i++) {
+                            byte b = CompilerIntrinsics.get_byte_of_interface_bits(typeid, i);
                             if (b == 0) {
                                 // no interfaces in this byte - advance to the next one
                                 interfaceId = CNative.<type_id>word(interfaceId.intValue() + 8);
@@ -483,7 +483,7 @@ public final class VMHelpers {
             Error clinitThrowable = null;
             try {
                 if (ObjectModel.has_class_initializer(typeid)) {
-                    ObjectModel.call_class_initializer(typeid);
+                    CompilerIntrinsics.call_class_initializer(typeid);
                 }
             } catch (Throwable t) {
                 if (t instanceof Error) {
@@ -497,7 +497,7 @@ public final class VMHelpers {
                     // completed successfully
                     state.setInitialized();
                     // update the native data as well for fast checks
-                    ObjectModel.set_initialized(typeid);
+                    CompilerIntrinsics.set_initialized(typeid);
                 } else {
                     state.setFailed(clinitThrowable);
                 }
@@ -551,17 +551,17 @@ public final class VMHelpers {
     // Temporary testing method
     public static void testClinit(Object o) throws Throwable {
         putchar(isInitialized(o) ? 'Y' : 'N');
-        initialize_class(Thread.currentThread(), ObjectModel.type_id_of(o));
+        initialize_class(Thread.currentThread(), CompilerIntrinsics.type_id_of(o));
         setInitialized(o);
         putchar(isInitialized(o) ? 'Y' : 'N');
     }
 
     public static boolean isInitialized(Object o) throws Throwable {
-        return ObjectModel.is_initialized(ObjectModel.type_id_of(o));
+        return CompilerIntrinsics.is_initialized(CompilerIntrinsics.type_id_of(o));
     }
 
     public static void setInitialized(Object o) throws Throwable {
-        ObjectModel.set_initialized(ObjectModel.type_id_of(o));
+        CompilerIntrinsics.set_initialized(CompilerIntrinsics.type_id_of(o));
     }
 
     // Run time class loading
@@ -570,13 +570,6 @@ public final class VMHelpers {
         // TODO: keep a map of run time loadable classes per class loader
         throw new ClassNotFoundException("Run time class loading not yet supported");
     }
-
-    /**
-     * This intrinsic sets up and executes the `public void run()` of threadParam.
-     * @param threadParam - java.lang.Thread object that has been cast to a void pointer to be compatible with pthread_create
-     * @return null - this return value will not be used
-     */
-    public static native void_ptr threadWrapperNative(void_ptr threadParam);
 
     /**
      * Wrapper for threadWrapperNative intrinsic.
@@ -591,16 +584,8 @@ public final class VMHelpers {
             // TODO this is a workaround until addr_of_function is working
             return threadParam;
         }
-        return threadWrapperNative(threadParam);
+        return CompilerIntrinsics.threadWrapperNative(threadParam);
     }
-
-    /**
-     * TODO
-     * @param thread
-     * @param pthreadPtr
-     * @return
-     */
-    public static native boolean saveNativeThread(void_ptr thread, pthread_t_ptr pthreadPtr);
 
     /**
      * Helper for java.lang.Thread.start0 allocates a pthread and creates/runs the thread.
@@ -621,7 +606,7 @@ public final class VMHelpers {
         ptr<pthread_t> pthreadPtr = (ptr<pthread_t>) castPtr(pthreadVoid, pthread_t.class);
 
         /* make GC aware of thread before starting */
-        if (!saveNativeThread(thread, (pthread_t_ptr) pthreadPtr)) {
+        if (!CompilerIntrinsics.saveNativeThread(thread, (pthread_t_ptr) pthreadPtr)) {
             free(pthreadVoid);
             throw new OutOfMemoryError();
         }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -20,17 +20,6 @@ import static org.qbicc.runtime.stdc.Stdlib.*;
 @SuppressWarnings("unused")
 public final class VMHelpers {
 
-    @Hidden
-    public static Class<?> getClass(Object instance) {
-        type_id typeId = CompilerIntrinsics.typeIdOf(instance);
-        uint8_t dims = word(0);
-        if (CompilerIntrinsics.isReferenceArray(typeId)) {
-            typeId = CompilerIntrinsics.elementTypeIdOf(instance);
-            dims = CompilerIntrinsics.dimensionsOf(instance);
-        }
-        return getClassFromTypeid(typeId, dims);
-    }
-
     @NoSideEffects
     @Hidden
     public static boolean instanceofClass(Object instance, Class<?> cls) {
@@ -104,6 +93,17 @@ public final class VMHelpers {
             // in the physical type range
             return toTypeId.isLe(fromTypeId) && fromTypeId.isLe(CompilerIntrinsics.maxSubClassTypeIdOf(toTypeId));
         }
+    }
+
+    @Hidden
+    public static Class<?> getClassFromObject(Object instance) {
+        type_id typeId = CompilerIntrinsics.typeIdOf(instance);
+        uint8_t dims = word(0);
+        if (CompilerIntrinsics.isReferenceArray(typeId)) {
+            typeId = CompilerIntrinsics.elementTypeIdOf(instance);
+            dims = CompilerIntrinsics.dimensionsOf(instance);
+        }
+        return getClassFromTypeid(typeId, dims);
     }
 
     @NoSideEffects

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -1,7 +1,7 @@
 package org.qbicc.runtime.stackwalk;
 
 import org.qbicc.runtime.CNative;
-import org.qbicc.runtime.main.ObjectModel;
+import org.qbicc.runtime.main.CompilerIntrinsics;
 
 import static org.qbicc.runtime.CNative.*;
 
@@ -19,7 +19,7 @@ public final class MethodData {
 
     public static Class<?> getClass(int minfoIndex) {
         type_id typeId = word(getTypeId(minfoIndex));
-        return ObjectModel.get_class_from_type_id(typeId, word(0));
+        return CompilerIntrinsics.get_class_from_type_id(typeId, word(0));
     }
 
     public static boolean hasAllModifiersOf(int minfoIndex, int mask) {

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -19,7 +19,7 @@ public final class MethodData {
 
     public static Class<?> getClass(int minfoIndex) {
         type_id typeId = word(getTypeId(minfoIndex));
-        return CompilerIntrinsics.get_class_from_type_id(typeId, word(0));
+        return CompilerIntrinsics.getClassFromTypeId(typeId, word(0));
     }
 
     public static boolean hasAllModifiersOf(int minfoIndex, int mask) {


### PR DESCRIPTION
There should be no semantic change here; just lots of methods being moved and/or renamed.