### PR TITLE
Initial implementation of mmap-based heap allocation

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -101,6 +101,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-gc-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-gc-nogc</artifactId>
         </dependency>
         <dependency>

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -61,6 +61,7 @@ import org.qbicc.plugin.dispatch.DevirtualizingBasicBlockBuilder;
 import org.qbicc.plugin.dispatch.DispatchTableBuilder;
 import org.qbicc.plugin.dispatch.DispatchTableEmitter;
 import org.qbicc.plugin.dot.DotGenerator;
+import org.qbicc.plugin.gc.common.GcCommon;
 import org.qbicc.plugin.gc.nogc.NoGcBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcMultiNewArrayBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcSetupHook;
@@ -389,6 +390,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPreHook(Phase.ADD, ReflectionIntrinsics::register);
                                 builder.addPreHook(Phase.ADD, Reflection::get);
                                 builder.addPreHook(Phase.ADD, ThrowExceptionHelper::get);
+                                builder.addPreHook(Phase.ADD, GcCommon::registerIntrinsics);
                                 builder.addPreHook(Phase.ADD, new VMHelpersSetupHook());
                                 builder.addPreHook(Phase.ADD, compilationContext -> {
                                     Vm vm = compilationContext.getVm();

--- a/plugins/gc/common/pom.xml
+++ b/plugins/gc/common/pom.xml
@@ -6,27 +6,32 @@
 
     <parent>
         <groupId>org.qbicc</groupId>
-        <artifactId>qbicc-runtime-gc-parent</artifactId>
+        <artifactId>qbicc-plugin-gc-parent</artifactId>
         <version>0.20.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>qbicc-runtime-gc-nogc</artifactId>
+    <artifactId>qbicc-plugin-gc-common</artifactId>
 
-    <name>Qbicc Run Time: GC: No GC</name>
-    <description>Qbicc no-GC GC implementation</description>
+    <name>Qbicc Plugin: GC: Common</name>
+    <description>Plugin supporting all GC implementations</description>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-runtime-api</artifactId>
+            <artifactId>qbicc-compiler</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-runtime-posix</artifactId>
+            <artifactId>qbicc-driver</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-intrinsics</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-runtime-gc-heap</artifactId>
+            <artifactId>qbicc-plugin-layout</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/GcCommon.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/GcCommon.java
@@ -1,0 +1,59 @@
+package org.qbicc.plugin.gc.common;
+
+import java.util.List;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.plugin.intrinsics.Intrinsics;
+import org.qbicc.type.TypeSystem;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
+import org.qbicc.type.descriptor.MethodDescriptor;
+
+/**
+ * Common utilities and setup for GC.
+ */
+public final class GcCommon {
+    private GcCommon() {}
+
+    public static void registerIntrinsics(CompilationContext ctxt) {
+        registerHeapIntrinsics(ctxt);
+    }
+
+    private static void registerHeapIntrinsics(final CompilationContext ctxt) {
+        Intrinsics intrinsics = Intrinsics.get(ctxt);
+        ClassContext classContext = ctxt.getBootstrapClassContext();
+        LiteralFactory lf = classContext.getLiteralFactory();
+        TypeSystem ts = classContext.getTypeSystem();
+
+        ClassTypeDescriptor heapDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/gc/heap/Heap");
+
+        MethodDescriptor emptyToLong = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.J, List.of());
+        MethodDescriptor emptyToInt = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of());
+
+        intrinsics.registerIntrinsic(heapDesc, "getConfiguredMinHeapSize", emptyToLong, (builder, target, arguments) -> {
+            // todo: configuration
+            // hard-coded 16MB for now
+            return lf.literalOf(16L * (1L << 20));
+        });
+
+        intrinsics.registerIntrinsic(heapDesc, "getConfiguredMaxHeapSize", emptyToLong, (builder, target, arguments) -> {
+            // todo: configuration
+            // hard-coded 128MB for now
+            return lf.literalOf(128L * (1L << 20));
+        });
+
+        intrinsics.registerIntrinsic(heapDesc, "getConfiguredHeapAlignment", emptyToLong, (builder, target, arguments) -> {
+            // todo: configuration
+            // hard-coded 16MB alignment for now
+            return lf.literalOf(1L << 24);
+        });
+
+        intrinsics.registerIntrinsic(heapDesc, "getConfiguredObjectAlignment", emptyToInt, (builder, target, arguments) -> {
+            // todo: configuration
+            // hard-coded to pointer alignment for now
+            return lf.literalOf(ts.getPointerAlignment());
+        });
+    }
+}

