### PR TITLE
Build-time-complete layout

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/VmClass.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmClass.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.descriptor.MethodDescriptor;
 
 /**
  *
@@ -46,4 +48,23 @@ public interface VmClass extends VmObject {
     Literal getValueForStaticField(FieldElement field);
 
     int indexOfStatic(FieldElement field) throws IllegalArgumentException;
+
+    /**
+     * Register an overriding {@code VmInvokable} for the given element.
+     *
+     * @param element the element to override (must not be {@code null})
+     * @param invokable the invokable to call (must not be {@code null})
+     * @throws IllegalStateException if the method was already compiled for interpretation
+     */
+    void registerInvokable(ExecutableElement element, VmInvokable invokable) throws IllegalStateException;
+
+    /**
+     * Register an overriding {@code VmInvokable} for the given element.
+     *
+     * @param name the name of the method or initializer to override (must not be {@code null})
+     * @param descriptor the descriptor of the method or initializer to override (must not be {@code null})
+     * @param invokable the invokable to call (must not be {@code null})
+     * @throws IllegalStateException if the method was already compiled for interpretation
+     */
+    void registerInvokable(String name, MethodDescriptor descriptor, VmInvokable invokable) throws IllegalStateException;
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1894,7 +1894,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         Layout layout = Layout.get(ctxt);
         LayoutInfo layoutInfo;
         if (fieldElement.isStatic()) {
-            layoutInfo = layout.getInterpreterStaticLayoutInfo(fieldElement.getEnclosingType());
+            layoutInfo = layout.getStaticLayoutInfo(fieldElement.getEnclosingType());
         } else {
             layoutInfo = layout.getInstanceLayoutInfo(fieldElement.getEnclosingType());
         }
@@ -2399,7 +2399,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
             CompilationContext ctxt = frame.element.getEnclosingType().getContext().getCompilationContext();
             Layout layout = Layout.get(ctxt);
             FieldElement field = node.getVariableElement();
