### PR TITLE
Annotations for serialization replacement

### DIFF
--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -28,6 +28,8 @@ import org.qbicc.plugin.serialization.BuildtimeHeap;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.IntegerType;
+import org.qbicc.type.annotation.Annotation;
+import org.qbicc.type.annotation.LongAnnotationValue;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -87,7 +89,10 @@ public class Lowering {
                 if (field.getRunTimeInitializer() != null) {
                     initialValue = lf.zeroInitializerLiteralOfType(field.getType());
                 } else {
-                    initialValue = ((DefinedTypeDefinition) typeDef).load().getInitialValue(field);
+                    initialValue = field.getReplacementValue(ctxt);
+                    if (initialValue == null) {
+                        initialValue = ((DefinedTypeDefinition) typeDef).load().getInitialValue(field);
+                    }
                     if (initialValue == null) {
                         initialValue = Constants.get(ctxt).getConstantValue(field);
                         if (initialValue == null) {

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -38,6 +38,8 @@ import org.qbicc.type.TypeSystem;
 import org.qbicc.type.TypeType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
+import org.qbicc.type.annotation.Annotation;
+import org.qbicc.type.annotation.LongAnnotationValue;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -258,10 +260,13 @@ public class BuildtimeHeap {
             if (f.isStatic()) {
                 continue;
             }
+
             CompoundType.Member im = memLayout.getMember(f);
             CompoundType.Member om = objLayout.getMember(f);
-            if (im.getType() instanceof IntegerType) {
-                IntegerType it = (IntegerType)im.getType();
+            Literal replacement = f.getReplacementValue(ctxt);
+            if (replacement != null) {
+                memberMap.put(om, replacement);
+            } else if (im.getType() instanceof IntegerType it) {
                 if (it.getSize() == 1) {
                     memberMap.put(om, lf.literalOf(it, memory.load8(im.getOffset(), SinglePlain)));
                 } else if (it.getSize() == 2) {
@@ -271,8 +276,7 @@ public class BuildtimeHeap {
                 } else {
                     memberMap.put(om, lf.literalOf(it, memory.load64(im.getOffset(), SinglePlain)));
                 }
-            } else if (im.getType() instanceof FloatType) {
-                FloatType ft = (FloatType)im.getType();
+            } else if (im.getType() instanceof FloatType ft) {
                 if (ft.getSize() == 4) {
                     memberMap.put(om, lf.literalOf(ft, memory.loadFloat(im.getOffset(), SinglePlain)));
                 } else {

--- a/runtime/api/src/main/java/org/qbicc/runtime/SerializeAsZero.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/SerializeAsZero.java
@@ -1,0 +1,20 @@
+package org.qbicc.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to indicate that when an instance or static field is
+ * serialized to the qbicc initial runtime heap that the value that
+ * was present in the field during build time initialization should
+ * be replaced by the zero-initializer (0, false, null) appropriate
+ * to the type of the field.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface SerializeAsZero {
+}
+
+

--- a/runtime/api/src/main/java/org/qbicc/runtime/SerializeBooleanAs.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/SerializeBooleanAs.java
@@ -1,0 +1,19 @@
+package org.qbicc.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to indicate that when an instance or static field
+ * of boolean type is serialized to the qbicc initial runtime heap that the value that
+ * was present in the field during build time initialization should
+ * be replaced by the value provided by the annotation.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface SerializeBooleanAs {
+    /** The value to serialize */
+    boolean value();
+}

--- a/runtime/api/src/main/java/org/qbicc/runtime/SerializeFloatingPointAs.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/SerializeFloatingPointAs.java
@@ -1,0 +1,20 @@
+package org.qbicc.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to indicate that when an instance or static field
+ * of a primitive floating point type (float or double) is
+ * serialized to the qbicc initial runtime heap that the value that
+ * was present in the field during build time initialization should
+ * be replaced by the value provided by the annotation.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface SerializeFloatingPointAs {
+    /** The value to serialize */
+    double value();
+}

--- a/runtime/api/src/main/java/org/qbicc/runtime/SerializeIntegralAs.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/SerializeIntegralAs.java
@@ -1,0 +1,20 @@
+package org.qbicc.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to indicate that when an instance or static field
+ * of a primitive integral type (byte, char, short, int or long) is
+ * serialized to the qbicc initial runtime heap that the value that
+ * was present in the field during build time initialization should
+ * be replaced by the value provided by the annotation.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface SerializeIntegralAs {
+    /** The value to serialize */
+    long value();
+}


### PR DESCRIPTION
Cover two basic cases of replacing a field with a zero-initializer and replacing an integral field with a constant value (eg -1 for FileDescriptor.fd).

Not that attached to the actual names of the annotations, so happy to adjust if there are suggestions.

Thought about supporting Float, Double, and Boolean constants as well but don't know if we have a motivating example yet.