--- a/plugins/gc/pom.xml
+++ b/plugins/gc/pom.xml
@@ -18,6 +18,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>common</module>
         <module>nogc</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -123,13 +123,25 @@
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>qbicc-runtime-main</artifactId>
+                <artifactId>qbicc-runtime-gc-heap</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-runtime-gc-nogc</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-runtime-linux</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-runtime-main</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -330,6 +342,12 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-plugin-intrinsics</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-plugin-gc-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/runtime/api/src/main/java/org/qbicc/runtime/stdc/String.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/stdc/String.java
@@ -19,4 +19,8 @@ public class String {
     public static native void_ptr memset(void_ptr dest, c_int data, size_t len);
 
     public static native c_int memcmp(const_void_ptr src1, const_void_ptr src2, size_t len);
+
+    public static native c_int strcmp(const_char_ptr src1, const_char_ptr src2);
+
+    public static native c_int strncmp(const_char_ptr src1, const_char_ptr src2, size_t len);
 }

--- a/runtime/gc/heap/pom.xml
+++ b/runtime/gc/heap/pom.xml
@@ -10,10 +10,10 @@
         <version>0.20.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>qbicc-runtime-gc-nogc</artifactId>
+    <artifactId>qbicc-runtime-gc-heap</artifactId>
 
-    <name>Qbicc Run Time: GC: No GC</name>
-    <description>Qbicc no-GC GC implementation</description>
+    <name>Qbicc Run Time: GC: Heap support</name>
+    <description>Qbicc heap API</description>
 
     <dependencies>
         <dependency>
@@ -24,9 +24,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-runtime-posix</artifactId>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-runtime-gc-heap</artifactId>
-        </dependency>
     </dependencies>
+
 </project>

