### PR TITLE
Sort submodule names

### DIFF
--- a/machine/pom.xml
+++ b/machine/pom.xml
@@ -18,10 +18,10 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>arch</module>
+        <module>file</module>
+        <module>llvm</module>
         <module>probe</module>
         <module>tool</module>
-        <module>file</module>
-        <module>arch</module>
-        <module>llvm</module>
     </modules>
 </project>


### PR DESCRIPTION
Just changes the order of the Maven submodules of the `machine` module to be sorted.