### PR TITLE
Remove obsolete workaround for "missing" static fields

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -362,12 +362,6 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
     }
 
     public Literal getValueForStaticField(FieldElement field) {
-        if (staticLayoutInfo == null || staticLayoutInfo.getMember(field) == null) {
-            // TODO: This should become a hard error at some point, but make it a warning while we are bringing interpreter online.
-            //       It seems to mostly be happening with callsites associated with invokedynamic.
-            vm.getCompilationContext().warning("No interpreter layout for static "+field+". Using zero initializer as value");
-            return vm.getCompilationContext().getLiteralFactory().zeroInitializerLiteralOfType(field.getType());
-        }
         int offset = staticLayoutInfo.getMember(field).getOffset();
         TypeDescriptor desc = field.getTypeDescriptor();
         if (desc.equals(BaseTypeDescriptor.Z)) {

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -53,7 +53,7 @@ class BuildtimeHeapAnalyzer {
         int fieldCount = ltd.getFieldCount();
         for (int i=0; i<fieldCount; i++) {
             FieldElement f = ltd.getField(i);
-            if (f.isStatic() && f.getType() instanceof ReferenceType) {
+            if (f.isStatic() && f.getType() instanceof ReferenceType && !f.isThreadLocal()) {
                 Value v = ltd.getInitialValue(f);
                 if (v instanceof ObjectLiteral) {
                     VmObject vo = ((ObjectLiteral) v).getValue();


### PR DESCRIPTION
Realized the only time this warning was firing anymore was for `_qbicc_bound_thread`, so we can eliminate it by not trying to trace the build-time initialization initial value of thread local fields.

