### PR TITLE
bug fix in copyInstanceField intrinsic

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -1102,7 +1102,7 @@ public final class CoreIntrinsics {
             //  2. We are overwriting the object header fields initialized by new when doing the copy
             //     (to make sure we copy any instance fields that have been assigned to use the padding bytes in the basic object header).
             MethodElement method = NoGc.get(ctxt).getCopyMethod();
-            return builder.call(builder.staticMethod(method, method.getDescriptor(), method.getType()), List.of(src, dst, size));
+            return builder.call(builder.staticMethod(method, method.getDescriptor(), method.getType()), List.of(dst, src, size));
         };
         intrinsics.registerIntrinsic(Phase.LOWER, ciDesc, "copyInstanceFields", copyDesc, copy);
     }


### PR DESCRIPTION
Forgot to convert from Java's (src, dst) convention to C's (dst, src).