### PR TITLE
Escape Analysis

### DIFF
--- a/driver/src/main/java/org/qbicc/driver/GraphGenConfig.java
+++ b/driver/src/main/java/org/qbicc/driver/GraphGenConfig.java
@@ -16,6 +16,8 @@ public class GraphGenConfig {
 
     private EnumMap<Phase, HashSet<String>> phaseToMethodsMap = new EnumMap<>(Phase.class);
 
+    private boolean enabled;
+
     public void addMethodAndPhase(String method, String phaseString) {
         List<Phase> phaseList = new ArrayList<>();
         if (phaseString.equalsIgnoreCase(ALL_PHASES)) {
@@ -41,6 +43,14 @@ public class GraphGenConfig {
 
     public GraphGenFilter getFilter() {
         return new GraphGenOptionsFilter();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     class GraphGenOptionsFilter implements GraphGenFilter {

--- a/integration-tests/src/it/java/org/qbicc/tests/integration/utils/Qbicc.java
+++ b/integration-tests/src/it/java/org/qbicc/tests/integration/utils/Qbicc.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 
 import org.jboss.logging.Logger;
 import org.qbicc.context.DiagnosticContext;
+import org.qbicc.driver.GraphGenConfig;
 import org.qbicc.main.ClassPathEntry;
 import org.qbicc.main.Main;
 
@@ -12,6 +13,7 @@ public class Qbicc {
         return Main.builder().appendBootPath(ClassPathEntry.of(outputPath))
             .setOutputPath(nativeOutputPath)
             .setDiagnosticsHandler(new QbiccDiagnosticLogger(logger))
+            .setGraphGenConfig(new GraphGenConfig())
             .setMainClass(mainClass)
             .build()
             .call();

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -118,7 +118,6 @@ import org.qbicc.plugin.opt.ea.EscapeAnalysisInterMethodAnalysis;
 import org.qbicc.plugin.opt.ea.EscapeAnalysisIntraMethodBuilder;
 import org.qbicc.plugin.opt.ea.ConnectionGraphDotGenerator;
 import org.qbicc.plugin.opt.ea.EscapeAnalysisOptimizeVisitor;
-import org.qbicc.plugin.opt.ea.EscapeAnalysisState;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.plugin.reachability.ReachabilityBlockBuilder;
 import org.qbicc.plugin.reachability.ReachabilityInfo;

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -114,6 +114,12 @@ import org.qbicc.plugin.patcher.AccessorTypeBuilder;
 import org.qbicc.plugin.patcher.Patcher;
 import org.qbicc.plugin.patcher.PatcherResolverBasicBlockBuilder;
 import org.qbicc.plugin.patcher.PatcherTypeResolver;
+import org.qbicc.plugin.opt.ea.EscapeAnalysisInterMethodAnalysis;
+import org.qbicc.plugin.opt.ea.EscapeAnalysisIntraMethodBuilder;
+import org.qbicc.plugin.opt.ea.ConnectionGraphDotGenerator;
+import org.qbicc.plugin.opt.ea.EscapeAnalysisOptimizeVisitor;
+import org.qbicc.plugin.opt.ea.EscapeAnalysisState;
+import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.plugin.reachability.ReachabilityBlockBuilder;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.plugin.reflection.Reflection;
@@ -150,6 +156,7 @@ public class Main implements Callable<DiagnosticContext> {
     private final boolean optPhis;
     private final boolean optGotos;
     private final boolean optInlining;
+    private final boolean optEscapeAnalysis;
     private final Platform platform;
     private final boolean smallTypeIds;
 
@@ -165,6 +172,7 @@ public class Main implements Callable<DiagnosticContext> {
         optInlining = builder.optInlining;
         optPhis = builder.optPhis;
         optGotos = builder.optGotos;
+        optEscapeAnalysis = builder.optEscapeAnalysis;
         platform = builder.platform;
         smallTypeIds = builder.smallTypeIds;
         ArrayList<ClassPathEntry> bootPaths = new ArrayList<>(builder.bootPathsPrepend.size() + 6 + builder.bootPathsAppend.size());
@@ -418,6 +426,9 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachable);
                                 builder.addElementHandler(Phase.ANALYZE, new ElementBodyCopier());
                                 builder.addElementHandler(Phase.ANALYZE, new ElementVisitorAdapter(new DotGenerator(Phase.ANALYZE, graphGenConfig)));
+                                if (optEscapeAnalysis && graphGenConfig.isEnabled()) {
+                                    builder.addElementHandler(Phase.ANALYZE, new ElementVisitorAdapter(new ConnectionGraphDotGenerator("intra")));
+                                }
                                 if (optGotos) {
                                     builder.addCopyFactory(Phase.ANALYZE, GotoRemovingVisitor::new);
                                 }
@@ -436,6 +447,9 @@ public class Main implements Callable<DiagnosticContext> {
                                 if (optInlining) {
                                     builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.OPTIMIZE, InliningBasicBlockBuilder::new);
                                 }
+                                if (optEscapeAnalysis) {
+                                    builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.OPTIMIZE, EscapeAnalysisIntraMethodBuilder::new);
+                                }
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, ReachabilityBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, LocalVariableFindingBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.ANALYZE, BuilderStage.INTEGRITY, StaticChecksBasicBlockBuilder::new);
@@ -443,10 +457,19 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPostHook(Phase.ANALYZE, ReachabilityInfo::reportStats);
                                 // todo: restore when adapted for run time initializers
                                 //builder.addPostHook(Phase.ANALYZE, new ClassInitializerRegister());
+                                if (optEscapeAnalysis) {
+                                    builder.addPostHook(Phase.ANALYZE, new EscapeAnalysisInterMethodAnalysis());
+                                    if (graphGenConfig.isEnabled()) {
+                                        builder.addPostHook(Phase.ANALYZE, new ConnectionGraphDotGenerator("inter"));
+                                    }
+                                }
                                 builder.addPostHook(Phase.ANALYZE, new DispatchTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
 
                                 builder.addPreHook(Phase.LOWER, new ClassObjectSerializer());
+                                if (optEscapeAnalysis) {
+                                    builder.addCopyFactory(Phase.LOWER, EscapeAnalysisOptimizeVisitor::new);
+                                }
                                 builder.addElementHandler(Phase.LOWER, new FunctionLoweringElementHandler());
                                 builder.addElementHandler(Phase.LOWER, new NativeXtorLoweringElementHandler());
                                 builder.addElementHandler(Phase.LOWER, new ElementVisitorAdapter(new DotGenerator(Phase.LOWER, graphGenConfig)));
@@ -559,6 +582,7 @@ public class Main implements Callable<DiagnosticContext> {
             .setOptInlining(optionsProcessor.optArgs.optInlining)
             .setOptGotos(optionsProcessor.optArgs.optGotos)
             .setOptPhis(optionsProcessor.optArgs.optPhis)
+            .setOptEscapeAnalysis(optionsProcessor.optArgs.optEscapeAnalysis)
             .setSmallTypeIds(optionsProcessor.smallTypeIds)
             .setGraphGenConfig(optionsProcessor.graphGenConfig);
         Platform platform = optionsProcessor.platform;
@@ -703,6 +727,8 @@ public class Main implements Callable<DiagnosticContext> {
             boolean optPhis;
             @CommandLine.Option(names = "--no-opt-gotos", negatable = true, defaultValue = "true", description = "Enable/disable `goto` elimination")
             boolean optGotos;
+            @CommandLine.Option(names = "--no-escape-analysis", negatable = true, defaultValue = "true", description = "Enable/disable escape analysis")
+            boolean optEscapeAnalysis;
         }
 
         public CmdResult process(String[] args) {
@@ -750,6 +776,7 @@ public class Main implements Callable<DiagnosticContext> {
             }
 
             if (graphGenArgs != null && graphGenArgs.genGraph) {
+                graphGenConfig.setEnabled(true);
                 if (graphGenArgs.methodsAndPhases == null) {
                     graphGenConfig.addMethodAndPhase(GraphGenConfig.ALL_METHODS, GraphGenConfig.ALL_PHASES);
                 } else {
@@ -786,6 +813,7 @@ public class Main implements Callable<DiagnosticContext> {
         private boolean optInlining = false;
         private boolean optPhis = true;
         private boolean optGotos = true;
+        private boolean optEscapeAnalysis = true;
         private GraphGenConfig graphGenConfig;
         private boolean smallTypeIds = false;
 
@@ -890,6 +918,11 @@ public class Main implements Callable<DiagnosticContext> {
 
         public Builder setOptGotos(boolean optGotos) {
             this.optGotos = optGotos;
+            return this;
+        }
+
+        public Builder setOptEscapeAnalysis(boolean optEscapeAnalysis) {
+            this.optEscapeAnalysis = optEscapeAnalysis;
             return this;
         }
 

--- a/plugins/optimization/pom.xml
+++ b/plugins/optimization/pom.xml
@@ -24,6 +24,15 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-driver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-layout</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-reachability</artifactId>
+        </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/ConnectionGraph.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/ConnectionGraph.java
@@ -1,0 +1,303 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.qbicc.graph.Call;
+import org.qbicc.graph.CheckCast;
+import org.qbicc.graph.InstanceFieldOf;
+import org.qbicc.graph.Load;
+import org.qbicc.graph.LocalVariable;
+import org.qbicc.graph.New;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.ParameterValue;
+import org.qbicc.graph.PhiValue;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+
+final class ConnectionGraph {
+    // TODO Handle situations where a node has multiple points-to.
+    //      Even if a reference is potentially assigned multiple New nodes (e.g. branches), the refs are currently different.
+    private final Map<Node, Node> pointsToEdges = new HashMap<>(); // solid (P) edges
+    private final Map<Node, ValueHandle> deferredEdges = new HashMap<>(); // dashed (D) edges
+    private final Map<Node, Collection<InstanceFieldOf>> fieldEdges = new HashMap<>(); // solid (F) edges
+
+    private final Map<Node, EscapeValue> escapeValues = new HashMap<>();
+    private final Map<ValueHandle, New> localNewNodes = new HashMap<>();
+    private final List<ParameterValue> parameters = new ArrayList<>();
+    private final String name;
+
+    ConnectionGraph(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionGraph{" +
+            "name='" + name + '\'' +
+            '}';
+    }
+
+    void trackLocalNew(LocalVariable localHandle, New new_) {
+        localNewNodes.put(localHandle, new_);
+    }
+
+    void trackNew(New new_, EscapeValue escapeValue) {
+        setEscapeValue(new_, escapeValue);
+    }
+
+    void trackParameters(List<ParameterValue> args) {
+        parameters.addAll(args);
+    }
+
+    void trackReturn(Value value) {
+        if (value instanceof Load) {
+            final Value localNew = localNewNodes.get(value.getValueHandle());
+            if (localNew != null) {
+                setEscapeValue(localNew, EscapeValue.ARG_ESCAPE);
+                return;
+            }
+        }
+
+        setEscapeValue(value, EscapeValue.ARG_ESCAPE);
+    }
+
+    void trackStoreStaticField(ValueHandle handle, Value value) {
+        addPointsToEdgeIfAbsent(handle, value);
+        setEscapeValue(handle, EscapeValue.GLOBAL_ESCAPE);
+    }
+
+    void trackThrowNew(New value) {
+        // New allocations thrown assumed to escape as arguments
+        // TODO Could it be possible to only mark as argument escaping those that escape the method?
+        setEscapeValue(value, EscapeValue.ARG_ESCAPE);
+    }
+    
+    void trackCast(CheckCast checkCast) {
+        addPointsToEdgeIfAbsent(checkCast, checkCast.getInput());
+    }
+
+    void fixEdgesField(New new_, ValueHandle newHandle, InstanceFieldOf instanceField) {
+        addFieldEdgeIfAbsent(new_, instanceField);
+        addPointsToEdgeIfAbsent(newHandle, new_);
+    }
+
+    void fixEdgesNew(ValueHandle newHandle, New new_) {
+        addPointsToEdgeIfAbsent(newHandle, new_);
+    }
+
+    void fixEdgesParameterValue(ParameterValue from, InstanceFieldOf to) {
+        addDeferredEdgeIfAbsent(from, to);
+    }
+
+    /**
+     * Returns the escape value associated with the given node.
+     * If the node is not found, its escape value is unknown.
+     */
+    EscapeValue getEscapeValue(Node node) {
+        return EscapeValue.of(escapeValues.get(node));
+    }
+
+    /**
+     * Returns the field nodes associated with the give node.
+     * If the node is not found, an empty collection is returned.
+     */
+    Collection<InstanceFieldOf> getFields(Node node) {
+         final Collection<InstanceFieldOf> fields = fieldEdges.get(node);
+         return Objects.isNull(fields) ? Collections.emptyList() : fields;
+    }
+
+    ValueHandle getDeferred(Node node) {
+        return deferredEdges.get(node);
+    }
+
+    void updateAtMethodEntry() {
+        // Set all parameters as arg escape
+        parameters.forEach(arg -> setEscapeValue(arg, EscapeValue.ARG_ESCAPE));
+    }
+
+    void updateAfterInvokingMethod(Call callee, ConnectionGraph calleeCG) {
+        // TODO this should really be removed, no method called that is not reachable should make it here
+        if (callee.getArguments().size() > calleeCG.parameters.size())
+            return;
+
+        final List<Value> arguments = callee.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            final Value outsideArg = arguments.get(i);
+            final ParameterValue insideArg = calleeCG.parameters.get(i);
+            updateCallerNodes(insideArg, List.of(outsideArg), calleeCG, new ArrayList<>());
+        }
+    }
+
+    private void updateCallerNodes(Node calleeNode, Collection<Node> mapsToField, ConnectionGraph calleeCG, Collection<Node> mapsToObj) {
+        // TODO includeSelf only needed for ParameterValue nodes, otherwise it's wasteful
+        //      consider alternative based on phantom nodes or self references
+        for (Node calleePointed : calleeCG.getPointsTo(calleeNode, true)) {
+            for (Node callerNode : mapsToField) {
+                for (Node callerPointed : getPointsTo(callerNode, true)) {
+                    if (mapsToObj.add(calleePointed)) {
+                        // The escape state of caller nodes is marked GlobalEscape,
+                        // if the escape state of the callee node is GlobalEscape.
+                        if (calleeCG.getEscapeValue(calleePointed).isGlobalEscape()) {
+                            setEscapeValue(callerPointed, EscapeValue.GLOBAL_ESCAPE);
+                        }
+
+                        for (InstanceFieldOf calleeField : calleeCG.getFields(calleePointed)) {
+                            final String calleeFieldName = calleeField.getVariableElement().getName();
+                            final Collection<Node> callerFields = getFields(callerPointed).stream()
+                                .filter(field -> Objects.equals(field.getVariableElement().getName(), calleeFieldName))
+                                .collect(Collectors.toList());
+
+                            updateCallerNodes(calleeField, callerFields, calleeCG, mapsToObj);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void updateAtMethodExit() {
+        // Use by pass function to eliminate all deferred edges in the CG
+        bypassAllDeferredEdges(deferredEdges);
+
+        // Mark all nodes reachable from a global escape nodes as global escape.
+        propagateGlobalEscape();
+
+        // Mark all nodes reachable from arg escape nodes, but not global escape, as arg escape.
+        propagateArgEscapeOnly();
+    }
+
+    private void bypassAllDeferredEdges(Map<Node, ValueHandle> oldDeferredEdges) {
+        if (oldDeferredEdges.isEmpty()) {
+            deferredEdges.clear();
+            return;
+        }
+
+        Map<Node, ValueHandle> newDeferredEdges = new HashMap<>();
+        for (ValueHandle node : oldDeferredEdges.values()) {
+            final ValueHandle defersTo = oldDeferredEdges.get(node);
+            final Node pointsTo = pointsToEdges.get(node);
+            if (defersTo != null || pointsTo != null) {
+                for (Map.Entry<Node, ValueHandle> incoming : oldDeferredEdges.entrySet()) {
+                    if (incoming.getValue().equals(node)) {
+                        if (defersTo != null) {
+                            newDeferredEdges.put(incoming.getKey(), defersTo);
+                        }
+                        if (pointsTo != null) {
+                            addPointsToEdgeIfAbsent(incoming.getKey(), pointsTo);
+                        }
+                    }
+                }
+            }
+        }
+
+        bypassAllDeferredEdges(newDeferredEdges);
+    }
+
+    private void propagateGlobalEscape() {
+        final List<Node> argEscapeOnly = escapeValues.entrySet().stream()
+            .filter(e -> e.getValue().isGlobalEscape())
+            .map(Map.Entry::getKey)
+            .toList();
+
+        // Separate computing from filtering since it modifies the collection itself
+        argEscapeOnly.forEach(this::computeGlobalEscape);
+    }
+
+    private void computeGlobalEscape(Node from) {
+        final Node to = pointsToEdges.get(from);
+
+        if (to != null) {
+            setEscapeValue(to, EscapeValue.GLOBAL_ESCAPE);
+            computeGlobalEscape(to);
+        }
+    }
+
+    void propagateArgEscapeOnly() {
+        final List<Node> argEscapeOnly = escapeValues.entrySet().stream()
+            .filter(e -> e.getValue().isArgEscape())
+            .map(Map.Entry::getKey)
+            .toList();
+
+        // Separate computing from filtering since it modifies the collection itself
+        argEscapeOnly.forEach(this::computeArgEscapeOnly);
+    }
+
+    private void computeArgEscapeOnly(Node from) {
+        final Node to = pointsToEdges.get(from);
+
+        if (to != null && getEscapeValue(to).notGlobalEscape()) {
+            setEscapeValue(to, EscapeValue.ARG_ESCAPE);
+            computeArgEscapeOnly(to);
+        }
+    }
+
+    /**
+     * PointsTo(p) returns the set of nodes that are immediately pointed by p.
+     * If includeSelf is true, the set also includes p, otherwise it won't be present.
+     */
+    Collection<Node> getPointsTo(Node node, boolean includeSef) {
+        final Node pointsTo = pointsToEdges.get(node);
+        return pointsTo != null
+            ? includeSef ? List.of(node, pointsTo) : List.of(pointsTo)
+            : includeSef ? List.of(node) : List.of();
+    }
+
+    ConnectionGraph union(ConnectionGraph other) {
+        if (Objects.nonNull(other)) {
+            this.pointsToEdges.putAll(other.pointsToEdges);
+            this.deferredEdges.putAll(other.deferredEdges);
+            this.fieldEdges.putAll(other.fieldEdges);
+
+            final Map<Node, EscapeValue> mergedEscapeValues = mergeEscapeValues(other);
+            this.escapeValues.clear();
+            this.escapeValues.putAll(mergedEscapeValues);
+
+            this.localNewNodes.putAll(other.localNewNodes);
+            this.parameters.addAll(other.parameters);
+        }
+
+        return this;
+    }
+
+    void resolveReturnedPhiValues() {
+        final List<Value> possibleNewValues = this.escapeValues.entrySet().stream()
+            .filter(entry -> entry.getKey() instanceof PhiValue && entry.getValue().isArgEscape())
+            .flatMap(entry -> ((PhiValue) entry.getKey()).getPossibleValues().stream())
+            .filter(value -> value instanceof New && getEscapeValue(value).isNoEscape())
+            .toList();
+
+        // Separate computing from filtering since it modifies the collection itself
+        possibleNewValues.forEach(value -> setEscapeValue(value, EscapeValue.ARG_ESCAPE));
+    }
+
+    private Map<Node, EscapeValue> mergeEscapeValues(ConnectionGraph other) {
+        final Map<Node, EscapeValue> result = new HashMap<>(this.escapeValues);
+        other.escapeValues.forEach((key, value) -> result.merge(key, value, EscapeValue::merge));
+        return result;
+    }
+
+    private boolean addFieldEdgeIfAbsent(New from, InstanceFieldOf to) {
+        return fieldEdges
+            .computeIfAbsent(from, obj -> new ArrayList<>())
+            .add(to);
+    }
+
+    private boolean addPointsToEdgeIfAbsent(Node from, Node to) {
+        return pointsToEdges.putIfAbsent(from, to) == null;
+    }
+
+    private boolean addDeferredEdgeIfAbsent(Node from, ValueHandle to) {
+        return deferredEdges.putIfAbsent(from, to) == null;
+    }
+
+    private void setEscapeValue(Node node, EscapeValue escapeValue) {
+        escapeValues.put(node, escapeValue);
+    }
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/ConnectionGraphDotGenerator.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/ConnectionGraphDotGenerator.java
@@ -1,0 +1,97 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.function.Consumer;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.context.Diagnostic;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.classfile.ClassFile;
+import org.qbicc.type.definition.element.BasicElement;
+import org.qbicc.type.definition.element.ElementVisitor;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+public final class ConnectionGraphDotGenerator implements ElementVisitor<CompilationContext, Void>, Consumer<CompilationContext> {
+    final String phase;
+
+    public ConnectionGraphDotGenerator(String phase) {
+        this.phase = phase;
+    }
+
+    @Override
+    public void accept(CompilationContext ctxt) {
+        EscapeAnalysisState state = EscapeAnalysisState.get(ctxt);
+        state.getMethodsVisited().forEach(this::process);
+    }
+
+    public Void visitUnknown(final CompilationContext ctxt, final BasicElement basicElement) {
+        if (basicElement instanceof ExecutableElement) {
+            process((ExecutableElement) basicElement);
+        }
+        return null;
+    }
+
+    private void process(ExecutableElement element) {
+        if (element.hasMethodBody()) {
+            MethodBody methodBody = element.getMethodBody();
+            process(element, methodBody);
+        }
+    }
+
+    private void process(final ExecutableElement element, final MethodBody methodBody) {
+        if (element.hasAllModifiersOf(ClassFile.ACC_ABSTRACT)) return;
+        DefinedTypeDefinition def = element.getEnclosingType();
+        CompilationContext ctxt = def.getContext().getCompilationContext();
+        BasicBlock entryBlock = methodBody.getEntryBlock();
+        Path dir = ctxt.getOutputDirectory(element);
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            failedToWrite(ctxt, dir, e);
+            return;
+        }
+        Path path = dir.resolve("ea-" + phase + ".dot");
+        try (BufferedWriter bw = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            bw.write("digraph {");
+            bw.newLine();
+            bw.write("graph [ rankdir = BT ];");
+            bw.newLine();
+            bw.write("edge [ splines = true ];");
+            bw.newLine();
+            bw.write("node [colorscheme=pastel24];");
+            bw.newLine();
+            bw.write("\"Global Escape\" [style=filled fillcolor = 2];");
+            bw.newLine();
+            bw.write("\"Arg Escape\" [style=filled fillcolor = 3];");
+            bw.newLine();
+            bw.write("\"No Escape\" [style=filled fillcolor = 1];");
+            bw.newLine();
+            bw.write("\"Unknown\" [style=filled fillcolor = 4];");
+            bw.newLine();
+            bw.newLine();
+            final ConnectionGraph connectionGraph = EscapeAnalysisState.get(ctxt).getConnectionGraph(element);
+            ConnectionGraphDotVisitor visitor = new ConnectionGraphDotVisitor(entryBlock, connectionGraph);
+            visitor.process(bw);
+            bw.write("}");
+        } catch (IOException e) {
+            failedToWrite(ctxt, path, e);
+        } catch (UncheckedIOException e) {
+            IOException cause = e.getCause();
+            failedToWrite(ctxt, path, cause);
+        } catch (TooBigException e) {
+            ctxt.warning("Element \"%s\" is too big to graph", element);
+        }
+    }
+
+    private static Diagnostic failedToWrite(final CompilationContext ctxt, final Path path, final IOException cause) {
+        return ctxt.warning("Failed to write \"%s\": %s", path, cause);
+    }
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/ConnectionGraphDotVisitor.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/ConnectionGraphDotVisitor.java
@@ -1,0 +1,1254 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.qbicc.graph.Action;
+import org.qbicc.graph.Add;
+import org.qbicc.graph.AddressOf;
+import org.qbicc.graph.And;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BinaryValue;
+import org.qbicc.graph.BitCast;
+import org.qbicc.graph.BlockEntry;
+import org.qbicc.graph.Call;
+import org.qbicc.graph.CallNoReturn;
+import org.qbicc.graph.CallNoSideEffects;
+import org.qbicc.graph.CastValue;
+import org.qbicc.graph.CheckCast;
+import org.qbicc.graph.ClassOf;
+import org.qbicc.graph.Cmp;
+import org.qbicc.graph.CmpAndSwap;
+import org.qbicc.graph.CmpG;
+import org.qbicc.graph.CmpL;
+import org.qbicc.graph.Comp;
+import org.qbicc.graph.ConstructorElementHandle;
+import org.qbicc.graph.Convert;
+import org.qbicc.graph.CountLeadingZeros;
+import org.qbicc.graph.CountTrailingZeros;
+import org.qbicc.graph.CurrentThreadRead;
+import org.qbicc.graph.DebugAddressDeclaration;
+import org.qbicc.graph.Div;
+import org.qbicc.graph.ElementOf;
+import org.qbicc.graph.ExactMethodElementHandle;
+import org.qbicc.graph.Extend;
+import org.qbicc.graph.ExtractElement;
+import org.qbicc.graph.ExtractInstanceField;
+import org.qbicc.graph.ExtractMember;
+import org.qbicc.graph.Fence;
+import org.qbicc.graph.FunctionElementHandle;
+import org.qbicc.graph.GetAndAdd;
+import org.qbicc.graph.GetAndBitwiseAnd;
+import org.qbicc.graph.GetAndBitwiseNand;
+import org.qbicc.graph.GetAndBitwiseOr;
+import org.qbicc.graph.GetAndBitwiseXor;
+import org.qbicc.graph.GetAndSet;
+import org.qbicc.graph.GetAndSetMax;
+import org.qbicc.graph.GetAndSetMin;
+import org.qbicc.graph.GetAndSub;
+import org.qbicc.graph.GlobalVariable;
+import org.qbicc.graph.Goto;
+import org.qbicc.graph.If;
+import org.qbicc.graph.InitCheck;
+import org.qbicc.graph.InsertElement;
+import org.qbicc.graph.InsertMember;
+import org.qbicc.graph.InstanceFieldOf;
+import org.qbicc.graph.InstanceOf;
+import org.qbicc.graph.InterfaceMethodElementHandle;
+import org.qbicc.graph.Invoke;
+import org.qbicc.graph.InvokeNoReturn;
+import org.qbicc.graph.IsEq;
+import org.qbicc.graph.IsGe;
+import org.qbicc.graph.IsGt;
+import org.qbicc.graph.IsLe;
+import org.qbicc.graph.IsLt;
+import org.qbicc.graph.IsNe;
+import org.qbicc.graph.Jsr;
+import org.qbicc.graph.Load;
+import org.qbicc.graph.LocalVariable;
+import org.qbicc.graph.Max;
+import org.qbicc.graph.MemberOf;
+import org.qbicc.graph.Min;
+import org.qbicc.graph.Mod;
+import org.qbicc.graph.MonitorEnter;
+import org.qbicc.graph.MonitorExit;
+import org.qbicc.graph.MultiNewArray;
+import org.qbicc.graph.Multiply;
+import org.qbicc.graph.Neg;
+import org.qbicc.graph.New;
+import org.qbicc.graph.NewArray;
+import org.qbicc.graph.NewReferenceArray;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.NotNull;
+import org.qbicc.graph.OffsetOfField;
+import org.qbicc.graph.Or;
+import org.qbicc.graph.OrderedNode;
+import org.qbicc.graph.ParameterValue;
+import org.qbicc.graph.PhiValue;
+import org.qbicc.graph.PointerHandle;
+import org.qbicc.graph.ReadModifyWriteValue;
+import org.qbicc.graph.ReferenceHandle;
+import org.qbicc.graph.Ret;
+import org.qbicc.graph.Return;
+import org.qbicc.graph.Rol;
+import org.qbicc.graph.Ror;
+import org.qbicc.graph.Select;
+import org.qbicc.graph.Shl;
+import org.qbicc.graph.Shr;
+import org.qbicc.graph.StackAllocation;
+import org.qbicc.graph.StaticField;
+import org.qbicc.graph.StaticMethodElementHandle;
+import org.qbicc.graph.Store;
+import org.qbicc.graph.Sub;
+import org.qbicc.graph.Switch;
+import org.qbicc.graph.TailCall;
+import org.qbicc.graph.TailInvoke;
+import org.qbicc.graph.Terminator;
+import org.qbicc.graph.Throw;
+import org.qbicc.graph.Truncate;
+import org.qbicc.graph.UnaryValue;
+import org.qbicc.graph.Unreachable;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.ValueReturn;
+import org.qbicc.graph.VirtualMethodElementHandle;
+import org.qbicc.graph.Xor;
+import org.qbicc.graph.literal.BitCastLiteral;
+import org.qbicc.graph.literal.BlockLiteral;
+import org.qbicc.graph.literal.BooleanLiteral;
+import org.qbicc.graph.literal.ConstantLiteral;
+import org.qbicc.graph.literal.FloatLiteral;
+import org.qbicc.graph.literal.IntegerLiteral;
+import org.qbicc.graph.literal.MethodHandleLiteral;
+import org.qbicc.graph.literal.NullLiteral;
+import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.graph.literal.ProgramObjectLiteral;
+import org.qbicc.graph.literal.StringLiteral;
+import org.qbicc.graph.literal.TypeLiteral;
+import org.qbicc.graph.literal.UndefinedLiteral;
+import org.qbicc.graph.literal.ZeroInitializerLiteral;
+
+public class ConnectionGraphDotVisitor implements NodeVisitor<Appendable, String, String, String, String> {
+
+    private final ConnectionGraph connectionGraph;
+
+    // TODO copied from DotNodeVisitor
+    final BasicBlock entryBlock;
+    final Map<Node, String> visited = new HashMap<>();
+    private final Set<BasicBlock> blockQueued = ConcurrentHashMap.newKeySet();
+    private final Queue<BasicBlock> blockQueue = new ArrayDeque<>();
+    int depth;
+    int counter;
+    int bbCounter;
+    boolean attr;
+    boolean commaNeeded;
+    // Queue<String> dependencyList = new ArrayDeque();
+    // List<NodePair> bbConnections = new ArrayList<>(); // stores pair of Terminator, BlockEntry
+    // private final Queue<PhiValue> phiQueue = new ArrayDeque<>();
+
+    public ConnectionGraphDotVisitor(BasicBlock entryBlock, ConnectionGraph connectionGraph) {
+        this.entryBlock = entryBlock;
+        this.connectionGraph = connectionGraph;
+    }
+
+    @Override
+    public String visitUnknown(final Appendable param, Value node) {
+        throw new IllegalStateException("Visitor for node " + node.getClass() + " is not implemented");
+    }
+
+    @Override
+    public String visit(Appendable param, BlockEntry node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Cmp node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, CmpAndSwap node) {
+        String name = register(node);
+        processDependency(param, node.getExpectedValue());
+        processDependency(param, node.getUpdateValue());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final CmpL node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final CmpG node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final ElementOf node) {
+        String name = register(node);
+        processDependency(param, node.getValueHandle());
+        processDependency(param, node.getIndex());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final GlobalVariable node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final InstanceFieldOf node) {
+        String name = register(node);
+        appendTo(param, name);
+        attr(param, "label", "field access\\n"+node.getVariableElement().getName()); // TODO copied from DotNodeVisitor
+        attr(param, "style", "filled");
+        attr(param, "fillcolor", String.valueOf(nodeType(connectionGraph.getEscapeValue(node)).fillColor));
+        nl(param);
+        final Collection<Node> pointsTo = connectionGraph.getPointsTo(node, false);
+        for (Node pointsToNode : pointsTo) {
+            String valueName = getNodeName(param, pointsToNode);
+            addEdge(param, name, valueName, EdgeType.POINTS_TO);
+        }
+
+        processDependency(param, node.getValueHandle());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final MemberOf node) {
+        String name = register(node);
+        processDependency(param, node.getValueHandle());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final MonitorEnter node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getInstance());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final MonitorExit node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getInstance());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final PointerHandle node) {
+        String name = register(node);
+        processDependency(param, node.getPointerValue());
+        return name;
+    }
+
+
+    @Override
+    public String visit(final Appendable param, final ReferenceHandle node) {
+        String name = register(node);
+        processDependency(param, node.getReferenceValue());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final StaticField node) {
+        String name = register(node);
+        appendTo(param, name);
+        nl(param);
+        attr(param, "label", "static field\\n" + node.getVariableElement().toString());
+        attr(param, "style", "filled");
+        attr(param, "fillcolor", String.valueOf(nodeType(connectionGraph.getEscapeValue(node)).fillColor));
+        nl(param);
+        final Collection<Node> pointsTo = connectionGraph.getPointsTo(node, false);
+        for (Node pointsToNode : pointsTo) {
+            String valueName = getNodeName(param, pointsToNode);
+            addEdge(param, name, valueName, EdgeType.POINTS_TO);
+        }
+        return name;
+    }
+
+    // value handles
+
+    @Override
+    public String visit(Appendable param, ConstructorElementHandle node) {
+        String name = register(node);
+        processDependency(param, node.getInstance());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, ExactMethodElementHandle node) {
+        String name = register(node);
+        processDependency(param, node.getInstance());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, FunctionElementHandle node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(Appendable param, InterfaceMethodElementHandle node) {
+        String name = register(node);
+        processDependency(param, node.getInstance());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, VirtualMethodElementHandle node) {
+        String name = register(node);
+        processDependency(param, node.getInstance());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, LocalVariable node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(Appendable param, StaticMethodElementHandle node) {
+        return register(node);
+    }
+
+    // terminators
+
+    // terminator
+    public String visit(final Appendable param, final CallNoReturn node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getValueHandle());
+        for (Value arg : node.getArguments()) {
+            processDependency(param, arg);
+        }
+        appendTo(param, "}");
+        nl(param);
+        return name;
+    }
+
+    // terminator
+    public String visit(Appendable param, Invoke node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getValueHandle());
+        for (Value arg : node.getArguments()) {
+            processDependency(param, arg);
+        }
+        appendTo(param, "}");
+        nl(param);
+        addToQueue(node.getCatchBlock());
+        addToQueue(node.getResumeTarget());
+        return name;
+    }
+
+    // terminator
+
+    public String visit(Appendable param, InvokeNoReturn node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getValueHandle());
+        for (Value arg : node.getArguments()) {
+            processDependency(param, arg);
+        }
+        appendTo(param, "}");
+        nl(param);
+        addToQueue(node.getCatchBlock());
+        return name;
+    }
+    // terminator
+
+    public String visit(Appendable param, TailCall node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getValueHandle());
+        for (Value arg : node.getArguments()) {
+            processDependency(param, arg);
+        }
+        appendTo(param, "}");
+        nl(param);
+        return name;
+    }
+    // terminator
+
+    public String visit(Appendable param, TailInvoke node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getValueHandle());
+        for (Value arg : node.getArguments()) {
+            processDependency(param, arg);
+        }
+        appendTo(param, "}");
+        nl(param);
+        addToQueue(node.getCatchBlock());
+        return name;
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Goto node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        appendTo(param, "}");
+        nl(param);
+        addToQueue(node.getResumeTarget());
+        return name;
+    }
+    // terminator
+
+    public String visit(final Appendable param, final If node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getCondition());
+        appendTo(param, "}");
+        nl(param);
+        addToQueue(node.getTrueBranch());
+        addToQueue(node.getFalseBranch());
+        return name;
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Jsr node) {
+        return bypassTerminator(param, node);
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Ret node) {
+        return bypassTerminator(param, node);
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Return node) {
+        return bypassTerminator(param, node);
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Invoke.ReturnValue node) {
+        processDependency(param, node.getInvoke());
+        return visited.get(node.getInvoke());
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Unreachable node) {
+        return bypassTerminator(param, node);
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Switch node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        appendTo(param, "}");
+        nl(param);
+        int cnt = node.getNumberOfValues();
+        for (int i = 0; i < cnt; i++) {
+            addToQueue(node.getTargetForIndex(i));
+        }
+        return name;
+    }
+    // terminator
+
+    public String visit(final Appendable param, final Throw node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getThrownValue());
+        appendTo(param, "}");
+        nl(param);
+        return name;
+    }
+    // terminator
+
+    public String visit(final Appendable param, final ValueReturn node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getReturnValue());
+        appendTo(param, "}");
+        nl(param);
+        return name;
+    }
+
+    // others
+
+    @Override
+    public String visit(Appendable param, InitCheck node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, DebugAddressDeclaration node) {
+        String name = register(node);
+        processDependency(param, node.getAddress());
+        processDependency(param, node.getDependency());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final Add node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final AddressOf node) {
+        String name = register(node);
+        processDependency(param, node.getValueHandle());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final And node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final BitCast node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final BitCastLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final BlockLiteral node) {
+        String name = register(node);
+        processDependency(param, node.getBlock().getBlockEntry());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final BooleanLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(Appendable param, Call node) {
+        String name = register(node);
+        appendTo(param, name);
+        attr(param, "label", "call" + "\\n" + node.getValueHandle().toString());
+        attr(param, "style", "filled");
+        attr(param, "fillcolor", String.valueOf(nodeType(connectionGraph.getEscapeValue(node)).fillColor));
+        nl(param);
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getValueHandle());
+        for (Value arg : node.getArguments()) {
+            processDependency(param, arg);
+        }
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final CallNoSideEffects node) {
+        String name = register(node);
+        processDependency(param, node.getValueHandle());
+        for (Value arg : node.getArguments()) {
+            processDependency(param, arg);
+        }
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final ClassOf node) {
+        String name = register(node);
+        processDependency(param, node.getInput());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final Comp node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final CountLeadingZeros node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final CountTrailingZeros node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Convert node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final CurrentThreadRead node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Div node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Extend node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, ExtractElement node) {
+        String name = register(node);
+        processDependency(param, node.getIndex());
+        processDependency(param, node.getArrayValue());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, ExtractInstanceField node) {
+        String name = register(node);
+        processDependency(param, node.getObjectValue());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, ExtractMember node) {
+        String name = register(node);
+        processDependency(param, node.getCompoundValue());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, Fence node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final FloatLiteral node) {
+        return register(node);
+    }
+
+    private String node(Appendable param, ReadModifyWriteValue node) {
+        String name = register(node);
+        if (node instanceof OrderedNode on) {
+            processDependency(param, on.getDependency());
+        }
+        processDependency(param, node.getValueHandle());
+        processDependency(param, node.getUpdateValue());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndAdd node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndSet node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndBitwiseAnd node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndBitwiseNand node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndBitwiseOr node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndBitwiseXor node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndSetMax node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndSetMin node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, GetAndSub node) {
+        return node(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, InsertElement node) {
+        String name = register(node);
+        processDependency(param, node.getIndex());
+        processDependency(param, node.getInsertedValue());
+        processDependency(param, node.getArrayValue());
+        return name;
+    }
+
+    @Override
+    public String visit(Appendable param, InsertMember node) {
+        String name = register(node);
+        processDependency(param, node.getInsertedValue());
+        processDependency(param, node.getCompoundValue());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final InstanceOf node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getInstance());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final IntegerLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final IsEq node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final IsGe node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final IsGt node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final IsLe node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final IsLt node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final IsNe node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Load node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getValueHandle());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final MethodHandleLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Max node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Min node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Mod node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final MultiNewArray node) {
+        String name = bypass(param, node);
+        for (Value dimension : node.getDimensions()) {
+            processDependency(param, dimension);
+        }
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final Multiply node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final OffsetOfField node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final CheckCast node) {
+        String name = register(node);
+        appendTo(param, name);
+        attr(param, "label", node.getKind() + "→" + node.getType().toString());
+        attr(param, "style", "filled");
+        attr(param, "fillcolor", String.valueOf(nodeType(connectionGraph.getEscapeValue(node)).fillColor));
+        nl(param);
+        final Collection<Node> pointsTo = connectionGraph.getPointsTo(node, false);
+        for (Node pointedTo : pointsTo) {
+            String pointedToName = getNodeName(param, pointedTo);
+            addEdge(param, name, pointedToName, EdgeType.POINTS_TO);
+        }
+        processDependency(param, node.getDependency());
+        processDependency(param, node.getInput());
+        processDependency(param, node.getToType());
+        processDependency(param, node.getToDimensions());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final ConstantLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Neg node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, New node) {
+        String name = register(node);
+        appendTo(param, name);
+        attr(param, "label", "new\\n" + show(node));
+        attr(param, "style", "filled");
+        attr(param, "fillcolor", String.valueOf(nodeType(connectionGraph.getEscapeValue(node)).fillColor));
+        nl(param);
+        final Collection<InstanceFieldOf> fields = connectionGraph.getFields(node);
+        for (InstanceFieldOf field : fields) {
+            String fieldName = getNodeName(param, field);
+            addEdge(param, name, fieldName, EdgeType.FIELD);
+        }
+        return name;
+    }
+
+    private String show(New node) {
+        return node.getType().getUpperBound().toString();
+    }
+
+    @Override
+    public String visit(final Appendable param, final NewArray node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getSize());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final NewReferenceArray node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getElemTypeId());
+        processDependency(param, node.getDimensions());
+        processDependency(param, node.getSize());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final NotNull node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final NullLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final ZeroInitializerLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final ObjectLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Or node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(Appendable param, ParameterValue node) {
+        String name = register(node);
+        appendTo(param, name);
+
+        int index = node.getIndex();
+        StringBuilder b = new StringBuilder();
+        b.append(node.getType()).append(' ').append("param").append('[').append(node.getLabel());
+        if (index > 0) {
+            b.append(index);
+        }
+        b.append(']');
+
+        attr(param, "label", b.toString());
+        attr(param, "style", "filled");
+        attr(param, "fillcolor", String.valueOf(nodeType(connectionGraph.getEscapeValue(node)).fillColor));
+        nl(param);
+
+        final ValueHandle deferred = connectionGraph.getDeferred(node);
+        if (deferred != null) {
+            String deferredName = getNodeName(param, deferred);
+            addEdge(param, name, deferredName, EdgeType.DEFERRED);
+        } else {
+            final Collection<Node> pointsTo = connectionGraph.getPointsTo(node, false);
+            for (Node pointedTo : pointsTo) {
+                String pointedToName = getNodeName(param, pointedTo);
+                addEdge(param, name, pointedToName, EdgeType.POINTS_TO);
+            }
+        }
+
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final PhiValue node) {
+        String name = register(node);
+        appendTo(param, name);
+        attr(param, "label", "phi");
+        attr(param, "style", "filled");
+        attr(param, "fillcolor", String.valueOf(nodeType(connectionGraph.getEscapeValue(node)).fillColor));
+        nl(param);
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final Rol node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Ror node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Select node) {
+        String name = register(node);
+        processDependency(param, node.getCondition());
+        processDependency(param, node.getTrueValue());
+        processDependency(param, node.getFalseValue());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final Shl node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Shr node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final StackAllocation node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getCount());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final Store node) {
+        String name = bypass(param, node);
+        processDependency(param, node.getValueHandle());
+        processDependency(param, node.getValue());
+        return name;
+    }
+
+    @Override
+    public String visit(final Appendable param, final StringLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final ProgramObjectLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Sub node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Truncate node) {
+        return bypass(param, node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final TypeLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final UndefinedLiteral node) {
+        return register(node);
+    }
+
+    @Override
+    public String visit(final Appendable param, final Xor node) {
+        return bypass(param, node);
+    }
+
+    private void addEdge(Appendable param, String fromName, String toName, EdgeType edge) {
+        appendTo(param, fromName);
+        appendTo(param, " -> ");
+        appendTo(param, toName);
+        attr(param, "style", edge.style);
+        attr(param, "color", edge.color);
+        attr(param, "label", " " + edge.label);
+        nl(param);
+    }
+
+    private String bypass(final Appendable param, BinaryValue node) {
+        String name = register(node);
+        processDependency(param, node.getLeftInput());
+        processDependency(param, node.getRightInput());
+        return name;
+    }
+
+    private String bypass(Appendable param, OrderedNode node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        return name;
+    }
+
+    private String bypass(final Appendable param, CastValue node) {
+        String name = register(node);
+        processDependency(param, node.getInput());
+        return name;
+    }
+
+    private String bypass(final Appendable param, UnaryValue node) {
+        String name = register(node);
+        processDependency(param, node.getInput());
+        return name;
+    }
+
+    private String bypassTerminator(Appendable param, OrderedNode node) {
+        String name = register(node);
+        processDependency(param, node.getDependency());
+        appendTo(param, "}");
+        nl(param);
+        return name;
+    }
+
+    // TODO copied from DotNodeVisitor
+    void processDependency(Appendable param, Node node) {
+        if (depth++ > 500) {
+            throw new TooBigException();
+        }
+        try {
+            getNodeName(param, node);
+        } finally {
+            depth--;
+        }
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String getNodeName(Appendable param, Node node) {
+        if (node instanceof Value) {
+            return getNodeName(param, (Value) node);
+        } else if (node instanceof ValueHandle) {
+            return getNodeName(param, (ValueHandle)node);
+        } else if (node instanceof Action) {
+            return getNodeName(param, (Action) node);
+        } else {
+            assert node instanceof Terminator;
+            return getNodeName(param, (Terminator) node);
+        }
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String getNodeName(Appendable param, Action node) {
+        String name = visited.get(node);
+        if (name == null) {
+            name = node.accept(this, param);
+        }
+        return name;
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String getNodeName(Appendable param, Value node) {
+        String name = visited.get(node);
+        if (name == null) {
+            name = node.accept(this, param);
+        }
+        return name;
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String getNodeName(Appendable param, ValueHandle node) {
+        String name = visited.get(node);
+        if (name == null) {
+            name = node.accept(this, param);
+        }
+        return name;
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String getNodeName(Appendable param, Terminator node) {
+        String name = visited.get(node);
+        if (name == null) {
+            name = node.accept(this, param);
+        }
+        return name;
+    }
+
+    // TODO copied from DotNodeVisitor
+    private void attr(Appendable param, String name, String val) {
+        if (! attr) {
+            attr = true;
+            appendTo(param, " [");
+        }
+        if (commaNeeded) {
+            appendTo(param, ',');
+        } else {
+            commaNeeded = true;
+        }
+        appendTo(param, name);
+        appendTo(param, '=');
+        quote(param, val);
+    }
+
+    // TODO copied from DotNodeVisitor
+    void quote(Appendable output, String orig) {
+        appendTo(output, '"');
+        int cp;
+        for (int i = 0; i < orig.length(); i += Character.charCount(cp)) {
+            cp = orig.codePointAt(i);
+            if (cp == '"') {
+                appendTo(output, '\\');
+            } else if (cp == '\\') {
+                if((i + 1) == orig.length() ||
+                    "nlrGNTHE".indexOf(orig.codePointAt(i + 1)) == -1) {
+                    appendTo(output, '\\');
+                }
+            }
+            if (Character.charCount(cp) == 1) {
+                appendTo(output, (char) cp);
+            } else {
+                appendTo(output, Character.highSurrogate(cp));
+                appendTo(output, Character.lowSurrogate(cp));
+            }
+        }
+        appendTo(output, '"');
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String register(final Node node) {
+        String name = nextName();
+        visited.put(node, name);
+        return name;
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String nextName() {
+        return "n" + counter++;
+    }
+
+    // TODO copied from DotNodeVisitor
+    public void process(final Appendable param) {
+        addToQueue(entryBlock);
+        BasicBlock block;
+        while ((block = blockQueue.poll()) != null) {
+            String bbName = nextBBName();
+            appendTo(param, "subgraph cluster_" + bbName + " {");
+            nl(param);
+            appendTo(param, "label = \"" + bbName + "\";");
+            nl(param);
+            getNodeName(param, block.getTerminator());
+        }
+        // connectBasicBlocks(param);
+        // processPhiQueue(param);
+    }
+
+    // TODO copied from DotNodeVisitor
+    private void nl(final Appendable param) {
+        if (attr) {
+            appendTo(param, ']');
+            attr = false;
+            commaNeeded = false;
+        }
+        appendTo(param, System.lineSeparator());
+    }
+
+    // TODO copied from DotNodeVisitor
+    static void appendTo(Appendable param, Object obj) {
+        try {
+            param.append(obj.toString());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+
+    // TODO copied from DotNodeVisitor
+    void addToQueue(final BasicBlock block) {
+        if (blockQueued.add(block)) {
+            blockQueue.add(block);
+        }
+    }
+
+    // TODO copied from DotNodeVisitor
+    private String nextBBName() {
+        return "b" + bbCounter++;
+    }
+
+    private enum EdgeType {
+        DEFERRED("black", "dashed"),
+        POINTS_TO("black", "solid"),
+        FIELD("black", "solid");
+
+        final String color;
+        final String style;
+        final char label;
+
+        EdgeType(String color, String style) {
+            this.color = color;
+            this.style = style;
+            this.label = this.toString().charAt(0);
+        }
+    }
+
+    private NodeType nodeType(EscapeValue value) {
+        switch (value) {
+            case GLOBAL_ESCAPE:
+                return NodeType.GLOBAL_ESCAPE;
+            case ARG_ESCAPE:
+                return NodeType.ARG_ESCAPE;
+            case NO_ESCAPE:
+                return NodeType.NO_ESCAPE;
+            case UNKNOWN:
+                return NodeType.UNKNOWN;
+            default:
+                throw new IllegalStateException("Unknown escape value: " + value);
+        }
+    }
+
+    private enum NodeType {
+        GLOBAL_ESCAPE(2),
+        ARG_ESCAPE(3),
+        NO_ESCAPE(1),
+        UNKNOWN(4);
+
+        final int fillColor;
+
+        NodeType(int fillColor) {
+            this.fillColor = fillColor;
+        }
+    }
+    
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisInterMethodAnalysis.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisInterMethodAnalysis.java
@@ -1,0 +1,192 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.Call;
+import org.qbicc.graph.Executable;
+import org.qbicc.plugin.reachability.ReachabilityInfo;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.NamedElement;
+
+public class EscapeAnalysisInterMethodAnalysis implements Consumer<CompilationContext> {
+
+    @Override
+    public void accept(CompilationContext ctxt) {
+        new ConnectionGraphUpdater(ctxt).run();
+    }
+
+    private static final class ConnectionGraphUpdater implements Runnable {
+        final Set<ExecutableElement> visited = new HashSet<>();
+        final EscapeAnalysisState state;
+        final ReachabilityInfo rta;
+
+        private ConnectionGraphUpdater(CompilationContext ctxt) {
+            this.state = EscapeAnalysisState.get(ctxt);
+            this.rta = ReachabilityInfo.get(ctxt);
+        }
+
+        @Override
+        public void run() {
+            state.getMethodsVisited().forEach(this::updateConnectionGraphIfNotVisited);
+        }
+
+        /**
+         * Traversal reverse topological order over the program control flow.
+         * A bottom-up traversal in which the connection graph of a callee
+         * is used to update the connection graph of the caller.
+         */
+        private ConnectionGraph updateConnectionGraphIfNotVisited(ExecutableElement caller) {
+            if (!visited.add(caller)) {
+                return state.getConnectionGraph(caller);
+            }
+
+            return updateConnectionGraph(caller);
+        }
+
+        private ConnectionGraph updateConnectionGraph(ExecutableElement caller) {
+            final ConnectionGraph callerCG = findConnectionGraph(caller);
+            if (callerCG == null) {
+                return null;
+            }
+
+            // 4.1 Update Connection Graph at Method Entry
+            callerCG.updateAtMethodEntry();
+
+            for (Call callee : state.getCallees(caller)) {
+                final ExecutableElement calleeElement = ((Executable) callee.getValueHandle()).getExecutable();
+                final ConnectionGraph calleeCG = updateConnectionGraphIfNotVisited(calleeElement);
+                if (calleeCG != null) {
+                    // 4.4 Update Connection Graph Immediately After a Method Invocation
+                    callerCG.updateAfterInvokingMethod(callee, calleeCG);
+                }
+            }
+
+            // 4.2 Update Connection Graph at Method Exit
+            callerCG.updateAtMethodExit();
+
+            return callerCG;
+        }
+
+        /**
+         * Find a connection graph for a given executable element.
+         */
+        private ConnectionGraph findConnectionGraph(ExecutableElement executable) {
+            ConnectionGraph cg = state.getConnectionGraph(executable);
+            // For direct, concrete, method invocations, the escape analysis state will contain a connection graph for it.
+            if (cg != null) {
+                // However, we need to take into account method overrides
+                final Set<ExecutableElement> subclasses = findSubclasses(executable, executable.getEnclosingType().load());
+                if (subclasses.isEmpty()) {
+                    return cg;
+                }
+
+                // If we find any method overrides, union them with the original method connection graph
+                return unionConnectionGraph(subclasses, cg);
+            }
+
+            // For interface methods, find connection graphs for all methods that might be a target of a call, and union them.
+            cg = findInterfaceConnectionGraph(executable);
+            if (cg != null) {
+                return cg;
+            }
+
+            // For abstract methods, find connection graphs for all available implementations
+            cg = findAbstractConnectionGraph(executable);
+            if (cg != null) {
+                return cg;
+            }
+
+            return cg;
+        }
+
+        private Set<ExecutableElement> findSubclasses(ExecutableElement executable, LoadedTypeDefinition loadedExecutableType) {
+            final Set<ExecutableElement> implementors = new HashSet<>();
+            rta.visitReachableSubclassesPostOrder(loadedExecutableType, type -> findReachableMethods(executable, type, implementors));
+            return implementors;
+        }
+
+        private ConnectionGraph findInterfaceConnectionGraph(ExecutableElement executable) {
+            final DefinedTypeDefinition enclosingType = executable.getEnclosingType();
+            if (!enclosingType.isInterface()) {
+                return null;
+            }
+
+            final LoadedTypeDefinition loadedExecutableType = enclosingType.load();
+            final Set<ExecutableElement> implementors = findInterfaceImplementors(executable, loadedExecutableType);
+            if (implementors.isEmpty()) {
+                return null;
+            }
+
+            // Get connection graphs for these implementors and union them.
+            // The implementors might be calling other methods (e.g. generic interface bridges),
+            // so make sure they're connection graphs have been updated before going and making a union.
+            return unionConnectionGraph(implementors, new ConnectionGraph(executable.toString()));
+        }
+
+        private ConnectionGraph findAbstractConnectionGraph(ExecutableElement executable) {
+            boolean isAbstractMethod = executable instanceof MethodElement && ((MethodElement) executable).isAbstract();
+            if (!isAbstractMethod) {
+                return null;
+            }
+
+            // Find the interface in which the executable was defined
+            final LoadedTypeDefinition loadedExecutableType = executable.getEnclosingType().load();
+
+            // Find all implementors that contain method definitions
+            final Set<ExecutableElement> subclasses = findSubclasses(executable, loadedExecutableType);
+
+            // If there are no implementors, skip
+            if (subclasses.isEmpty()) {
+                return null;
+            }
+
+            // Get connection graphs for these implementors and union them.
+            // The implementors might be calling other methods (e.g. generic interface bridges),
+            // so make sure they're connection graphs have been updated before going and making a union.
+            return unionConnectionGraph(subclasses, new ConnectionGraph(executable.toString()));
+        }
+
+        private ConnectionGraph unionConnectionGraph(Set<ExecutableElement> methods, ConnectionGraph initValue) {
+            return methods.stream()
+                .map(this::updateConnectionGraphIfNotVisited)
+                .reduce(initValue, ConnectionGraph::union);
+        }
+
+        private Set<ExecutableElement> findInterfaceImplementors(ExecutableElement executable, LoadedTypeDefinition loadedExecutableType) {
+            final Set<ExecutableElement> implementors = new HashSet<>();
+            // TODO create a type to carry implementors and executable (and add logging when implementors added to)
+            rta.visitReachableImplementors(loadedExecutableType, type -> findReachableMethods(executable, type, implementors));
+            return implementors;
+        }
+
+        private void findReachableMethods(ExecutableElement executable, LoadedTypeDefinition type, Set<ExecutableElement> implementors) {
+            final MethodElement[] instanceMethods = type.getInstanceMethods();
+            for (MethodElement instanceMethod : instanceMethods) {
+                if (isImplementationOf(executable, instanceMethod) && isReachable(instanceMethod)) {
+                    implementors.add(instanceMethod);
+                }
+            }
+        }
+
+        // TODO this does not seem to be really working (that's why there's the workaround in CG.updateAfterInvokingMethod)
+        private boolean isReachable(ExecutableElement executable) {
+            return executable instanceof MethodElement && rta.isInvokableMethod((MethodElement) executable);
+        }
+    }
+
+    private static boolean isImplementationOf(ExecutableElement executable, MethodElement instanceMethod) {
+        if (executable instanceof NamedElement) {
+            final String executableName = ((NamedElement) executable).getName();
+            return executableName.equals(instanceMethod.getName())
+                && executable.getDescriptor().equals(instanceMethod.getDescriptor());
+        }
+
+        return false;
+    }
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisIntraMethodBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisIntraMethodBuilder.java
@@ -37,7 +37,6 @@ public final class EscapeAnalysisIntraMethodBuilder extends DelegatingBasicBlock
         super(delegate);
         this.connectionGraph = new ConnectionGraph(getCurrentElement().toString());
         this.escapeAnalysisState = EscapeAnalysisState.get(ctxt);
-        this.escapeAnalysisState.trackMethod(getCurrentElement(), this.connectionGraph);
         this.bootstrapClassContext = ctxt.getBootstrapClassContext();
     }
 
@@ -111,6 +110,7 @@ public final class EscapeAnalysisIntraMethodBuilder extends DelegatingBasicBlock
     @Override
     public void startMethod(List<ParameterValue> arguments) {
         super.startMethod(arguments);
+        escapeAnalysisState.trackMethod(getCurrentElement(), this.connectionGraph);
         connectionGraph.trackParameters(arguments);
     }
 

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisIntraMethodBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisIntraMethodBuilder.java
@@ -1,0 +1,174 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.util.List;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.Call;
+import org.qbicc.graph.CheckCast;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Executable;
+import org.qbicc.graph.InstanceFieldOf;
+import org.qbicc.graph.LocalVariable;
+import org.qbicc.graph.New;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NotNull;
+import org.qbicc.graph.OrderedNode;
+import org.qbicc.graph.ParameterValue;
+import org.qbicc.graph.ReferenceHandle;
+import org.qbicc.graph.StaticField;
+import org.qbicc.graph.Store;
+import org.qbicc.graph.Truncate;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.type.ClassObjectType;
+import org.qbicc.type.ObjectType;
+import org.qbicc.type.definition.element.FieldElement;
+
+public final class EscapeAnalysisIntraMethodBuilder extends DelegatingBasicBlockBuilder  {
+    private final EscapeAnalysisState escapeAnalysisState;
+    private final ConnectionGraph connectionGraph;
+    private final ClassContext bootstrapClassContext;
+
+    public EscapeAnalysisIntraMethodBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+        super(delegate);
+        this.connectionGraph = new ConnectionGraph(getCurrentElement().toString());
+        this.escapeAnalysisState = EscapeAnalysisState.get(ctxt);
+        this.escapeAnalysisState.trackMethod(getCurrentElement(), this.connectionGraph);
+        this.bootstrapClassContext = ctxt.getBootstrapClassContext();
+    }
+
+    @Override
+    public Value new_(final ClassObjectType type, final Value typeId, final Value size, final Value align) {
+        final New result = (New) super.new_(type, typeId, size, align);
+
+        connectionGraph.trackNew(result, defaultEscapeValue(type));
+
+        return result;
+    }
+
+    private EscapeValue defaultEscapeValue(ClassObjectType type) {
+        if (isSubtypeOfClass("java/lang/Thread", type) ||
+            isSubtypeOfClass("java/lang/ThreadGroup", type)) {
+            return EscapeValue.GLOBAL_ESCAPE;
+        }
+
+        return EscapeValue.NO_ESCAPE;
+    }
+
+    private boolean isSubtypeOfClass(String name, ClassObjectType type) {
+        return type.isSubtypeOf(bootstrapClassContext.findDefinedType(name).load().getType());
+    }
+
+    @Override
+    public ValueHandle instanceFieldOf(ValueHandle handle, FieldElement field) {
+        final InstanceFieldOf result = (InstanceFieldOf) super.instanceFieldOf(handle, field);
+
+        // T a = new T(...);
+        // To get represent the GC from 'a' to 'new T(...)',
+        // we hijack future 'a' references to fix the pointer.
+        // When 'a.x' is accessed, we fix the pointer from 'a' to 'new T(...)'.
+        handleInstanceFieldOf(result, handle, handle);
+
+        return result;
+    }
+
+    @Override
+    public Node store(ValueHandle handle, Value value, WriteAccessMode mode) {
+        final Node result = super.store(handle, value, mode);
+
+        if (handle instanceof StaticField) {
+            // static T a = ...
+            if (value instanceof NotNull nn) {
+                connectionGraph.trackStoreStaticField(handle, nn.getInput());
+            } else {
+                connectionGraph.trackStoreStaticField(handle, value);
+            }
+        } else if (handle instanceof InstanceFieldOf && value instanceof New) {
+            // p.f = new T(); // where p is a parameter
+            connectionGraph.fixEdgesNew(handle, (New) value);
+        } else if (handle instanceof LocalVariable && value instanceof New) {
+            connectionGraph.trackLocalNew((LocalVariable) handle, (New) value);
+        }
+
+        return result;
+    }
+
+    @Override
+    public Value call(ValueHandle target, List<Value> arguments) {
+        final Value result = super.call(target, arguments);
+
+        if (target instanceof Executable) {
+            escapeAnalysisState.trackCall(getCurrentElement(), (Call) result);
+        }
+
+        return result;
+    }
+
+    @Override
+    public void startMethod(List<ParameterValue> arguments) {
+        super.startMethod(arguments);
+        connectionGraph.trackParameters(arguments);
+    }
+
+    @Override
+    public BasicBlock return_(Value value) {
+        final BasicBlock result = super.return_(value);
+
+        // Skip primitive values truncated, they are not objects
+        if (!(value instanceof Truncate)) {
+            connectionGraph.trackReturn(value);
+        }
+
+        return result;
+    }
+
+    @Override
+    public BasicBlock throw_(Value value) {
+        final BasicBlock result = super.throw_(value);
+
+        if (value instanceof New) {
+            connectionGraph.trackThrowNew((New) value);
+        }
+
+        return result;
+    }
+
+    @Override
+    public Value checkcast(Value value, Value toType, Value toDimensions, CheckCast.CastType kind, ObjectType expectedType) {
+        final CheckCast result = (CheckCast) super.checkcast(value, toType, toDimensions, kind, expectedType);
+        connectionGraph.trackCast(result);
+        return result;
+    }
+
+    @Override
+    public void finish() {
+        super.finish();
+        // Incoming values for phi nodes can only be calculated upon finish.
+        connectionGraph.resolveReturnedPhiValues();
+    }
+
+    private void handleInstanceFieldOf(InstanceFieldOf result, ValueHandle handle, Node target) {
+        if (target instanceof New) {
+            connectionGraph.fixEdgesField((New) target, handle, result);
+        } else if (target instanceof ParameterValue) {
+            connectionGraph.fixEdgesParameterValue((ParameterValue) target, result);
+        } else if (target instanceof Store) {
+            final Value value = ((Store) target).getValue();
+            if (value instanceof New) {
+                handleInstanceFieldOf(result, handle, value);
+            } else {
+                handleInstanceFieldOf(result, handle, target.getValueHandle());
+            }
+        } else if (target instanceof InstanceFieldOf) {
+            handleInstanceFieldOf(result, handle, target.getValueHandle());
+        } else if (target instanceof ReferenceHandle) {
+            handleInstanceFieldOf(result, handle, ((ReferenceHandle) target).getReferenceValue());
+        } else if (target instanceof OrderedNode) {
+            handleInstanceFieldOf(result, handle, ((OrderedNode) target).getDependency());
+        }
+    }
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisOptimizeVisitor.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisOptimizeVisitor.java
@@ -1,0 +1,129 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.util.List;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.BlockEntry;
+import org.qbicc.graph.BlockLabel;
+import org.qbicc.graph.MemoryAtomicityMode;
+import org.qbicc.graph.New;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.OrderedNode;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.literal.IntegerLiteral;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.plugin.coreclasses.CoreClasses;
+import org.qbicc.plugin.layout.Layout;
+import org.qbicc.plugin.layout.LayoutInfo;
+import org.qbicc.type.ClassObjectType;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.IntegerType;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.MethodElement;
+
+public final class EscapeAnalysisOptimizeVisitor implements NodeVisitor.Delegating<Node.Copier, Value, Node, BasicBlock, ValueHandle> {
+    private final CompilationContext ctxt;
+    private final NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle> delegate;
+    private final MethodElement zeroMethod;
+
+    public EscapeAnalysisOptimizeVisitor(final CompilationContext ctxt, final NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle> delegate) {
+        this.ctxt = ctxt;
+        this.delegate = delegate;
+
+        ClassContext classContext = ctxt.getBootstrapClassContext();
+        DefinedTypeDefinition defined = classContext.findDefinedType("org/qbicc/runtime/gc/nogc/NoGcHelpers");
+        if (defined == null) {
+            throw runtimeMissing();
+        }
+        LoadedTypeDefinition loaded = defined.load();
+        int index = loaded.findMethodIndex(e -> e.getName().equals("clear"));
+        if (index == -1) {
+            throw methodMissing();
+        }
+        zeroMethod = loaded.getMethod(index);
+    }
+
+    private static IllegalStateException runtimeMissing() {
+        return new IllegalStateException("The NoGC helpers runtime classes are not present in the bootstrap class path");
+    }
+
+    private static IllegalStateException methodMissing() {
+        return new IllegalStateException("Required method is missing from the NoGC helpers");
+    }
+
+    public NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle> getDelegateNodeVisitor() {
+        return delegate;
+    }
+
+    @Override
+    public Value visit(Node.Copier param, New original) {
+        final BasicBlockBuilder bbb = param.getBlockBuilder();
+        if (isStackAllocate(original, bbb)) {
+            // Copy dependency so that stack allocation can be scheduled in the right place
+            param.copyNode(original.getDependency());
+            return stackAllocate(original, bbb);
+        }
+
+        return NodeVisitor.Delegating.super.visit(param, original);
+    }
+
+    private boolean isStackAllocate(New new_, BasicBlockBuilder bbb) {
+        return EscapeAnalysisState.get(ctxt).isNotEscapingMethod(new_, bbb.getCurrentElement())
+            && notInLoop(new_);
+    }
+
+    private boolean notInLoop(Node node) {
+        if (node instanceof OrderedNode on) {
+            final Node dependency = on.getDependency();
+            if (dependency instanceof BlockEntry be) {
+                return BlockLabel.getTargetOf(be.getPinnedBlockLabel()).getLoops().size() == 0;
+            }
+            return notInLoop(on.getDependency());
+        }
+
+        return false;
+    }
+
+    private Value stackAllocate(New new_, BasicBlockBuilder bbb) {
+        ClassObjectType type = new_.getClassObjectType();
+
+        // Copied and adjusted from NoGcBasicBlockBuilder
+        Layout layout = Layout.get(ctxt);
+        LayoutInfo info = layout.getInstanceLayoutInfo(type.getDefinition());
+        CompoundType compoundType = info.getCompoundType();
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        IntegerLiteral align = lf.literalOf(compoundType.getAlign());
+
+        // TODO David Lloyd: the alignment should be the minimum alignment of the lowered target type
+        // TODO David Lloyd: which we don't know until lower, but perhaps ObjectAccessLoweringBuilder could intercept that and set the minimum alignment to the minimum of the layout
+        Value ptrVal = bbb.stackAllocate(compoundType, lf.literalOf(1), align);
+
+        Value oop = bbb.valueConvert(ptrVal, type.getReference());
+
+        // zero initialize the object's instance fields
+        initializeObjectFieldsToZero(info, lf, oop, bbb);
+        // initialize object header
+        initializeObjectHeader(CoreClasses.get(ctxt), bbb.referenceHandle(oop), ctxt.getLiteralFactory().literalOfType(type), bbb);
+
+        return oop;
+    }
+
+    private void initializeObjectFieldsToZero(final LayoutInfo info, final LiteralFactory lf, final Value oop, final BasicBlockBuilder bbb) {
+        bbb.call(bbb.staticMethod(zeroMethod, zeroMethod.getDescriptor(), zeroMethod.getType()), List.of(oop, lf.literalOf(info.getCompoundType().getSize())));
+    }
+
+    // TODO copied from BasicInitializationBasicBlockBuilder
+    private void initializeObjectHeader(final CoreClasses coreClasses, final ValueHandle handle, final Value typeId, final BasicBlockBuilder bbb) {
+        bbb.store(bbb.instanceFieldOf(handle, coreClasses.getObjectTypeIdField()), typeId, MemoryAtomicityMode.UNORDERED);
+        FieldElement monitorField = coreClasses.getObjectNativeObjectMonitorField();
+        bbb.store(bbb.instanceFieldOf(handle, monitorField), ctxt.getLiteralFactory().literalOf((IntegerType)monitorField.getType(), 0L), MemoryAtomicityMode.NONE);
+    }
+
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisState.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisState.java
@@ -1,0 +1,63 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.Call;
+import org.qbicc.graph.New;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+public final class EscapeAnalysisState {
+    private static final AttachmentKey<EscapeAnalysisState> KEY = new AttachmentKey<>();
+    private final Map<ExecutableElement, List<Call>> callGraph = new ConcurrentHashMap<>();
+    private final Map<ExecutableElement, ConnectionGraph> connectionGraphs = new ConcurrentHashMap<>();
+
+    ConnectionGraph getConnectionGraph(ExecutableElement element) {
+        return connectionGraphs.get(element);
+    }
+
+    // TODO Collection<MethodElement> instead?
+    Collection<ExecutableElement> getMethodsVisited() {
+        return connectionGraphs.keySet();
+    }
+
+    /**
+     * Returns the list of callees called from the given method.
+     * If method not found in the call graph, an empty list is returned.
+     */
+    List<Call> getCallees(ExecutableElement element) {
+        final List<Call> callees = callGraph.get(element);
+        return callees != null ? callees : Collections.emptyList();
+    }
+
+    void trackMethod(ExecutableElement element, ConnectionGraph connectionGraph) {
+        connectionGraphs.put(element, connectionGraph);
+    }
+
+    void trackCall(ExecutableElement from, Call to) {
+        callGraph.computeIfAbsent(from, k -> new ArrayList<>()).add(to);
+    }
+
+    boolean isNotEscapingMethod(New new_, ExecutableElement element) {
+        final ConnectionGraph connectionGraph = connectionGraphs.get(element);
+        return connectionGraph != null && connectionGraph.getEscapeValue(new_).isNoEscape();
+    }
+
+    static EscapeAnalysisState get(CompilationContext ctxt) {
+        EscapeAnalysisState escapeAnalysisState = ctxt.getAttachment(KEY);
+        if (escapeAnalysisState == null) {
+            escapeAnalysisState = new EscapeAnalysisState();
+            EscapeAnalysisState appearing = ctxt.putAttachmentIfAbsent(KEY, escapeAnalysisState);
+            if (appearing != null) {
+                escapeAnalysisState = appearing;
+            }
+        }
+        return escapeAnalysisState;
+    }
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisState.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisState.java
@@ -13,7 +13,7 @@ import org.qbicc.graph.Call;
 import org.qbicc.graph.New;
 import org.qbicc.type.definition.element.ExecutableElement;
 
-public final class EscapeAnalysisState {
+final class EscapeAnalysisState {
     private static final AttachmentKey<EscapeAnalysisState> KEY = new AttachmentKey<>();
     private final Map<ExecutableElement, List<Call>> callGraph = new ConcurrentHashMap<>();
     private final Map<ExecutableElement, ConnectionGraph> connectionGraphs = new ConcurrentHashMap<>();

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeValue.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeValue.java
@@ -1,0 +1,37 @@
+package org.qbicc.plugin.opt.ea;
+
+import java.util.Objects;
+
+enum EscapeValue {
+    GLOBAL_ESCAPE, ARG_ESCAPE, NO_ESCAPE, UNKNOWN;
+
+    boolean isArgEscape() {
+        return this == ARG_ESCAPE;
+    }
+
+    boolean isGlobalEscape() {
+        return this == GLOBAL_ESCAPE;
+    }
+
+    boolean notGlobalEscape() {
+        return !isGlobalEscape();
+    }
+
+    boolean isNoEscape() {
+        return this == NO_ESCAPE;
+    }
+
+    static EscapeValue of(EscapeValue escapeValue) {
+        return Objects.isNull(escapeValue) ? EscapeValue.UNKNOWN : escapeValue;
+    }
+
+    static EscapeValue merge(EscapeValue a, EscapeValue b) {
+        if (b.isGlobalEscape())
+            return GLOBAL_ESCAPE;
+
+        if (a.isNoEscape())
+            return b;
+
+        return a;
+    }
+}

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/TooBigException.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/TooBigException.java
@@ -1,0 +1,6 @@
+package org.qbicc.plugin.opt.ea;
+
+// TODO copied from DotNodeVisitor
+public class TooBigException extends RuntimeException {
+    public TooBigException() {}
+}

--- a/plugins/optimization/src/test/java/org/qbicc/plugin/opt/ea/EscapeValueTest.java
+++ b/plugins/optimization/src/test/java/org/qbicc/plugin/opt/ea/EscapeValueTest.java
@@ -1,0 +1,33 @@
+package org.qbicc.plugin.opt.ea;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.qbicc.plugin.opt.ea.EscapeValue.*;
+
+public class EscapeValueTest {
+
+    @Test
+    public void testMergeToNoEscape() {
+        assertEquals(NO_ESCAPE, EscapeValue.merge(NO_ESCAPE, NO_ESCAPE));
+    }
+
+    @Test
+    public void testMergeToArgEscape() {
+        assertEquals(ARG_ESCAPE, EscapeValue.merge(NO_ESCAPE, ARG_ESCAPE));
+        assertEquals(ARG_ESCAPE, EscapeValue.merge(ARG_ESCAPE, NO_ESCAPE));
+        assertEquals(ARG_ESCAPE, EscapeValue.merge(ARG_ESCAPE, ARG_ESCAPE));
+    }
+
+    @Test
+    public void testMergeToGlobalEscape() {
+        assertEquals(GLOBAL_ESCAPE, EscapeValue.merge(GLOBAL_ESCAPE, NO_ESCAPE));
+        assertEquals(GLOBAL_ESCAPE, EscapeValue.merge(GLOBAL_ESCAPE, ARG_ESCAPE));
+        assertEquals(GLOBAL_ESCAPE, EscapeValue.merge(GLOBAL_ESCAPE, GLOBAL_ESCAPE));
+
+        assertEquals(GLOBAL_ESCAPE, EscapeValue.merge(NO_ESCAPE, GLOBAL_ESCAPE));
+        assertEquals(GLOBAL_ESCAPE, EscapeValue.merge(ARG_ESCAPE, GLOBAL_ESCAPE));
+        assertEquals(GLOBAL_ESCAPE, EscapeValue.merge(GLOBAL_ESCAPE, GLOBAL_ESCAPE));
+    }
+
+}


### PR DESCRIPTION
Please see the [Escape Analysis design discussion](https://github.com/qbicc/qbicc/discussions/931) for an overview of the implementation.

I've been using [this Escape Analysis sample project](https://github.com/galderz/qoccido/tree/main/ea-samples) to verify things work as expected. It uses byteman to [intercept stack allocations](https://github.com/galderz/qoccido/blob/main/ea-samples/src/main/resources/ea/verify.btm#L29-L47) and compare them with [expectations](https://github.com/galderz/qoccido/blob/main/ea-samples/src/main/resources/ea/verify.btm#L8-L24). A summary of the samples can be found [here](https://github.com/galderz/qoccido/tree/main/ea-samples#overview). 

I feel there's a lot of duplication between `DotNodeVisitor` and the `ConnectionGraphDotNodeVisitor`. Maintaining this duplication has been a bit of a pain at times, but couldn't see an easy way to reuse things at a first glance. I think the graph navigation is identical in both cases so I wonder if that could be shared somehow, or if the `DotNodeVisitor` could be made to produce EA connection graph information too.