### PR TITLE
Fix padding-related problems

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
+++ b/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
@@ -1,5 +1,6 @@
 package org.qbicc.graph;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -164,7 +165,7 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
                 .setName(null)
                 .addNextMember(valueType)
                 .addNextMember(ts.getBooleanType())
-                .setOverallAlignment(valueType.getAlign())
+                .setOverallAlignment(1)
                 .build();
             CompoundType appearing = map.putIfAbsent(valueType, compoundType);
             if (appearing != null) {

--- a/compiler/src/main/java/org/qbicc/graph/ExtractMember.java
+++ b/compiler/src/main/java/org/qbicc/graph/ExtractMember.java
@@ -19,9 +19,6 @@ public final class ExtractMember extends AbstractValue {
         this.compoundValue = compoundValue;
         compoundType = (CompoundType) compoundValue.getType();
         this.member = member;
-        if (! compoundType.getMembers().contains(member)) {
-            throw new IllegalStateException(String.format("Compound %s does not contain %s", compoundType, member));
-        }
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/graph/MemberOf.java
+++ b/compiler/src/main/java/org/qbicc/graph/MemberOf.java
@@ -22,9 +22,6 @@ public final class MemberOf extends AbstractValueHandle {
         this.member = member;
         pointerType = member.getType().getPointer().withQualifiersFrom(structureHandle.getPointerType());
         structType = (CompoundType) structureHandle.getValueType();
-        if (! structType.getMembers().contains(member)) {
-            throw new IllegalStateException(String.format("Compound %s does not contain %s", structType, member));
-        }
     }
 
     public CompoundType getStructType() {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -240,7 +240,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         if (handle.getValueType() instanceof CompoundType ct) {
             LiteralFactory lf = ctxt.getLiteralFactory();
             Value res = lf.zeroInitializerLiteralOfType(ct);
-            for (CompoundType.Member member : ct.getMembers()) {
+            for (CompoundType.Member member : ct.getPaddedMembers()) {
                 res = insertMember(res, member, load(memberOf(handle, member), accessMode));
             }
             return res;
@@ -304,7 +304,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         }
         // Break apart atomic structure and array stores
         if (handle.getValueType() instanceof CompoundType ct) {
-            for (CompoundType.Member member : ct.getMembers()) {
+            for (CompoundType.Member member : ct.getPaddedMembers()) {
                 store(memberOf(handle, member), extractMember(value, member), accessMode);
             }
             return nop();

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -212,14 +212,6 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
     }
 
     @Override
-    public Value extractElement(Value array, Value index) {
-        if (!(index instanceof Literal)) {
-            ctxt.error(getLocation(), "Index of ExtractElement must be constant");
-        }
-        return super.extractElement(array, index);
-    }
-
-    @Override
     public Value offsetOfField(FieldElement fieldElement) {
         if (fieldElement.isStatic()) {
             return ctxt.getLiteralFactory().literalOf(-1);

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -259,7 +259,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
                 // rolled loop
                 BlockLabel top = new BlockLabel();
                 BlockLabel exit = new BlockLabel();
-                UnsignedIntegerType idxType = ctxt.getTypeSystem().getUnsignedInteger64Type();
+                SignedIntegerType idxType = ctxt.getTypeSystem().getSignedInteger64Type();
                 BasicBlock entry = goto_(top);
                 PhiValue idx = phi(idxType, top);
                 PhiValue val = phi(at, top);
@@ -321,7 +321,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
                 // rolled loop
                 BlockLabel top = new BlockLabel();
                 BlockLabel exit = new BlockLabel();
-                UnsignedIntegerType idxType = ctxt.getTypeSystem().getUnsignedInteger64Type();
+                SignedIntegerType idxType = ctxt.getTypeSystem().getSignedInteger64Type();
                 BasicBlock entry = goto_(top);
                 PhiValue idx = phi(idxType, top);
                 begin(top);

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -251,6 +251,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
             for (CompoundType.Member member : ct.getMembers()) {
                 res = insertMember(res, member, load(memberOf(handle, member), accessMode));
             }
+            return res;
         } else if (handle.getValueType() instanceof ArrayType at) {
             long ec = at.getElementCount();
             LiteralFactory lf = ctxt.getLiteralFactory();
@@ -314,6 +315,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
             for (CompoundType.Member member : ct.getMembers()) {
                 store(memberOf(handle, member), extractMember(value, member), accessMode);
             }
+            return nop();
         } else if (handle.getValueType() instanceof ArrayType at) {
             long ec = at.getElementCount();
             LiteralFactory lf = ctxt.getLiteralFactory();


### PR DESCRIPTION
Structures are not correctly initialized (zeroed) or copied at present when there are members we do not know about (they exist in the padding space).  Furthermore there are several bugs around the ability to load and store structure and array values.

This series of commits adds a facility to get a padded member list for a `CompoundType`. The padded member list is used to load and store structure members piecemeal so that our atomicity guarantees can be maintained even in the face of members we do not know about.  We insert 64-bit integer padding whenever possible, and fall back to smaller padding sizes only to fill in unaligned spaces.

The padded member list is then also used to replace code in the LLVM back end which had the same job.  The previous padding code always used byte arrays, preventing atomic copying from working as expected. The newer solution is nicer in that any part of the compilation process which cares about padding can use the same facility with the same padding rules.
