### PR TITLE
Introduce support for member selectors

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -279,6 +279,15 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value checkcast(Value value, TypeDescriptor desc);
 
+    /**
+     * Wrap the pointer value with a member selection node, which can later be unwrapped.
+     *
+     * @param pointerValue the pointer value to wrap (must not be {@code null})
+     * @return the member selection node (not {@code null})
+     * @see MemberSelector
+     */
+    Value selectMember(Value pointerValue);
+
     // memory handles
 
     /**

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -120,6 +120,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().checkcast(value, desc);
     }
 
+    public Value selectMember(Value pointerValue) {
+        return getDelegate().selectMember(pointerValue);
+    }
+
     public ValueHandle currentThread() {
         return getDelegate().currentThread();
     }

--- a/compiler/src/main/java/org/qbicc/graph/MemberSelector.java
+++ b/compiler/src/main/java/org/qbicc/graph/MemberSelector.java
@@ -1,0 +1,47 @@
+package org.qbicc.graph;
+
+import org.qbicc.type.VoidType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * An opaque member selection which always has a {@code void} type.  The wrapped value is a pointer to any memory object.
+ */
+public final class MemberSelector extends AbstractValue implements UnaryValue {
+    private final Value value;
+    private final VoidType voidType;
+
+    MemberSelector(Node callSite, ExecutableElement element, int line, int bci, Value value, VoidType voidType) {
+        super(callSite, element, line, bci);
+        this.value = value;
+        this.voidType = voidType;
+    }
+
+    public Value getInput() {
+        return value;
+    }
+
+    public VoidType getType() {
+        return voidType;
+    }
+
+    int calcHashCode() {
+        return value.hashCode() * 19;
+    }
+
+    @Override
+    String getNodeName() {
+        return "MemberSelector";
+    }
+
+    public boolean equals(final Object other) {
+        return other instanceof MemberSelector && equals((MemberSelector) other);
+    }
+
+    public boolean equals(final MemberSelector other) {
+        return this == other || other != null && value.equals(other.value);
+    }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -729,6 +729,10 @@ public interface Node {
                 return param.getBlockBuilder().max(param.copyValue(node.getLeftInput()), param.copyValue(node.getRightInput()));
             }
 
+            public Value visit(final Copier param, final MemberSelector node) {
+                return param.getBlockBuilder().selectMember(param.copyValue(node.getInput()));
+            }
+
             public Value visit(final Copier param, final Min node) {
                 return param.getBlockBuilder().min(param.copyValue(node.getLeftInput()), param.copyValue(node.getRightInput()));
             }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -384,6 +384,9 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
 
     public Value checkcast(final Value value, final Value toType, final Value toDimensions, final CheckCast.CastType kind, final ObjectType expectedType) {
         ValueType inputType = value.getType();
+        if (inputType instanceof VoidType) {
+            return value;
+        }
         if (! (inputType instanceof ReferenceType)) {
             throw new IllegalArgumentException("Only references can be checkcast");
         }
@@ -400,6 +403,11 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
 
     public Value checkcast(final Value value, final TypeDescriptor desc) {
         throw new IllegalStateException("CheckCast of unresolved type");
+    }
+
+    public Value selectMember(Value pointerValue) {
+        TypeSystem ts = element.getEnclosingType().getContext().getTypeSystem();
+        return new MemberSelector(callSite, element, line, bci, pointerValue, ts.getVoidType());
     }
 
     public ValueHandle currentThread() {

--- a/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
@@ -252,6 +252,10 @@ public interface ValueVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, MemberSelector node) {
+        return visitUnknown(param, node);
+    }
+
     default R visit(T param, MethodHandleLiteral node) {
         return visitUnknown(param, node);
     }
@@ -608,6 +612,10 @@ public interface ValueVisitor<T, R> {
         }
 
         default R visit(T param, Max node) {
+            return getDelegateValueVisitor().visit(param, node);
+        }
+
+        default R visit(T param, MemberSelector node) {
             return getDelegateValueVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -777,7 +777,22 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_AALOAD: {
                         v2 = pop1();
                         v1 = pop1();
-                        if (v1.getType() instanceof ArrayType) {
+                        if (v1 instanceof MemberSelector ms) {
+                            v1 = ms.getInput();
+                            if (v1.getType() instanceof PointerType pt) {
+                                ValueHandle element;
+                                if (pt.getPointeeType() instanceof ArrayType) {
+                                    element = gf.elementOf(gf.pointerHandle(v1), v2);
+                                } else {
+                                    ctxt.getCompilationContext().error(gf.getLocation(), "Invalid array dereference");
+                                    throw new BlockEarlyTermination(gf.unreachable());
+                                }
+                                v1 = gf.selectMember(gf.addressOf(element));
+                            } else {
+                                ctxt.getCompilationContext().error(gf.getLocation(), "Invalid array dereference");
+                                throw new BlockEarlyTermination(gf.unreachable());
+                            }
+                        } else if (v1.getType() instanceof ArrayType) {
                             v1 = gf.extractElement(v1, v2);
                         } else if (v1.getType() instanceof PointerType) {
                             v1 = gf.load(gf.pointerHandle(v1, v2), MemoryAtomicityMode.NONE);
@@ -791,7 +806,22 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_LALOAD: {
                         v2 = pop1();
                         v1 = pop1();
-                        if (v1.getType() instanceof ArrayType) {
+                        if (v1 instanceof MemberSelector ms) {
+                            v1 = ms.getInput();
+                            if (v1.getType() instanceof PointerType pt) {
+                                ValueHandle element;
+                                if (pt.getPointeeType() instanceof ArrayType) {
+                                    element = gf.elementOf(gf.pointerHandle(v1), v2);
+                                } else {
+                                    ctxt.getCompilationContext().error(gf.getLocation(), "Invalid array dereference");
+                                    throw new BlockEarlyTermination(gf.unreachable());
+                                }
+                                v1 = gf.selectMember(gf.addressOf(element));
+                            } else {
+                                ctxt.getCompilationContext().error(gf.getLocation(), "Invalid array dereference");
+                                throw new BlockEarlyTermination(gf.unreachable());
+                            }
+                        } else if (v1.getType() instanceof ArrayType) {
                             v1 = gf.extractElement(v1, v2);
                         } else if (v1.getType() instanceof PointerType) {
                             v1 = gf.load(gf.pointerHandle(v1, v2), MemoryAtomicityMode.NONE);
@@ -808,7 +838,22 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_CALOAD: {
                         v2 = pop1();
                         v1 = pop1();
-                        if (v1.getType() instanceof ArrayType) {
+                        if (v1 instanceof MemberSelector ms) {
+                            v1 = ms.getInput();
+                            if (v1.getType() instanceof PointerType pt) {
+                                ValueHandle element;
+                                if (pt.getPointeeType() instanceof ArrayType) {
+                                    element = gf.elementOf(gf.pointerHandle(v1), v2);
+                                } else {
+                                    ctxt.getCompilationContext().error(gf.getLocation(), "Invalid array dereference");
+                                    throw new BlockEarlyTermination(gf.unreachable());
+                                }
+                                v1 = gf.selectMember(gf.addressOf(element));
+                            } else {
+                                ctxt.getCompilationContext().error(gf.getLocation(), "Invalid array dereference");
+                                throw new BlockEarlyTermination(gf.unreachable());
+                            }
+                        } else if (v1.getType() instanceof ArrayType) {
                             v1 = promote(gf.extractElement(v1, v2));
                         } else if (v1.getType() instanceof PointerType) {
                             v1 = promote(gf.load(gf.pointerHandle(v1, v2), MemoryAtomicityMode.NONE));

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -23,6 +23,7 @@ import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.BlockEarlyTermination;
 import org.qbicc.graph.BlockLabel;
 import org.qbicc.graph.Invoke;
+import org.qbicc.graph.MemberSelector;
 import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.NodeVisitor;
@@ -50,6 +51,7 @@ import org.qbicc.type.CompoundType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.ObjectType;
+import org.qbicc.type.PhysicalObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
@@ -1542,7 +1544,24 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                         TypeDescriptor desc = getDescriptorOfFieldRef(fieldRef);
                         String name = getNameOfFieldRef(fieldRef);
                         v1 = pop1();
-                        if (v1.getType() instanceof CompoundType ct) {
+                        if (v1 instanceof MemberSelector ms) {
+                            v1 = ms.getInput();
+                            if (v1.getType() instanceof PointerType pt) {
+                                ValueHandle member;
+                                if (pt.getPointeeType() instanceof CompoundType ct) {
+                                    member = gf.memberOf(gf.pointerHandle(v1), ct.getMember(name));
+                                } else if (pt.getPointeeType() instanceof PhysicalObjectType) {
+                                    member = gf.instanceFieldOf(gf.pointerHandle(v1), owner, name, desc);
+                                } else {
+                                    ctxt.getCompilationContext().error(gf.getLocation(), "Invalid field dereference of '%s'", name);
+                                    throw new BlockEarlyTermination(gf.unreachable());
+                                }
+                                push(gf.selectMember(gf.addressOf(member)), false);
+                            } else {
+                                ctxt.getCompilationContext().error(gf.getLocation(), "Invalid field dereference of '%s'", name);
+                                throw new BlockEarlyTermination(gf.unreachable());
+                            }
+                        } else if (v1.getType() instanceof CompoundType ct) {
                             final CompoundType.Member member = ct.getMember(name);
                             push(promote(gf.extractMember(v1, member)), desc.isClass2());
                         } else {

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -80,6 +80,7 @@ import org.qbicc.graph.Load;
 import org.qbicc.graph.LocalVariable;
 import org.qbicc.graph.Max;
 import org.qbicc.graph.MemberOf;
+import org.qbicc.graph.MemberSelector;
 import org.qbicc.graph.Min;
 import org.qbicc.graph.Mod;
 import org.qbicc.graph.MonitorEnter;
@@ -1059,6 +1060,10 @@ public class DotNodeVisitor implements NodeVisitor<Appendable, String, String, S
 
     public String visit(final Appendable param, final Max node) {
         return node(param, "max", node);
+    }
+
+    public String visit(final Appendable param, final MemberSelector node) {
+        return node(param, "sel", node);
     }
 
     public String visit(final Appendable param, final Min node) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -14,6 +14,7 @@ import org.qbicc.graph.BlockEarlyTermination;
 import org.qbicc.graph.ClassOf;
 import org.qbicc.graph.Extend;
 import org.qbicc.graph.Load;
+import org.qbicc.graph.MemberSelector;
 import org.qbicc.graph.MemoryAtomicityMode;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
@@ -111,6 +112,9 @@ final class CNativeIntrinsics {
 
         StaticIntrinsic addrOf = (builder, target, arguments) -> {
             Value value = arguments.get(0);
+            if (value instanceof MemberSelector ms) {
+                return ms.getInput();
+            }
             if (value instanceof BitCast) {
                 value = ((BitCast)value).getInput();
             }
@@ -134,6 +138,7 @@ final class CNativeIntrinsics {
         intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, int16ptrDesc, List.of(BaseTypeDescriptor.S)), addrOf);
         intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, boolPtrDesc, List.of(BaseTypeDescriptor.Z)), addrOf);
         intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(nObjDesc)), addrOf);
+        intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(objDesc)), addrOf);
 
         StaticIntrinsic refToPtr = (builder, target, arguments) -> {
             Value value = arguments.get(0);
@@ -435,6 +440,10 @@ final class CNativeIntrinsics {
         intrinsics.registerIntrinsic(ptrDesc, "minus", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(BaseTypeDescriptor.I)), minus);
         intrinsics.registerIntrinsic(ptrDesc, "minus", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(ptrDiffTDesc)), minus);
         intrinsics.registerIntrinsic(ptrDesc, "minus", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(sizeTDesc)), minus);
+
+        InstanceIntrinsic sel = (builder, instance, target, arguments) -> builder.selectMember(instance);
+
+        intrinsics.registerIntrinsic(ptrDesc, "sel", MethodDescriptor.synthesize(classContext, nObjDesc, List.of()), sel);
     }
 
     static Value smartConvert(BasicBlockBuilder builder, Value input, WordType toType, boolean cRules) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -139,6 +139,8 @@ final class CNativeIntrinsics {
         intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, boolPtrDesc, List.of(BaseTypeDescriptor.Z)), addrOf);
         intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(nObjDesc)), addrOf);
         intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(objDesc)), addrOf);
+        // todo: this one is deprecated
+        intrinsics.registerIntrinsic(cNativeDesc, "addr_of", MethodDescriptor.synthesize(classContext, ptrDesc, List.of(nObjDesc)), addrOf);
 
         StaticIntrinsic refToPtr = (builder, target, arguments) -> {
             Value value = arguments.get(0);

--- a/pom.xml
+++ b/pom.xml
@@ -737,6 +737,24 @@
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jboss.bridger</groupId>
+                    <artifactId>bridger</artifactId>
+                    <version>1.6.Final</version>
+                    <executions>
+                        <execution>
+                            <id>weave</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>transform</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/runtime/api/pom.xml
+++ b/runtime/api/pom.xml
@@ -17,4 +17,13 @@
 
     <dependencies>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.bridger</groupId>
+                <artifactId>bridger</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -134,7 +134,13 @@ public final class CNative {
      * @param <T> the object type
      * @return a pointer to the object
      */
-    public static native <T extends object, P extends ptr<T>> P addr_of(T obj);
+    public static native <T, P extends ptr<T>> P addr_of(T obj);
+
+    /**
+     * @hidden
+     */
+    @Deprecated
+    public static native <T extends object, P extends ptr<T>> P addr_of$$bridge(T obj);
 
     /**
      * Get the address of the given value.  The value may be a local variable, or it may be a member or element of a
@@ -914,6 +920,14 @@ public final class CNative {
          * @return the offset pointer
          */
         public native <R extends object, P extends ptr<R>> P minus(size_t offset);
+
+        /**
+         * Select a subfield from this pointer, which must be passed back through {@link #addr_of} in order
+         * to be used.  The returned subfield has {@code void} type and thus cannot be accessed directly.
+         *
+         * @return the selection view of the pointee
+         */
+        public native T sel();
 
         /**
          * Determine if this pointer instance is a pointer to a pinned Java data structure.


### PR DESCRIPTION
This is a replacement for the unworkable `Deref` concept.

Allow a member to be selected, like this:

```java
struct_foo_ptr my_ptr = ...;
int_ptr memberPtr = addr_of(my_ptr.sel().member);
```

It's not quite as elegant but it is concise.