--- a/runtime/gc/heap/src/main/java/org/qbicc/runtime/gc/heap/Heap.java
+++ b/runtime/gc/heap/src/main/java/org/qbicc/runtime/gc/heap/Heap.java
@@ -1,0 +1,421 @@
+package org.qbicc.runtime.gc.heap;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.posix.String.*;
+import static org.qbicc.runtime.posix.SysMman.*;
+import static org.qbicc.runtime.posix.Unistd.*;
+import static org.qbicc.runtime.stdc.Errno.*;
+import static org.qbicc.runtime.stdc.Stdint.*;
+import static org.qbicc.runtime.stdc.Stdio.*;
+import static org.qbicc.runtime.stdc.Stdlib.*;
+import static org.qbicc.runtime.stdc.String.*;
+
+import java.lang.invoke.VarHandle;
+
+import org.qbicc.runtime.Build;
+
+/**
+ * Heap management utilities.
+ * <p>
+ * The heap index values follow this rule:
+ * <p>
+ * {@code 0 ≤ allocated ≤ Xms ≤ committed ≤ limit(Xmx)}
+ */
+public final class Heap {
+    private Heap() {}
+
+    private static boolean initOk;
+    private static int initErrno;
+    private static ptr<@c_const c_char> errorMsgTemplate;
+    private static ptr<@c_const c_char> errorExtraArg;
+
+    /**
+     * The detected page size.
+     */
+    private static long pageSize;
+
+    /**
+     * The base pointer of the run time heap memory region.
+     */
+    private static void_ptr heap;
+    /**
+     * The allocated count for the heap, obeying this relation: {@code 0 ≤ allocated ≤ committed ≤ limit}.
+     */
+    private static long allocated;
+    /**
+     * The committed count for the heap, obeying this relation: {@code 0 ≤ allocated ≤ committed ≤ limit}.
+     */
+    private static long committed;
+    /**
+     * The upper limit for the heap, obeying this relation: {@code 0 ≤ allocated ≤ committed ≤ limit}.
+     */
+    private static long limit;
+
+    /**
+     * Get the build-time-configured maximum heap size.
+     *
+     * @return the configured maximum heap size in bytes
+     */
+    public static native long getConfiguredMinHeapSize();
+
+    /**
+     * Get the build-time-configured minimum heap size.
+     *
+     * @return the configured minimum heap size in bytes
+     */
+    public static native long getConfiguredMaxHeapSize();
+
+    /**
+     * Get the build-time-configured minimum heap alignment.
+     *
+     * @return the configured heap alignment
+     */
+    public static native long getConfiguredHeapAlignment();
+
+    /**
+     * Get the constant, build-time-configured minimum object alignment, in bytes.
+     * It is always the case that {@code Integer.bitCount(getConfiguredObjectAlignment()) == 1}.
+     *
+     * @return the configured object alignment
+     */
+    public static native int getConfiguredObjectAlignment();
+
+    /**
+     * An OOME that can always be safely thrown without allocating anything on the heap.
+     */
+    public static final OutOfMemoryError OOME;
+
+    static {
+        //
+        OutOfMemoryError error = new OutOfMemoryError();
+        error.setStackTrace(new StackTraceElement[0]);
+        OOME = error;
+    }
+
+    /**
+     * Get a pointer to the given heap offset. No checking is performed on the value.
+     *
+     * @param offset the offset
+     * @return the pointer (not {@code null})
+     */
+    public static void_ptr pointerToOffset(long offset) {
+        return heap.plus(offset);
+    }
+
+    /**
+     * Get the amount of free heap.  This does not include free space within allocated regions, which can only be
+     * established by the garbage collector.
+     *
+     * @return the amount of unallocated space, in bytes
+     */
+    public static long getHeapUnallocated() {
+        return limit - addr_of(allocated).loadSingleAcquire().longValue();
+    }
+
+    /**
+     * Get the detected page size.
+     *
+     * @return the page size
+     */
+    public static long getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Get the current heap offset.
+     *
+     * @return the heap offset
+     */
+    public static long getCurrentHeapOffset() {
+        return Heap.allocated;
+    }
+
+    /**
+     * Allocate space on the heap, throwing OOME if the allocation fails.  If the {@code expectedOffset} argument
+     * is not {@code -1} and the returned value does not equal {@code expectedOffset}, nothing will be allocated
+     * and the call must be repeated.
+     *
+     * @param expectedOffset the expected region offset, or {@code -1} if it does not matter
+     * @param size the number of bytes to allocate (must be a multiple of the page size)
+     * @return the previous heap region offset
+     * @throws IllegalArgumentException if the size is not a valid allocation size
+     * @throws OutOfMemoryError if some heap could not be committed
+     */
+    public static long allocateRegion(long expectedOffset, long size) throws IllegalArgumentException, OutOfMemoryError {
+        if (Build.isHost()) {
+            throw new IllegalStateException();
+        }
+        if ((size & (pageSize - 1)) != 0) {
+            throw new IllegalArgumentException();
+        }
+        int64_t_ptr allocatedPtr = addr_of(Heap.allocated);
+        long limit = Heap.limit;
+        long oldOffset, newOffset;
+        do {
+            oldOffset = allocatedPtr.loadSingleAcquire().longValue();
+            if (expectedOffset != -1L && oldOffset != expectedOffset) {
+                // someone allocated a region
+                return oldOffset;
+            }
+            newOffset = oldOffset + size;
+            if (newOffset > limit) {
+                // heap is fully allocated
+                throw OOME;
+            }
+            // commit if needed
+            commitUpTo(newOffset);
+            // now try to update the allocated value
+        } while (! allocatedPtr.compareAndSetRelease(word(oldOffset), word(newOffset)));
+        // return the pointer to the new space
+        return oldOffset;
+    }
+
+    public static void commitUpTo(long index) throws IllegalArgumentException, OutOfMemoryError {
+        if (Build.isHost()) {
+            throw new IllegalStateException();
+        }
+        if ((index & (pageSize - 1)) != 0) {
+            throw new IllegalArgumentException();
+        }
+        if (index > limit) {
+            // too much to commit
+            throw OOME;
+        }
+        int64_t_ptr committedPtr = addr_of(Heap.committed);
+        long committedOld;
+        do {
+            committedOld = committedPtr.loadSingleAcquire().longValue();
+            if (committedOld >= index) {
+                // OK
+                return;
+            }
+            // need to commit it
+            c_int res = mprotect(heap.plus(committedOld), word(index - committedOld), wordOr(PROT_READ, PROT_WRITE));
+            if (res == word(-1)) {
+                // failed to commit; throw without allocating anything
+                throw OOME;
+            }
+        } while (! committedPtr.compareAndSetRelease(word(committedOld), word(index)));
+        // requested memory is committed
+        return;
+    }
+
+    /**
+     * Check on the status of heap initialization and return a flag if the heap is usable.
+     *
+     * @param printErrors {@code true} to print errors to {@code stderr}, {@code false} to skip printing
+     * @return {@code true} if the heap is usable, {@code false} otherwise
+     */
+    public static boolean checkInit(boolean printErrors) {
+        if (! initOk) {
+            if (printErrors) {
+                int initErrno = Heap.initErrno;
+                ptr<@c_const c_char> errorMsgTemplate = Heap.errorMsgTemplate;
+                ptr<@c_const c_char> message;
+                if (errorMsgTemplate.isZero()) {
+                    message = utf8z("Heap initialization was not completed").cast();
+                } else {
+                    message = errorMsgTemplate;
+                }
+                final int bufSize = 256;
+                ptr<c_char> buf = alloca(word(bufSize)).cast();
+                ptr<c_char> arg;
+                if (strerror_r(word(initErrno), buf, word(bufSize)).isNonZero()) {
+                    arg = utf8z("(too long)").cast();
+                } else {
+                    arg = buf;
+                }
+                fprintf(stderr, message.cast(), arg, errorExtraArg);
+                fflush(stderr);
+            }
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static boolean isHeapArgument(ptr<@c_const c_char> argPtr) {
+        return strncmp(argPtr.cast(), utf8z("-Xmx"), word(4)).isZero()
+            || strncmp(argPtr.cast(), utf8z("-Xms"), word(4)).isZero()
+            ;
+    }
+
+    // TODO: hoist error reporting to some kind of entry-point prologue
+    @constructor(priority = 0)
+    @export
+    static void initHeap(c_int argc, char_ptr_ptr argv) {
+        if (Build.isHost()) {
+            throw new IllegalStateException();
+        }
+        long pageMask;
+        // Initializer function - JDK AND HEAP NOT YET AVAILABLE
+        if (Build.Target.isPosix()) {
+            int pageSize = sysconf(_SC_PAGE_SIZE).intValue();
+            if (pageSize == -1) {
+                errorMsgTemplate = utf8z("Failed to determine page size: %s\n").cast();
+                initErrno = errno;
+                return;
+            }
+            if (Integer.bitCount(pageSize) != 1) {
+                // not a power of 2? but not likely enough to be worth spending memory on an error message
+                return;
+            }
+            Heap.pageSize = pageSize;
+            pageMask = pageSize - 1;
+        } else {
+            errorMsgTemplate = utf8z("Platform not supported\n").cast();
+            return;
+        }
+        // cycle through the arguments to find heap size options
+        long maxHeap = -1;
+        long minHeap = -1;
+        for (int i = 1; i < argc.intValue(); i ++) {
+            const_char_ptr arg = argv.asArray()[i].cast();
+            if (strncmp(arg, utf8z("-Xmx"), word(4)) == zero()) {
+                maxHeap = parseMemSize(arg.plus(4));
+                if (maxHeap == -1) {
+                    // failed
+                    return;
+                }
+                if (maxHeap < pageSize) {
+                    maxHeap = pageSize;
+                }
+            } else if (strncmp(arg, utf8z("-Xms"), word(4)) == zero()) {
+                minHeap = parseMemSize(arg.plus(4));
+                if (minHeap == -1) {
+                    // failed
+                    return;
+                }
+                if (minHeap < pageSize) {
+                    minHeap = pageSize;
+                }
+            } else if (strcmp(arg, utf8z("--")) == zero()) {
+                // arguments done
+                break;
+            }
+        }
+        if (maxHeap == -1 && minHeap == -1) {
+            maxHeap = getConfiguredMaxHeapSize();
+            minHeap = getConfiguredMinHeapSize();
+            // round up to page size
+            maxHeap = (maxHeap + pageMask) & ~pageMask;
+            minHeap = (minHeap + pageMask) & ~pageMask;
+            if (maxHeap < minHeap) {
+                maxHeap = minHeap;
+            }
+        } else if (maxHeap == -1) {
+            maxHeap = getConfiguredMaxHeapSize();
+            // round up to page size
+            maxHeap = (maxHeap + pageMask) & ~pageMask;
+            minHeap = (minHeap + pageMask) & ~pageMask;
+            if (maxHeap < minHeap) {
+                // minHeap takes precedence because maxHeap was not given
+                maxHeap = minHeap;
+            }
+        } else if (minHeap == -1) {
+            minHeap = getConfiguredMinHeapSize();
+            // round up to page size
+            maxHeap = (maxHeap + pageMask) & ~pageMask;
+            minHeap = (minHeap + pageMask) & ~pageMask;
+            if (maxHeap < minHeap) {
+                // maxHeap takes precedence because minHeap was not given
+                minHeap = maxHeap;
+            }
+        } else {
+            // round up to page size
+            maxHeap = (maxHeap + pageMask) & ~pageMask;
+            minHeap = (minHeap + pageMask) & ~pageMask;
+            if (maxHeap < minHeap) {
+                maxHeap = minHeap;
+            }
+        }
+        // First, reserve the full address space that we need
+        long heapAlignment = getConfiguredHeapAlignment();
+        void_ptr heap = mmap(zero(),
+            word(maxHeap + heapAlignment),
+            PROT_NONE,
+            wordOr(MAP_ANON, MAP_PRIVATE),
+            word(-1),
+            zero()
+        );
+        if (heap == MAP_FAILED) {
+            errorMsgTemplate = utf8z("Failed to map initial heap: %s\n").cast();
+            initErrno = errno;
+            // failed
+            return;
+        }
+        // align the heap
+        long misalignment = heap.longValue() & (heapAlignment - 1);
+        // release the extra address space at the start and the end
+        long trimAtStart = heapAlignment - misalignment;
+        if (trimAtStart > 0) {
+            munmap(heap, word(trimAtStart));
+            heap = heap.plus(trimAtStart);
+        }
+        // (heap is now aligned)
+        if (misalignment > 0) {
+            munmap(heap.plus(maxHeap), word(misalignment));
+        }
+        // next attempt to commit the minimum heap size
+        c_int res = mprotect(heap, word(minHeap), wordOr(PROT_READ, PROT_WRITE));
+        if (res == word(-1)) {
+            errorMsgTemplate = utf8z("Failed to commit minimum heap space: %s\n").cast();
+            initErrno = errno;
+            // failed
+            return;
+        }
+        Heap.heap = heap;
+        Heap.allocated = 0;
+        Heap.committed = minHeap;
+        Heap.limit = maxHeap;
+        Heap.initOk = true;
+        VarHandle.releaseFence();
+        // The empty heap is configured!
+        return;
+    }
+
+    @export(withScope = ExportScope.LOCAL)
+    private static long parseMemSize(final char_ptr arg) {
+        char_ptr endPtr = auto();
+        long num = strtoll(arg.cast(), addr_of(endPtr), word(10)).longValue();
+        char ch = endPtr.loadUnshared().cast(unsigned_char.class).charValue();
+        if (ch == 0) {
+            // just bytes
+        } else if (ch == 'T' || ch == 't') {
+            // terabytes
+            num *= 1L << 40;
+            endPtr = endPtr.plus(1);
+        } else if (ch == 'G' || ch == 'g') {
+            // gigabytes
+            num *= 1L << 30;
+            endPtr = endPtr.plus(1);
+        } else if (ch == 'M' || ch == 'm') {
+            // megabytes
+            num *= 1L << 20;
+            endPtr = endPtr.plus(1);
+        } else if (ch == 'K' || ch == 'k') {
+            // kilobytes
+            num *= 1L << 10;
+            endPtr = endPtr.plus(1);
+        }
+        ch = endPtr.loadUnshared().cast(unsigned_char.class).charValue();
+        if (ch != 0) {
+            errorMsgTemplate = utf8z("Invalid memory size: %2$s\n").cast();
+            errorExtraArg = arg;
+            return -1;
+        }
+        return num;
+    }
+
+    @destructor(priority = 0)
+    @export
+    static void destroyHeap() {
+        VarHandle.acquireFence();
+        void_ptr heap = Heap.heap;
+        if (heap != null) {
+            munmap(heap, word(limit));
+        }
+        Heap.heap = zero();
+        VarHandle.releaseFence();
+    }
+}

--- a/runtime/gc/nogc/src/main/java/org/qbicc/runtime/gc/nogc/NoGcHelpers.java
+++ b/runtime/gc/nogc/src/main/java/org/qbicc/runtime/gc/nogc/NoGcHelpers.java
@@ -1,14 +1,12 @@
 package org.qbicc.runtime.gc.nogc;
 
 import static org.qbicc.runtime.CNative.*;
-import static org.qbicc.runtime.posix.Stdlib.*;
-import static org.qbicc.runtime.stdc.Stddef.*;
-import static org.qbicc.runtime.stdc.Stdlib.*;
+import static org.qbicc.runtime.stdc.Stdint.*;
 import static org.qbicc.runtime.stdc.String.*;
 
 import org.qbicc.runtime.AutoQueued;
-import org.qbicc.runtime.Build;
 import org.qbicc.runtime.Hidden;
+import org.qbicc.runtime.gc.heap.Heap;
 
 /**
  *
@@ -16,29 +14,42 @@ import org.qbicc.runtime.Hidden;
 public final class NoGcHelpers {
     private NoGcHelpers() {}
 
+    // our allocation position
+    private static long pos;
+
     @Hidden
     @AutoQueued
     public static Object allocate(long size, int align) {
-        if (false && Build.Target.isPosix()) {
-            void_ptr ptr = auto();
-            c_int res = posix_memalign(addr_of(ptr), word((long)align), word(size));
-            if (res.intValue() != 0) {
-                // todo: read errno
-                throw new OutOfMemoryError(/*"Allocation failed"*/);
+        // todo: per-object alignment - should we allow it? perhaps not (ignore for now)
+        int64_t_ptr posPtr = addr_of(pos);
+
+        long oldPos, newPos;
+        long oldRegionPos;
+        for (;;) {
+            oldPos = posPtr.loadSingleAcquire().longValue();
+            oldRegionPos = Heap.getCurrentHeapOffset();
+            if (oldPos + size >= oldRegionPos) {
+                // allocate some more pages
+                long pageSize = Heap.getPageSize();
+                long pageMask = pageSize - 1;
+                // this is how far over we are (in pages)
+                long amount = size - oldRegionPos + oldPos + pageMask & ~pageMask;
+                if (Heap.allocateRegion(oldRegionPos, amount) != oldRegionPos) {
+                    // our requested heap was not allocated; retry the loop
+                    continue;
+                }
             }
-            return ptr;
-        } else {
-            void_ptr ptr = malloc(word(size + align));
-            if (ptr.isNull()) {
-                throw new OutOfMemoryError(/*"Allocation failed"*/);
+            newPos = oldPos + size;
+            int objAlign = Heap.getConfiguredObjectAlignment();
+            int objAlignMask = objAlign - 1;
+            long misalign = newPos & objAlignMask;
+            if (misalign != 0) {
+                newPos += objAlign - misalign;
             }
-            long mask = align - 1;
-            long misAlign = ptr.longValue() & mask;
-            if (misAlign != 0) {
-                ptrdiff_t word = word(((~ misAlign) & mask) + 1);
-                ptr = ptr.plus(word.intValue());
+            if (posPtr.compareAndSetRelease(word(oldPos), word(newPos))) {
+                return ptrToRef(Heap.pointerToOffset(oldPos));
             }
-            return ptrToRef(ptr);
+            Thread.onSpinWait();
         }
     }
 

--- a/runtime/gc/pom.xml
+++ b/runtime/gc/pom.xml
@@ -18,6 +18,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>heap</module>
         <module>nogc</module>
     </modules>
 </project>

--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysMman.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysMman.java
@@ -1,0 +1,52 @@
+package org.qbicc.runtime.posix;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.posix.SysTypes.*;
+import static org.qbicc.runtime.stdc.Stddef.*;
+
+@SuppressWarnings("SpellCheckingInspection")
+@include("<sys/mman.h>")
+@define(value = "_POSIX_C_SOURCE", as = "200809L")
+public final class SysMman {
+    private SysMman() {}
+
+    public static native void_ptr mmap(void_ptr addr, size_t length, c_int prot, c_int flags, c_int fd, off_t offset);
+    public static native c_int munmap(void_ptr addr, size_t length);
+
+    public static native c_int mprotect(void_ptr addr, size_t length, c_int prot);
+
+    public static native c_int mlock(const_void_ptr addr, size_t length);
+    public static native c_int munlock(const_void_ptr addr, size_t length);
+
+    public static native c_int mlockall(c_int flags);
+    public static native c_int munlockall();
+
+    public static native c_int msync(void_ptr addr, size_t length, c_int flags);
+
+    public static native c_int posix_madvise(void_ptr addr, size_t length, c_int advice);
+
+    public static native c_int posix_mem_offset(const_void_ptr addr, size_t length, off_t_ptr offsetPtr, size_t_ptr contigLen, int_ptr fdPtr);
+
+    public static native c_int shm_open(const_char_ptr name, c_int oflag, mode_t mode);
+    public static native c_int shm_unlink(const_char_ptr name);
+
+    // NOTE: Not POSIX but widely supported
+    public static final c_int MAP_ANON = constant();
+
+    public static final c_int MAP_SHARED = constant();
+    public static final c_int MAP_PRIVATE = constant();
+    public static final c_int MAP_FIXED = constant();
+
+    public static final void_ptr MAP_FAILED = constant();
+
+    public static final c_int PROT_READ = constant();
+    public static final c_int PROT_WRITE = constant();
+    public static final c_int PROT_EXEC = constant();
+    public static final c_int PROT_NONE = constant();
+
+    public static final c_int POSIX_MADV_NORMAL = constant();
+    public static final c_int POSIX_MADV_SEQUENTIAL = constant();
+    public static final c_int POSIX_MADV_RANDOM = constant();
+    public static final c_int POSIX_MADV_WILLNEED = constant();
+    public static final c_int POSIX_MADV_DONTNEED = constant();
+}


### PR DESCRIPTION
Some things are still unimplemented, but this code ensures that the heap is present when any entry point method is called, and allocates all new objects out of a single contiguous memory area, throwing OOME when no more space is available.

TODO:

- ~~More than one kind of pre-allocated OOME with a descriptive error~~ Going to skip this one for now
- [x] Defer errors to a "checkErrors" method which is run at any entry point before binding a thread (so that error messages can be properly printed)
- [x] Relay pre-configured values (such as the configured default minimum and maximum heap sizes and heap alignment, which are presently hard-coded)