-            LayoutInfo layoutInfo = layout.getInterpreterStaticLayoutInfo(field.getEnclosingType());
+            LayoutInfo layoutInfo = layout.getStaticLayoutInfo(field.getEnclosingType());
             if (layoutInfo == null) {
                 throw new IllegalStateException("No static fields found");
             }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1891,7 +1891,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     public Object visit(VmThreadImpl param, OffsetOfField node) {
         FieldElement fieldElement = node.getFieldElement();
         CompilationContext ctxt = element.getEnclosingType().getContext().getCompilationContext();
-        Layout layout = Layout.getForInterpreter(ctxt);
+        Layout layout = Layout.get(ctxt);
         LayoutInfo layoutInfo;
         if (fieldElement.isStatic()) {
             layoutInfo = layout.getInterpreterStaticLayoutInfo(fieldElement.getEnclosingType());
@@ -2340,7 +2340,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
                     CompilationContext ctxt = frame.element.getEnclosingType().getContext().getCompilationContext();
                     CoreClasses coreClasses = CoreClasses.get(ctxt);
                     FieldElement field = coreClasses.getArrayContentField(physicalBound);
-                    Layout interpLayout = Layout.getForInterpreter(ctxt);
+                    Layout interpLayout = Layout.get(ctxt);
                     int fieldOffset = interpLayout.getInstanceLayoutInfo(field.getEnclosingType()).getMember(field).getOffset();
                     ArrayType contentType = (ArrayType)field.getType();
                     return node.getValueHandle().accept(this, frame) + fieldOffset + index * contentType.getElementSize();
@@ -2363,7 +2363,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         @Override
         public long visit(Frame frame, InstanceFieldOf node) {
             CompilationContext ctxt = frame.element.getEnclosingType().getContext().getCompilationContext();
-            Layout layout = Layout.getForInterpreter(ctxt);
+            Layout layout = Layout.get(ctxt);
             FieldElement field = node.getVariableElement();
             LayoutInfo layoutInfo = layout.getInstanceLayoutInfo(field.getEnclosingType());
             try {
@@ -2397,7 +2397,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         @Override
         public long visit(Frame frame, StaticField node) {
             CompilationContext ctxt = frame.element.getEnclosingType().getContext().getCompilationContext();
-            Layout layout = Layout.getForInterpreter(ctxt);
+            Layout layout = Layout.get(ctxt);
             FieldElement field = node.getVariableElement();
             LayoutInfo layoutInfo = layout.getInterpreterStaticLayoutInfo(field.getEnclosingType());
             if (layoutInfo == null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -109,8 +109,8 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         ClassContext classContext = typeDefinition.getContext();
         classLoader = (VmClassLoaderImpl) classContext.getClassLoader();
         CompilationContext ctxt = classContext.getCompilationContext();
-        layoutInfo = typeDefinition.isInterface() ? null : Layout.getForInterpreter(ctxt).getInstanceLayoutInfo(typeDefinition);
-        staticLayoutInfo = Layout.getForInterpreter(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
+        layoutInfo = typeDefinition.isInterface() ? null : Layout.get(ctxt).getInstanceLayoutInfo(typeDefinition);
+        staticLayoutInfo = Layout.get(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
         staticMemory = staticLayoutInfo == null ? vmImpl.allocate(0) : vmImpl.allocate((int) staticLayoutInfo.getCompoundType().getSize());
         initializeConstantStaticFields();
     }
@@ -132,14 +132,14 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
 
     VmClassImpl(final VmImpl vm, final ClassContext classContext, @SuppressWarnings("unused") Class<VmClassClassImpl> classClassOnly) {
         // special ctor for Class.class, where getClass() == Class.class
-        super(vm, VmClassImpl.class, Layout.getForInterpreter(classContext.getCompilationContext()).getInstanceLayoutInfo(classContext.findDefinedType("java/lang/Class").load()));
+        super(vm, VmClassImpl.class, Layout.get(classContext.getCompilationContext()).getInstanceLayoutInfo(classContext.findDefinedType("java/lang/Class").load()));
         this.vm = vm;
         typeDefinition = classContext.findDefinedType("java/lang/Class").load();
         protectionDomain = null;
         classLoader = null;
         CompilationContext ctxt = classContext.getCompilationContext();
-        layoutInfo = Layout.getForInterpreter(ctxt).getInstanceLayoutInfo(typeDefinition);
-        staticLayoutInfo = Layout.getForInterpreter(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
+        layoutInfo = Layout.get(ctxt).getInstanceLayoutInfo(typeDefinition);
+        staticLayoutInfo = Layout.get(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
         staticMemory = staticLayoutInfo == null ? vm.allocate(0) : vm.allocate((int) staticLayoutInfo.getCompoundType().getSize());
         superClass = new VmClassImpl(vm, (VmClassClassImpl) this, classContext.findDefinedType("java/lang/Object").load(), null);
         initializeConstantStaticFields();
@@ -512,7 +512,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
     public int indexOfStatic(FieldElement field) throws IllegalArgumentException {
         LoadedTypeDefinition loaded = field.getEnclosingType().load();
         CompilationContext ctxt = loaded.getContext().getCompilationContext();
-        LayoutInfo layoutInfo = Layout.getForInterpreter(ctxt).getInterpreterStaticLayoutInfo(loaded);
+        LayoutInfo layoutInfo = Layout.get(ctxt).getInterpreterStaticLayoutInfo(loaded);
         if (layoutInfo != null) {
             CompoundType.Member member = layoutInfo.getMember(field);
             if (member != null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -110,7 +110,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         classLoader = (VmClassLoaderImpl) classContext.getClassLoader();
         CompilationContext ctxt = classContext.getCompilationContext();
         layoutInfo = typeDefinition.isInterface() ? null : Layout.get(ctxt).getInstanceLayoutInfo(typeDefinition);
-        staticLayoutInfo = Layout.get(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
+        staticLayoutInfo = Layout.get(ctxt).getStaticLayoutInfo(typeDefinition);
         staticMemory = staticLayoutInfo == null ? vmImpl.allocate(0) : vmImpl.allocate((int) staticLayoutInfo.getCompoundType().getSize());
         initializeConstantStaticFields();
     }
@@ -139,7 +139,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         classLoader = null;
         CompilationContext ctxt = classContext.getCompilationContext();
         layoutInfo = Layout.get(ctxt).getInstanceLayoutInfo(typeDefinition);
-        staticLayoutInfo = Layout.get(ctxt).getInterpreterStaticLayoutInfo(typeDefinition);
+        staticLayoutInfo = Layout.get(ctxt).getStaticLayoutInfo(typeDefinition);
         staticMemory = staticLayoutInfo == null ? vm.allocate(0) : vm.allocate((int) staticLayoutInfo.getCompoundType().getSize());
         superClass = new VmClassImpl(vm, (VmClassClassImpl) this, classContext.findDefinedType("java/lang/Object").load(), null);
         initializeConstantStaticFields();
@@ -512,7 +512,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
     public int indexOfStatic(FieldElement field) throws IllegalArgumentException {
         LoadedTypeDefinition loaded = field.getEnclosingType().load();
         CompilationContext ctxt = loaded.getContext().getCompilationContext();
-        LayoutInfo layoutInfo = Layout.get(ctxt).getInterpreterStaticLayoutInfo(loaded);
+        LayoutInfo layoutInfo = Layout.get(ctxt).getStaticLayoutInfo(loaded);
         if (layoutInfo != null) {
             CompoundType.Member member = layoutInfo.getMember(field);
             if (member != null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -601,12 +601,36 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         return target;
     }
 
-    void registerInvokable(final ExecutableElement element, final VmInvokable invokable) {
+    @Override
+    public void registerInvokable(final ExecutableElement element, final VmInvokable invokable) {
         Assert.checkNotNullParam("invokable", invokable);
         synchronized (methodTable) {
             if (methodTable.putIfAbsent(element, invokable) != null) {
                 throw new IllegalStateException("Attempted to register an invokable for an already-compiled method");
             }
+        }
+    }
+
+    @Override
+    public void registerInvokable(String name, MethodDescriptor descriptor, VmInvokable invokable) throws IllegalStateException {
+        if (name.equals("<clinit>")) {
+            if (descriptor.equals(MethodDescriptor.VOID_METHOD_DESCRIPTOR)) {
+                registerInvokable(typeDefinition.getInitializer(), invokable);
+            } else {
+                throw new IllegalArgumentException("Invalid initializer descriptor " + descriptor + " on " + this);
+            }
+        } else if (name.equals("<init>")) {
+            int idx = typeDefinition.findConstructorIndex(descriptor);
+            if (idx == -1) {
+                throw new IllegalArgumentException("No constructor found with descriptor " + descriptor + " on " + this);
+            }
+            registerInvokable(typeDefinition.getConstructor(idx), invokable);
+        } else {
+            int idx = typeDefinition.findMethodIndex(name, descriptor);
+            if (idx == -1) {
+                throw new IllegalArgumentException("No method found with name \"" + name + "\" and descriptor " + descriptor + " on " + this);
+            }
+            registerInvokable(typeDefinition.getMethod(idx), invokable);
         }
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -715,6 +715,7 @@ public final class VmImpl implements Vm {
 
             // MethodHandleNatives
             VmClassImpl methodHandleNatives = bootstrapClassLoader.loadClass("java/lang/invoke/MethodHandleNatives");
+            methodHandleNatives.registerInvokable("init", (thread, target, args) -> null);
             methodHandleNatives.registerInvokable("resolve", (thread, target, args) -> {
                 VmThreadImpl ourThread = (VmThreadImpl) thread;
                 VmMemberNameImpl self = (VmMemberNameImpl) args.get(0);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -1119,6 +1119,9 @@ public final class VmImpl implements Vm {
     }
 
     VmClassImpl getClassForDescriptor(VmClassLoaderImpl cl, TypeDescriptor descriptor) {
+        if (cl == null) {
+            cl = bootstrapClassLoader;
+        }
         if (descriptor instanceof BaseTypeDescriptor) {
             return getPrimitiveClass(Primitive.getPrimitiveFor((BaseTypeDescriptor) descriptor));
         } else if (descriptor instanceof ArrayTypeDescriptor) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -613,6 +613,15 @@ public final class VmImpl implements Vm {
                 }
                 return null;
             });
+            classClass.registerInvokable("isInstance", (thread, target, args) -> {
+                VmClassImpl clazz = (VmClassImpl) target;
+                VmObject obj = (VmObject) args.get(0);
+                if (obj == null) {
+                    return Boolean.FALSE;
+                }
+                VmClass objClazz = obj.getVmClass();
+                return Boolean.valueOf(objClazz.getObjectType().isSubtypeOf(clazz.getInstanceObjectType()));
+            });
 
             // Array
             VmClassImpl arrayClass = bootstrapClassLoader.loadClass("java/lang/reflect/Array");

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -65,7 +65,6 @@ import org.qbicc.type.definition.element.Element;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
-import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
 import org.qbicc.type.descriptor.ArrayTypeDescriptor;
@@ -179,7 +178,7 @@ public final class VmImpl implements Vm {
         stringClass = new VmStringClassImpl(this, stringDef);
         FieldElement coderField = stringDef.findField("coder");
         FieldElement valueField = stringDef.findField("value");
-        Layout layout = Layout.getForInterpreter(ctxt);
+        Layout layout = Layout.get(ctxt);
         LayoutInfo stringLayout = layout.getInstanceLayoutInfo(stringDef);
         stringCoderOffset = stringLayout.getMember(coderField).getOffset();
         stringValueOffset = stringLayout.getMember(valueField).getOffset();
@@ -688,7 +687,7 @@ public final class VmImpl implements Vm {
                     if (field.isStatic()) {
                         throw new Thrown(threadImpl.getVM().errorClass.newInstance("Wrong field kind"));
                     } else {
-                        layoutInfo = Layout.getForInterpreter(ctxt).getInstanceLayoutInfo(field.getEnclosingType());
+                        layoutInfo = Layout.get(ctxt).getInstanceLayoutInfo(field.getEnclosingType());
                     }
                     return Long.valueOf(layoutInfo.getMember(field).getOffset());
                 } else {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
@@ -111,7 +111,7 @@ class VmObjectImpl implements VmObject, Referenceable {
     public int indexOf(FieldElement field) throws IllegalArgumentException {
         LoadedTypeDefinition loaded = field.getEnclosingType().load();
         CompilationContext ctxt = loaded.getContext().getCompilationContext();
-        LayoutInfo layoutInfo = Layout.getForInterpreter(ctxt).getInstanceLayoutInfo(loaded);
+        LayoutInfo layoutInfo = Layout.get(ctxt).getInstanceLayoutInfo(loaded);
         CompoundType.Member member = layoutInfo.getMember(field);
         if (member == null) {
             throw new IllegalArgumentException("Field " + field + " is not present on " + this);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableImpl.java
@@ -36,7 +36,7 @@ final class VmThrowableImpl extends VmObjectImpl implements VmThrowable {
         }
         MemoryImpl memory = getMemory();
         LoadedTypeDefinition throwableClassDef = ((VmImpl)Vm.requireCurrent()).throwableClass.getTypeDefinition();
-        Layout interpLayout = Layout.getForInterpreter(throwableClassDef.getContext().getCompilationContext());
+        Layout interpLayout = Layout.get(throwableClassDef.getContext().getCompilationContext());
         LayoutInfo layout = interpLayout.getInstanceLayoutInfo(throwableClassDef);
         int depthIdx = layout.getMember(throwableClassDef.findField("depth")).getOffset();
         memory.store32(depthIdx, backTrace.length, MemoryAtomicityMode.UNORDERED);
@@ -48,7 +48,7 @@ final class VmThrowableImpl extends VmObjectImpl implements VmThrowable {
 
     void initStackTraceElements(VmArrayImpl array) {
         VmImpl vm = getVmClass().getVm();
-        Layout interpLayout = Layout.getForInterpreter(vm.getCompilationContext());
+        Layout interpLayout = Layout.get(vm.getCompilationContext());
         // create the stack trace directly
         LoadedTypeDefinition steClassDef = vm.stackTraceElementClass.getTypeDefinition();
         LayoutInfo layout = interpLayout.getInstanceLayoutInfo(steClassDef);

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -447,7 +447,6 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPostHook(Phase.ANALYZE, new DispatchTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
 
-                                builder.addPreHook(Phase.LOWER, Layout::unlock);
                                 builder.addPreHook(Phase.LOWER, new ClassObjectSerializer());
                                 builder.addElementHandler(Phase.LOWER, new FunctionLoweringElementHandler());
                                 builder.addElementHandler(Phase.LOWER, new NativeXtorLoweringElementHandler());

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -252,18 +252,6 @@ public final class CoreIntrinsics {
         InstanceIntrinsic desiredAssertionStatus =  (builder, instance, target, arguments) ->
             classContext.getLiteralFactory().literalOf(false);
 
-        InstanceIntrinsic cast = (builder, instance, target, arguments) -> {
-            // TODO: Once we support java.lang.Class literals, we should add a check here to
-            //  emit a CheckCast node instead of a call to the helper method if `instance` is a Class literal.
-            MethodElement helper = methodFinder.getMethod("checkcastClass");
-            builder.getFirstBuilder().call(builder.staticMethod(helper, helper.getDescriptor(), helper.getType()), List.of(arguments.get(0), instance));
-
-            // Generics erasure issue. The return type of Class<T>.cast is T, but it gets wiped to Object.
-            // If the result of this cast is actually used as a T, there will be a (redundant) checkcast bytecode following this operation.
-            ReferenceType jlot = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Object").load().getType().getReference();
-            return builder.bitCast(arguments.get(0), jlot);
-        };
-
         InstanceIntrinsic initClassName = (builder, instance, target, arguments) -> {
             // not reachable; we always would initialize our class name eagerly
             throw new BlockEarlyTermination(builder.unreachable());
@@ -308,7 +296,6 @@ public final class CoreIntrinsics {
 
         //    static native Class<?> getPrimitiveClass(String name);
 
-        intrinsics.registerIntrinsic(jlcDesc, "cast", objToObj, cast);
         intrinsics.registerIntrinsic(jlcDesc, "desiredAssertionStatus0", classToBool, desiredAssertionStatus0);
         intrinsics.registerIntrinsic(jlcDesc, "desiredAssertionStatus", emptyToBool, desiredAssertionStatus);
         intrinsics.registerIntrinsic(jlcDesc, "initClassName", emptyToString, initClassName);

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
@@ -26,7 +26,6 @@ import org.qbicc.type.definition.element.FieldElement;
  */
 public final class Layout {
     private static final AttachmentKey<Layout> KEY = new AttachmentKey<>();
-    private static final AttachmentKey<Layout> I_KEY = new AttachmentKey<>();
 
     private final Map<LoadedTypeDefinition, LayoutInfo> instanceLayouts = new ConcurrentHashMap<>();
     private final Map<LoadedTypeDefinition, LayoutInfo> staticLayouts = new ConcurrentHashMap<>();
@@ -37,23 +36,11 @@ public final class Layout {
         this.ctxt = ctxt;
     }
 
-    public static void unlock(CompilationContext ctxt) {
-        ctxt.putAttachmentIfAbsent(KEY, new Layout(ctxt));
-    }
-
     public static Layout get(CompilationContext ctxt) {
         Layout layout = ctxt.getAttachment(KEY);
         if (layout == null) {
-            throw new IllegalStateException("Layout is not yet available");
-        }
-        return layout;
-    }
-
-    public static Layout getForInterpreter(CompilationContext ctxt) {
-        Layout layout = ctxt.getAttachment(I_KEY);
-        if (layout == null) {
             layout = new Layout(ctxt);
-            Layout appearing = ctxt.putAttachmentIfAbsent(I_KEY, layout);
+            Layout appearing = ctxt.putAttachmentIfAbsent(KEY, layout);
             if (appearing != null) {
                 layout = appearing;
             }

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
@@ -5,6 +5,8 @@ import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.object.Section;
+import org.qbicc.plugin.layout.Layout;
+import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
@@ -24,13 +26,17 @@ public class StaticFieldLoweringBasicBlockBuilder extends DelegatingBasicBlockBu
 
     @Override
     public ValueHandle staticField(FieldElement field) {
-        GlobalVariableElement global = Lowering.get(ctxt).getGlobalForField(field);
+        if (! field.isStatic()) {
+            throw new IllegalArgumentException();
+        }
+        GlobalVariableElement global = Lowering.get(ctxt).getStaticsGlobalForType(field.getEnclosingType().load());
         DefinedTypeDefinition fieldHolder = field.getEnclosingType();
         if (! fieldHolder.equals(ourHolder)) {
             // we have to declare it in our translation unit
             Section section = ctxt.getOrAddProgramModule(ourHolder).getOrAddSection(global.getSection());
             section.declareData(field, global.getName(), global.getType());
         }
-        return globalVariable(global);
+        LayoutInfo layoutInfo = Layout.get(ctxt).getStaticLayoutInfo(fieldHolder);
+        return memberOf(globalVariable(global), layoutInfo.getMember(field));
     }
 }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -64,7 +64,7 @@ class BuildtimeHeapAnalyzer {
             }
         }
 
-        Layout interpreterLayout = Layout.getForInterpreter(ctxt);
+        Layout interpreterLayout = Layout.get(ctxt);
         CoreClasses coreClasses = CoreClasses.get(ctxt);
         while (!worklist.isEmpty()) {
             VmObject cur = worklist.pop();

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -81,7 +81,7 @@ public class BuildtimeHeap {
 
     private BuildtimeHeap(CompilationContext ctxt) {
         this.ctxt = ctxt;
-        this.interpreterLayout = Layout.getForInterpreter(ctxt);
+        this.interpreterLayout = Layout.get(ctxt);
         this.coreClasses = CoreClasses.get(ctxt);
 
         LoadedTypeDefinition ih = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/InitialHeap").load();


### PR DESCRIPTION
This PR introduces changes which:

* Make layout (nearly) 100% consistent between build and run time
* Opens up the `VmClass.registerInvokable` API
* Lowers static fields to structures again, in order to facilitate `Unsafe.staticFieldBase`
* Removes obsolete `Class.cast` intrinsic
* Add `Class.isInstance` support to the VM (not to run time though)
* Fix a couple of problems and missing features in reflective field and method enumeration
* Change support for `objectFieldOffset` and friends to yield an exact offset, but be build-time only - fields whose offsets are observed are marked as `I_ACC_PINNED`, to allow future `LOWER`-time field deletion and reshuffling
