### PR TITLE
Introduce Facts API, track field reachability

### DIFF
--- a/compiler/src/main/java/org/qbicc/facts/Condition.java
+++ b/compiler/src/main/java/org/qbicc/facts/Condition.java
@@ -1,0 +1,270 @@
+package org.qbicc.facts;
+
+import java.util.function.ObjLongConsumer;
+
+/**
+ * A condition that, when met, triggers the execution of an action.
+ *
+ * @param <F> the fact type
+ */
+public abstract class Condition<F extends Fact<?>> {
+    Condition() {}
+
+    /**
+     * A condition which is true when the given fact is present.
+     *
+     * @param fact the fact
+     * @param <F> the fact type
+     * @return the condition
+     */
+    public static <F extends Fact<?>> Condition<F> when(F fact) {
+        return new Of<>(fact);
+    }
+
+
+    /**
+     * A condition which is true when all of the given facts are present.
+     *
+     * @param fact1 the first fact
+     * @param fact2 the second fact
+     * @param <F> the fact type
+     * @return the condition
+     */
+    public static <F extends Fact<?>> Condition<F> whenAll(F fact1, F fact2) {
+        return new All2<>(fact1, fact2);
+    }
+
+    /**
+     * A condition which is true when all of the given facts are present.
+     *
+     * @param fact1 the first fact
+     * @param fact2 the second fact
+     * @param fact3 the second fact
+     * @param <F> the fact type
+     * @return the condition
+     */
+    public static <F extends Fact<?>> Condition<F> whenAll(F fact1, F fact2, F fact3) {
+        return new All3<>(fact1, fact2, fact3);
+    }
+
+    /**
+     * A condition which is true when all of the given facts are present.
+     *
+     * @param facts the facts
+     * @param <F> the fact type
+     * @return the condition
+     */
+    @SafeVarargs
+    public static <F extends Fact<?>> Condition<F> whenAll(F... facts) {
+        return new AllMany<>(facts);
+    }
+
+
+    /**
+     * A condition which is true when any of the given facts are present.
+     *
+     * @param fact1 the first fact
+     * @param fact2 the second fact
+     * @param <F> the fact type
+     * @return the condition
+     */
+    public static <F extends Fact<?>> Condition<F> whenAny(F fact1, F fact2) {
+        return new Any2<>(fact1, fact2);
+    }
+
+    /**
+     * A condition which is true when any of the given facts are present.
+     *
+     * @param fact1 the first fact
+     * @param fact2 the second fact
+     * @param fact3 the third fact
+     * @param <F> the fact type
+     * @return the condition
+     */
+    public static <F extends Fact<?>> Condition<F> whenAny(F fact1, F fact2, F fact3) {
+        return new Any3<>(fact1, fact2, fact3);
+    }
+
+    /**
+     * A condition which is true when any of the given facts are present.
+     *
+     * @param facts the facts
+     * @param <F> the fact type
+     * @return the condition
+     */
+    @SafeVarargs
+    public static <F extends Fact<?>> Condition<F> whenAny(F... facts) {
+        return new AnyMany<>(facts);
+    }
+
+
+    /**
+     * Get a condition which is true when both this condition and the given condition are true.
+     *
+     * @param other the other condition
+     * @return the new condition
+     */
+    public Condition<F> and(Condition<F> other) {
+        return new And<F>(this, other);
+    }
+
+
+    /**
+     * Get a condition which is true when either this condition or the given condition are true.
+     *
+     * @param other the other condition
+     * @return the new condition
+     */
+    public Condition<F> or(Condition<F> other) {
+        return new Or<F>(this, other);
+    }
+
+
+    abstract ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next);
+
+    static class Of<F extends Fact<?>> extends Condition<F> {
+        final F fact1;
+
+        Of(F fact1) {
+            this.fact1 = fact1;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return (holder, bits) -> next.accept(holder, bits | 1L << holder.getFactIndex(fact1));
+        }
+    }
+
+    static class Any2<F extends Fact<?>> extends Of<F> {
+        final F fact2;
+
+        Any2(F fact1, F fact2) {
+            super(fact1);
+            this.fact2 = fact2;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return (holder, bits) -> {
+                next.accept(holder, bits | 1L << holder.getFactIndex(fact1));
+                next.accept(holder, bits | 1L << holder.getFactIndex(fact2));
+            };
+        }
+    }
+
+    static class Any3<F extends Fact<?>> extends Any2<F> {
+        final F fact3;
+
+        Any3(F fact1, F fact2, F fact3) {
+            super(fact1, fact2);
+            this.fact3 = fact3;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return (holder, bits) -> {
+                next.accept(holder, bits | 1L << holder.getFactIndex(fact1));
+                next.accept(holder, bits | 1L << holder.getFactIndex(fact2));
+                next.accept(holder, bits | 1L << holder.getFactIndex(fact3));
+            };
+        }
+    }
+
+    static class AnyMany<F extends Fact<?>> extends Condition<F> {
+        final F[] facts;
+
+        AnyMany(F[] facts) {
+            this.facts = facts;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return (holder, bits) -> {
+                for (F fact : facts) {
+                    next.accept(holder, bits | 1L << holder.getFactIndex(fact));
+                }
+            };
+        }
+    }
+
+    static class All2<F extends Fact<?>> extends Of<F> {
+        final F fact2;
+
+        All2(F fact1, F fact2) {
+            super(fact1);
+            this.fact2 = fact2;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return (holder, bits) -> next.accept(holder, bits | 1L << holder.getFactIndex(fact1) | 1L << holder.getFactIndex(fact2));
+        }
+    }
+
+    static class All3<F extends Fact<?>> extends All2<F> {
+        final F fact3;
+
+        All3(F fact1, F fact2, F fact3) {
+            super(fact1, fact2);
+            this.fact3 = fact3;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return (holder, bits) -> next.accept(holder, bits | 1L << holder.getFactIndex(fact1) | 1L << holder.getFactIndex(fact2) | 1L << holder.getFactIndex(fact3));
+        }
+    }
+
+    static class AllMany<F extends Fact<?>> extends Condition<F> {
+        final F[] facts;
+
+        AllMany(F[] facts) {
+            this.facts = facts;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return (holder, bits) -> {
+                for (F fact : facts) {
+                    bits |= 1L << holder.getFactIndex(fact);
+                }
+                next.accept(holder, bits);
+            };
+        }
+    }
+
+    static class Or<F extends Fact<?>> extends Condition<F> {
+        private final Condition<F> cond1;
+        private final Condition<F> cond2;
+
+        Or(Condition<F> cond1, Condition<F> cond2) {
+            this.cond1 = cond1;
+            this.cond2 = cond2;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            var f1 = cond1.getRegisterFunction(next);
+            var f2 = cond2.getRegisterFunction(next);
+            return (holder, bits) -> {
+                f1.accept(holder, bits);
+                f2.accept(holder, bits);
+            };
+        }
+    }
+
+    static class And<F extends Fact<?>> extends Condition<F> {
+        private final Condition<F> cond1;
+        private final Condition<F> cond2;
+
+        And(Condition<F> cond1, Condition<F> cond2) {
+            this.cond1 = cond1;
+            this.cond2 = cond2;
+        }
+
+        @Override
+        ObjLongConsumer<Facts> getRegisterFunction(ObjLongConsumer<Facts> next) {
+            return cond1.getRegisterFunction(cond2.getRegisterFunction(next));
+        }
+    }
+}

--- a/compiler/src/main/java/org/qbicc/facts/Fact.java
+++ b/compiler/src/main/java/org/qbicc/facts/Fact.java
@@ -1,0 +1,8 @@
+package org.qbicc.facts;
+
+/**
+ * A boolean fact which applies to a specific element type.
+ */
+public interface Fact<E> {
+    Class<E> getElementType();
+}

--- a/compiler/src/main/java/org/qbicc/facts/Facts.java
+++ b/compiler/src/main/java/org/qbicc/facts/Facts.java
@@ -1,0 +1,305 @@
+package org.qbicc.facts;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.ObjectIntMaps;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.map.primitive.ImmutableObjectIntMap;
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.context.PhaseAttachmentKey;
+
+/**
+ * A central point for registering and tracking facts about types and members.
+ */
+public final class Facts {
+    private static final VarHandle factIdsHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "factIds", VarHandle.class, Facts.class, ImmutableObjectIntMap.class);
+    private static final VarHandle longArrayHandle = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "_", VarHandle.class, long[].class);
+
+    private final CompilationContext ctxt;
+
+    private static final AttachmentKey<Facts> KEY = new AttachmentKey<>();
+
+    private static final PhaseAttachmentKey<PerPhase> PER_PHASE_KEY = new PhaseAttachmentKey<>();
+
+    @SuppressWarnings("FieldMayBeFinal") // VarHandle
+    private volatile ImmutableObjectIntMap<Fact<?>> factIds = ObjectIntMaps.immutable.empty();
+
+    static final class PerPhase {
+        // The array value contains two elements:
+        //   [0] - bits representing discovered facts
+        //   [1] - bits representing executed actions
+        // It seems like it would be possible to deduce the actions from the old and new facts, however this doesn't cover late-added actions
+        final Map<Object, long[]> facts = new ConcurrentHashMap<>();
+        final Map<Fact<?>, long[]> counts = new ConcurrentHashMap<>();
+        volatile ImmutableList<Action<?>> actions = Lists.immutable.empty();
+
+        PerPhase() {}
+    }
+
+    private Facts(CompilationContext ctxt) {
+        this.ctxt = ctxt;
+    }
+
+    public static Facts get(CompilationContext ctxt) {
+        Facts facts = ctxt.getAttachment(KEY);
+        if (facts == null) {
+            facts = new Facts(ctxt);
+            Facts appearing = ctxt.putAttachmentIfAbsent(KEY, facts);
+            if (appearing != null) {
+                facts = appearing;
+            }
+        }
+        return facts;
+    }
+
+    int getFactIndex(Fact<?> fact) {
+        int id;
+        ImmutableObjectIntMap<Fact<?>> oldMap, newMap;
+        for (;;) {
+            oldMap = factIds;
+            id = oldMap.getIfAbsent(fact, -1);
+            if (id != -1) {
+                return id;
+            }
+            id = oldMap.size();
+            // if we need more, we'll have to do a slight design adjustment in order to preserve atomicity across multi-word RMW
+            if (id >= 64) {
+                throw new IllegalStateException("Too many facts");
+            }
+            newMap = oldMap.newWithKeyValue(fact, id);
+            if (factIdsHandle.compareAndSet(this, oldMap, newMap)) {
+                return id;
+            }
+        }
+    }
+
+    private PerPhase getPerPhase() {
+        PerPhase perPhase = ctxt.getAttachment(PER_PHASE_KEY);
+        if (perPhase == null) {
+            perPhase = new PerPhase();
+            PerPhase appearing = ctxt.putAttachmentIfAbsent(PER_PHASE_KEY, perPhase);
+            if (appearing != null) {
+                perPhase = appearing;
+            }
+        }
+        return perPhase;
+    }
+
+    private PerPhase getPreviousPerPhase() {
+        return ctxt.getPreviousPhaseAttachment(PER_PHASE_KEY);
+    }
+
+    private void registerAction(long bits, BiConsumer<?, Facts> consumer) {
+        PerPhase perPhase = getPerPhase();
+        synchronized (perPhase) {
+            Action<?> action = new Action<>(bits, consumer);
+            ImmutableList<Action<?>> newActions = perPhase.actions.newWith(action);
+            perPhase.actions = newActions;
+            Map<Object, long[]> factsMap = perPhase.facts;
+            if (! factsMap.isEmpty()) {
+                // execute all newly-registered actions
+                int actionBit = newActions.size() - 1;
+                for (Map.Entry<Object, long[]> entry : factsMap.entrySet()) {
+                    long[] array = entry.getValue();
+                    long factBits = (long) longArrayHandle.getVolatile(array, 0);
+                    if (action.isNewlySatisfiedBy(0, factBits)) {
+                        long oldVal;
+                        long newVal;
+                        for (;;) {
+                            oldVal = (long) longArrayHandle.getVolatile(array, 1);
+                            newVal = oldVal | 1L << actionBit;
+                            if (oldVal == newVal) {
+                                break;
+                            }
+                            if (longArrayHandle.compareAndSet(array, 1, oldVal, newVal)) {
+                                action.accept(entry.getKey());
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static long[] newArray(Object ignored) {
+        // [0] = fact bits
+        // [1] = action bits
+        return new long[2];
+    }
+
+    private <E> long discover(E item, long factBits) {
+        PerPhase perPhase = getPerPhase();
+        Map<Object, long[]> facts = perPhase.facts;
+        long[] array = facts.computeIfAbsent(item, Facts::newArray);
+        long oldFacts, newFacts;
+        do {
+            oldFacts = (long) longArrayHandle.getVolatile(array, 0);
+            if ((oldFacts & factBits) == factBits) {
+                // already known
+                return 0;
+            }
+            newFacts = oldFacts | factBits;
+        } while (! longArrayHandle.compareAndSet(array, 0, oldFacts, newFacts));
+        // todo: optimize by utilizing newFacts ^ oldFacts to find the actions that could be newly satisfied
+        ImmutableList<Action<?>> actions = perPhase.actions;
+        int size = actions.size();
+        for (int i = 0; i < size; i ++) {
+            Action<?> action = actions.get(i);
+            if (action.isNewlySatisfiedBy(oldFacts, newFacts)) {
+                long oldVal;
+                long newVal;
+                for (;;) {
+                    oldVal = (long) longArrayHandle.getVolatile(array, 1);
+                    newVal = oldVal | 1L << i;
+                    if (oldVal == newVal) {
+                        break;
+                    }
+                    if (longArrayHandle.compareAndSet(array, 1, oldVal, newVal)) {
+                        ctxt.submitTask(item, action);
+                        break;
+                    }
+                }
+            }
+        }
+        return newFacts & ~oldFacts;
+    }
+
+    public <E> void discover(E item, Fact<? super E> fact) {
+        // type check
+        fact.getElementType().cast(item);
+        if (discover(item, 1L << getFactIndex(fact)) != 0) {
+            longArrayHandle.getAndAdd(getPerPhase().counts.computeIfAbsent(fact, Facts::newArray), 0, 1L);
+        }
+    }
+
+    public <E> void discover(E item, Fact<? super E> fact1, Fact<? super E> fact2) {
+        // type check
+        fact1.getElementType().cast(item);
+        fact2.getElementType().cast(item);
+        long bit1 = 1L << getFactIndex(fact1);
+        long bit2 = 1L << getFactIndex(fact2);
+        long newly = discover(item, bit1 | bit2);
+        PerPhase perPhase = getPerPhase();
+        if ((newly & bit1) != 0) {
+            longArrayHandle.getAndAdd(perPhase.counts.computeIfAbsent(fact1, Facts::newArray), 0, 1L);
+        }
+        if ((newly & bit2) != 0) {
+            longArrayHandle.getAndAdd(perPhase.counts.computeIfAbsent(fact2, Facts::newArray), 0, 1L);
+        }
+    }
+
+    public <E> void discover(E item, Fact<? super E> fact1, Fact<? super E> fact2, Fact<? super E> fact3) {
+        // type check
+        fact1.getElementType().cast(item);
+        fact2.getElementType().cast(item);
+        fact3.getElementType().cast(item);
+        long bit1 = 1L << getFactIndex(fact1);
+        long bit2 = 1L << getFactIndex(fact2);
+        long bit3 = 1L << getFactIndex(fact3);
+        long newly = discover(item, bit1 | bit2 | bit3);
+        PerPhase perPhase = getPerPhase();
+        if ((newly & bit1) != 0) {
+            longArrayHandle.getAndAdd(perPhase.counts.computeIfAbsent(fact1, Facts::newArray), 0, 1L);
+        }
+        if ((newly & bit2) != 0) {
+            longArrayHandle.getAndAdd(perPhase.counts.computeIfAbsent(fact2, Facts::newArray), 0, 1L);
+        }
+        if ((newly & bit3) != 0) {
+            longArrayHandle.getAndAdd(perPhase.counts.computeIfAbsent(fact3, Facts::newArray), 0, 1L);
+        }
+    }
+
+    public long getDiscoveredCount(Fact<?> fact) {
+        long[] array = getPerPhase().counts.get(fact);
+        return array == null ? 0 : (long) longArrayHandle.getVolatile(array, 0);
+    }
+
+    public <E> boolean isDiscovered(final E item, final Fact<? super E> fact) {
+        long[] array = getPerPhase().facts.get(item);
+        long factBits = 1L << getFactIndex(fact);
+        return array != null && fact.getElementType().isInstance(item) && (array[0] & factBits) == factBits;
+    }
+
+    private <E> boolean hadAllFactBits(E item, long factBits) {
+        PerPhase previous = getPreviousPerPhase();
+        if (previous == null) {
+            return false;
+        }
+        long[] array = previous.facts.get(item);
+        return array != null && (array[0] & factBits) == factBits;
+    }
+
+    private <E> boolean hadAnyFactBits(E item, long factBits) {
+        PerPhase previous = getPreviousPerPhase();
+        if (previous == null) {
+            return false;
+        }
+        long[] array = previous.facts.get(item);
+        return array != null && (array[0] & factBits) != 0;
+    }
+
+    public <E> boolean hadFact(E item, Fact<? super E> fact) {
+        return fact.getElementType().isInstance(item) && hadAllFactBits(item, 1L << getFactIndex(fact));
+    }
+
+    public <E> boolean hadAllFacts(E item, Fact<? super E> fact1, Fact<? super E> fact2) {
+        return fact1.getElementType().isInstance(item) && fact2.getElementType().isInstance(item) && hadAllFactBits(item, 1L << getFactIndex(fact1) | 1L << getFactIndex(fact2));
+    }
+
+    public <E> boolean hadAllFacts(E item, Fact<? super E> fact1, Fact<? super E> fact2, Fact<? super E> fact3) {
+        return fact1.getElementType().isInstance(item) && fact2.getElementType().isInstance(item) && fact3.getElementType().isInstance(item) && hadAllFactBits(item, 1L << getFactIndex(fact1) | 1L << getFactIndex(fact2) | 1L << getFactIndex(fact3));
+    }
+
+    public <E> boolean hadAnyFacts(E item, Fact<? super E> fact1, Fact<? super E> fact2) {
+        return fact1.getElementType().isInstance(item) && fact2.getElementType().isInstance(item) && hadAnyFactBits(item, 1L << getFactIndex(fact1) | 1L << getFactIndex(fact2));
+    }
+
+    public <E> boolean hadAnyFacts(E item, Fact<? super E> fact1, Fact<? super E> fact2, Fact<? super E> fact3) {
+        return fact1.getElementType().isInstance(item) && fact2.getElementType().isInstance(item) && fact3.getElementType().isInstance(item) && hadAnyFactBits(item, 1L << getFactIndex(fact1) | 1L << getFactIndex(fact2) | 1L << getFactIndex(fact3));
+    }
+
+    public <E> void registerAction(Condition<? extends Fact<? super E>> condition, BiConsumer<E, Facts> action) {
+        condition.getRegisterFunction((facts, bits) -> facts.registerAction(bits, action)).accept(this, 0);
+    }
+
+    public <E> void registerAction(Condition<? extends Fact<? super E>> condition, Consumer<E> action) {
+        registerAction(condition, (e, f) -> action.accept(e));
+    }
+
+    public CompilationContext getCompilationContext() {
+        return ctxt;
+    }
+
+    public boolean hasPreviousFacts() {
+        return ctxt.getPreviousPhaseAttachment(PER_PHASE_KEY) != null;
+    }
+
+    final class Action<K> implements Consumer<Object> {
+        private final long requiredBits;
+        private final BiConsumer<K, Facts> consumer;
+
+        Action(long requiredBits, BiConsumer<K, Facts> consumer) {
+            this.requiredBits = requiredBits;
+            this.consumer = consumer;
+        }
+
+        boolean isNewlySatisfiedBy(long oldBits, long newBits) {
+            long requiredBits = this.requiredBits;
+            return (oldBits & requiredBits) != requiredBits && (newBits & requiredBits) == requiredBits;
+        }
+
+        @SuppressWarnings("unchecked")
+        public void accept(final Object item) {
+            consumer.accept((K) item, Facts.this);
+        }
+    }
+}

--- a/compiler/src/main/java/org/qbicc/facts/core/ExecutableReachabilityFacts.java
+++ b/compiler/src/main/java/org/qbicc/facts/core/ExecutableReachabilityFacts.java
@@ -1,0 +1,20 @@
+package org.qbicc.facts.core;
+
+import org.qbicc.facts.Fact;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * The core set of facts which apply to any executable element.
+ */
+public enum ExecutableReachabilityFacts implements Fact<ExecutableElement> {
+    /**
+     * This element is definitely directly invoked.
+     */
+    IS_INVOKED,
+    ;
+
+    @Override
+    public Class<ExecutableElement> getElementType() {
+        return ExecutableElement.class;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
@@ -1,5 +1,6 @@
 package org.qbicc.type.definition;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -13,6 +14,7 @@ import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
 import org.qbicc.type.descriptor.MethodDescriptor;
@@ -457,8 +459,47 @@ public interface LoadedTypeDefinition extends DefinedTypeDefinition {
         }
     }
 
+    default void forEachSigPolyInstanceMethod(Consumer<? super InstanceMethodElement> consumer) {
+        forEachSigPolyInstanceMethod(consumer, Consumer::accept);
+    }
 
-    void forEachSigPolyMethod(Consumer<MethodElement> consumer);
+    default void forEachSigPolyMethod(Consumer<? super MethodElement> consumer) {
+        forEachSigPolyMethod(consumer, Consumer::accept);
+    }
+
+    <T> void forEachSigPolyInstanceMethod(T argument, BiConsumer<T, ? super InstanceMethodElement> consumer);
+
+    <T> void forEachSigPolyMethod(T argument, BiConsumer<T, ? super MethodElement> consumer);
+
+    default void forEachMethod(Consumer<? super MethodElement> consumer) {
+        int mc = getMethodCount();
+        for (int i = 0; i < mc; i ++) {
+            consumer.accept(getMethod(i));
+        }
+        forEachSigPolyMethod(consumer);
+    }
+
+    default void forEachNonStaticMethod(Consumer<? super InstanceMethodElement> consumer) {
+        int mc = getMethodCount();
+        for (int i = 0; i < mc; i ++) {
+            MethodElement method = getMethod(i);
+            if (! method.isStatic()) {
+                consumer.accept((InstanceMethodElement) method);
+            }
+        }
+        forEachSigPolyInstanceMethod(consumer);
+    }
+
+    default <T> void forEachNonStaticMethod(T argument, BiConsumer<T, ? super InstanceMethodElement> consumer) {
+        int mc = getMethodCount();
+        for (int i = 0; i < mc; i ++) {
+            MethodElement method = getMethod(i);
+            if (! method.isStatic()) {
+                consumer.accept(argument, (InstanceMethodElement) method);
+            }
+        }
+        forEachSigPolyInstanceMethod(argument, consumer);
+    }
 
     ConstructorElement getConstructor(int index);
 

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import io.smallrye.common.constraint.Assert;
@@ -23,6 +24,7 @@ import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
 import org.qbicc.type.definition.element.ParameterElement;
@@ -272,12 +274,26 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
     }
 
     @Override
-    public void forEachSigPolyMethod(Consumer<MethodElement> consumer) {
+    public <T> void forEachSigPolyInstanceMethod(T arg, BiConsumer<T, ? super InstanceMethodElement> consumer) {
         Map<MethodElement, Map<MethodDescriptor, MethodElement>> sigPolyMethods = this.sigPolyMethods;
         if (sigPolyMethods != null) {
             for (Map<MethodDescriptor, MethodElement> subMap : sigPolyMethods.values()) {
                 for (MethodElement element : subMap.values()) {
-                    consumer.accept(element);
+                    if (element instanceof InstanceMethodElement ime) {
+                        consumer.accept(arg, ime);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public <T> void forEachSigPolyMethod(T arg, BiConsumer<T, ? super MethodElement> consumer) {
+        Map<MethodElement, Map<MethodDescriptor, MethodElement>> sigPolyMethods = this.sigPolyMethods;
+        if (sigPolyMethods != null) {
+            for (Map<MethodDescriptor, MethodElement> subMap : sigPolyMethods.values()) {
+                for (MethodElement element : subMap.values()) {
+                    consumer.accept(arg, element);
                 }
             }
         }

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -71,6 +71,9 @@ public class TestClassContext implements ClassContext {
             return null;
         }
 
+        public <T> void submitTask(T item, Consumer<T> itemConsumer) {
+        }
+
         public ClassContext getBootstrapClassContext() {
             return null;
         }
@@ -96,10 +99,6 @@ public class TestClassContext implements ClassContext {
         }
 
         public NativeMethodConfigurator getNativeMethodConfigurator() {
-            return null;
-        }
-
-        public ExecutableElement dequeue() {
             return null;
         }
 

--- a/driver/src/main/java/org/qbicc/driver/Phase.java
+++ b/driver/src/main/java/org/qbicc/driver/Phase.java
@@ -67,6 +67,7 @@ public enum Phase {
         complete(ctxt);
         ctxt.putAttachment(KEY, this);
         MDC.put("phase", name());
+        ctxt.runParallelTask(context -> MDC.put("phase", name()));
         log.info("Entering phase");
     }
 

--- a/main/src/main/java/org/qbicc/main/ElementReachableAdapter.java
+++ b/main/src/main/java/org/qbicc/main/ElementReachableAdapter.java
@@ -1,0 +1,25 @@
+package org.qbicc.main;
+
+import java.util.function.Consumer;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.facts.Condition;
+import org.qbicc.facts.Facts;
+import org.qbicc.facts.core.ExecutableReachabilityFacts;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ *
+ */
+final class ElementReachableAdapter implements Consumer<CompilationContext> {
+    private final Consumer<ExecutableElement> handler;
+
+    ElementReachableAdapter(final Consumer<ExecutableElement> handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public void accept(CompilationContext context) {
+        Facts.get(context).registerAction(Condition.when(ExecutableReachabilityFacts.IS_INVOKED), handler);
+    }
+}

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/FieldReachabilityFacts.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/FieldReachabilityFacts.java
@@ -1,0 +1,24 @@
+package org.qbicc.plugin.reachability;
+
+import org.qbicc.facts.Fact;
+import org.qbicc.type.definition.element.FieldElement;
+
+/**
+ * The core set of field facts.
+ */
+public enum FieldReachabilityFacts implements Fact<FieldElement> {
+    /**
+     * The field is touched by a read operation in reachable code.
+     */
+    IS_READ,
+    /**
+     * The field is touched by a write operation in reachable code.
+     */
+    IS_WRITTEN,
+    ;
+
+    @Override
+    public Class<FieldElement> getElementType() {
+        return FieldElement.class;
+    }
+}

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/InstanceMethodReachabilityFacts.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/InstanceMethodReachabilityFacts.java
@@ -1,0 +1,38 @@
+package org.qbicc.plugin.reachability;
+
+import org.qbicc.facts.Fact;
+import org.qbicc.type.definition.element.InstanceMethodElement;
+
+/**
+ * The core set of facts which apply to instance methods.
+ */
+public enum InstanceMethodReachabilityFacts implements Fact<InstanceMethodElement> {
+    /**
+     * The exact enclosing type is present on the heap.
+     */
+    EXACT_RECEIVER_IS_ON_HEAP,
+    /**
+     * At least one object is on the heap which would select this method.
+     */
+    DISPATCH_RECEIVER_IS_ON_HEAP,
+    /**
+     * This method might be directly invoked upon by reachable code, dependent upon {@link #EXACT_RECEIVER_IS_ON_HEAP}.
+     * Only applies to instance methods.
+     */
+    IS_PROVISIONALLY_INVOKED,
+    /**
+     * This method is dispatch invoked upon (virtual or interface), dependent upon {@link #DISPATCH_RECEIVER_IS_ON_HEAP}.
+     * Only applies to instance methods.
+     */
+    IS_PROVISIONALLY_DISPATCH_INVOKED,
+    /**
+     * This method is dispatch invoked upon (virtual or interface). Only applies to non-static methods.
+     */
+    IS_DISPATCH_INVOKED,
+    ;
+
+    @Override
+    public Class<InstanceMethodElement> getElementType() {
+        return InstanceMethodElement.class;
+    }
+}

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ObjectReachabilityFacts.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ObjectReachabilityFacts.java
@@ -1,0 +1,21 @@
+package org.qbicc.plugin.reachability;
+
+import org.qbicc.facts.Fact;
+import org.qbicc.interpreter.VmObject;
+
+/**
+ * The core set of heap object facts.
+ */
+public enum ObjectReachabilityFacts implements Fact<VmObject> {
+    /**
+     * The heap object is reachable from an object literal, a static field value, or a reference from another reachable
+     * heap object.
+     */
+    IS_REACHABLE,
+    ;
+
+    @Override
+    public Class<VmObject> getElementType() {
+        return VmObject.class;
+    }
+}

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
@@ -5,7 +5,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.qbicc.context.CompilationContext;
-import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.facts.Facts;
+import org.qbicc.facts.core.ExecutableReachabilityFacts;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.InterfaceObjectType;
@@ -14,9 +15,11 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.InitializerElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
 import org.qbicc.type.definition.element.InvokableElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.StaticFieldElement;
+import org.qbicc.type.definition.element.StaticMethodElement;
 
 /**
  * An implementation of Rapid Type Analysis (RTA).
@@ -88,6 +91,13 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
     }
 
     public synchronized void processReachableExactInvocation(final InvokableElement target, ExecutableElement currentElement) {
+        if (target instanceof StaticMethodElement me) {
+            Facts.get(ctxt).discover(me, ExecutableReachabilityFacts.IS_INVOKED);
+        } else if (target instanceof InstanceMethodElement me) {
+            Facts.get(ctxt).discover(me, InstanceMethodReachabilityFacts.IS_PROVISIONALLY_INVOKED);
+        } else if (target instanceof ConstructorElement ce) {
+            Facts.get(ctxt).discover(ce, ExecutableReachabilityFacts.IS_INVOKED);
+        }
         if (!ctxt.wasEnqueued(target)) {
             processReachableType(target.getEnclosingType().load(), currentElement);
 
@@ -139,8 +149,10 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
 
         if (onHeapType) {
             ReachabilityInfo.LOGGER.debugf("Adding class %s (heap reachable from %s)", type.getDescriptor(), currentElement);
+            Facts.get(ctxt).discover(type, TypeReachabilityFacts.IS_ON_HEAP);
         } else {
             ReachabilityInfo.LOGGER.debugf("Adding class %s (instantiated in %s)", type.getDescriptor(), currentElement);
+            Facts.get(ctxt).discover(type, TypeReachabilityFacts.IS_INSTANTIATED, TypeReachabilityFacts.IS_ON_HEAP);
         }
 
         info.addReachableClass(type);

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityFactsSetup.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityFactsSetup.java
@@ -1,0 +1,118 @@
+package org.qbicc.plugin.reachability;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.facts.Condition;
+import org.qbicc.facts.Facts;
+import org.qbicc.facts.core.ExecutableReachabilityFacts;
+import org.qbicc.graph.atomic.AccessModes;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.type.PhysicalObjectType;
+import org.qbicc.type.ReferenceType;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.ConstructorElement;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.InstanceFieldElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
+
+/**
+ * Core facts utility class.
+ */
+public final class ReachabilityFactsSetup {
+    private ReachabilityFactsSetup() {}
+
+    public static void setupAdd(CompilationContext ctxt) {
+        Facts facts = Facts.get(ctxt);
+        setupReachability(facts);
+    }
+
+    public static void setupAnalyze(CompilationContext ctxt) {
+        Facts facts = Facts.get(ctxt);
+        setupReachability(facts);
+        setupValidate(facts);
+    }
+
+    public static void setupLower(CompilationContext ctxt) {
+        Facts facts = Facts.get(ctxt);
+        setupReachability(facts);
+        setupValidate(facts);
+    }
+
+    public static void setupGenerate(CompilationContext ctxt) {
+        Facts facts = Facts.get(ctxt);
+        setupReachability(facts);
+        setupValidate(facts);
+    }
+
+    private static void setupReachability(final Facts facts) {
+        facts.registerAction(Condition.when(TypeReachabilityFacts.IS_INSTANTIATED), ReachabilityFactsSetup::markEachMethodAsInstantiated);
+        facts.registerAction(Condition.when(InstanceMethodReachabilityFacts.IS_PROVISIONALLY_INVOKED), ReachabilityFactsSetup::markEnclosingTypeAsProvisionallyInvoked);
+        facts.registerAction(Condition.when(InstanceMethodReachabilityFacts.IS_PROVISIONALLY_DISPATCH_INVOKED), ReachabilityFactsSetup::markEnclosingTypeAsProvisionallyDispatched);
+        facts.registerAction(Condition.whenAll(InstanceMethodReachabilityFacts.EXACT_RECEIVER_IS_ON_HEAP, InstanceMethodReachabilityFacts.IS_PROVISIONALLY_INVOKED), ReachabilityFactsSetup::markAsInvoked);
+        facts.registerAction(Condition.whenAll(InstanceMethodReachabilityFacts.DISPATCH_RECEIVER_IS_ON_HEAP, InstanceMethodReachabilityFacts.IS_PROVISIONALLY_DISPATCH_INVOKED), ReachabilityFactsSetup::markAsDispatchInvoked);
+        facts.registerAction(Condition.when(ObjectReachabilityFacts.IS_REACHABLE), ReachabilityFactsSetup::markObjectTypeDefAsOnHeap);
+        facts.registerAction(Condition.when(ExecutableReachabilityFacts.IS_INVOKED), ReachabilityFactsSetup::markEnclosingAsInstantiatedIfCtor);
+        // TODO: generate DISPATCH_RECEIVER_IS_ON_HEAP
+        facts.registerAction(Condition.when(TypeReachabilityFacts.HAS_CLASS), (ltd, f) -> ReachabilityInfo.get(f.getCompilationContext()).getAnalysis().processReachableType(ltd, null));
+    }
+
+    private static void setupValidate(final Facts facts) {
+        facts.registerAction(Condition.when(ExecutableReachabilityFacts.IS_INVOKED), ReachabilityFactsSetup::validateWasInvoked);
+    }
+
+    // actions
+
+    private static void validateWasInvoked(ExecutableElement me, Facts facts) {
+        if (!facts.hadFact(me, ExecutableReachabilityFacts.IS_INVOKED)) {
+            facts.getCompilationContext().error(me, "Element cannot become reachable after being unreachable in the previous phase");
+        }
+    }
+
+    private static void markEachMethodAsInstantiated(LoadedTypeDefinition ltd, Facts facts) {
+        ltd.forEachNonStaticMethod(facts, ReachabilityFactsSetup::markMethodWithOnHeapReceiver);
+    }
+
+    private static void markMethodWithOnHeapReceiver(Facts facts, InstanceMethodElement me) {
+        facts.discover(me, InstanceMethodReachabilityFacts.EXACT_RECEIVER_IS_ON_HEAP);
+    }
+
+    private static void markEnclosingTypeAsProvisionallyInvoked(InstanceMethodElement me, Facts facts) {
+        facts.discover(me.getEnclosingType().load(), TypeReachabilityFacts.ELEMENT_IS_PROVISIONALLY_INVOKED);
+    }
+
+    private static void markEnclosingTypeAsProvisionallyDispatched(InstanceMethodElement me, Facts facts) {
+        facts.discover(me.getEnclosingType().load(), TypeReachabilityFacts.ELEMENT_IS_PROVISIONALLY_DISPATCH_INVOKED);
+    }
+
+    private static void markAsInvoked(InstanceMethodElement me, Facts facts) {
+        facts.discover(me, ExecutableReachabilityFacts.IS_INVOKED);
+    }
+
+    private static void markAsDispatchInvoked(InstanceMethodElement me, Facts facts) {
+        facts.discover(me, InstanceMethodReachabilityFacts.IS_DISPATCH_INVOKED);
+    }
+
+    private static void markEnclosingAsInstantiatedIfCtor(final ExecutableElement e, final Facts facts) {
+        if (e instanceof ConstructorElement ce) {
+            LoadedTypeDefinition type = ce.getEnclosingType().load();
+            CompilationContext ctxt = type.getContext().getCompilationContext();
+            Facts facts1 = Facts.get(ctxt);
+            facts1.discover(type, TypeReachabilityFacts.IS_INSTANTIATED);
+        }
+    }
+
+    private static void markObjectTypeDefAsOnHeap(VmObject obj, Facts facts) {
+        facts.discover(obj.getVmClass().getTypeDefinition(), TypeReachabilityFacts.IS_ON_HEAP);
+        // iterate fields of object to recursively mark them reachable
+        PhysicalObjectType objectType = obj.getObjectType();
+        LoadedTypeDefinition def = objectType.getDefinition().load();
+        int fc = def.getFieldCount();
+        for (int i = 0; i < fc; i++) {
+            if (def.getField(i) instanceof InstanceFieldElement fe && fe.getType() instanceof ReferenceType) {
+                VmObject nested = obj.getMemory().loadRef(fe.getOffset(), AccessModes.SinglePlain);
+                if (nested != null) {
+                    facts.discover(nested, ObjectReachabilityFacts.IS_REACHABLE);
+                }
+            }
+        }
+    }
+}

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
@@ -15,8 +15,10 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.descriptor.MethodDescriptor;
+import org.qbicc.type.definition.element.StaticMethodElement;
 
 /**
  * ReachabilityInfo records the types and methods that have been determined to be reachable
@@ -161,13 +163,11 @@ public class ReachabilityInfo {
     }
 
     public void processRootReachableElement(ExecutableElement elem) {
-        if (elem instanceof MethodElement me) {
-            if (me.isStatic()) {
-                analysis.processReachableType(me.getEnclosingType().load(), null);
-                analysis.processReachableExactInvocation(me, null);
-            } else {
-                analysis.processReachableDispatchedInvocation(me, null);
-            }
+        if (elem instanceof StaticMethodElement me) {
+            analysis.processReachableType(me.getEnclosingType().load(), null);
+            analysis.processReachableExactInvocation(me, null);
+        } else if (elem instanceof InstanceMethodElement me) {
+            analysis.processReachableDispatchedInvocation(me, null);
         } else if (elem instanceof ConstructorElement ce) {
             analysis.processInstantiatedClass(ce.getEnclosingType().load(), false, null);
             analysis.processReachableExactInvocation(ce, null);

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/TypeReachabilityFacts.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/TypeReachabilityFacts.java
@@ -1,0 +1,40 @@
+package org.qbicc.plugin.reachability;
+
+import org.qbicc.facts.Fact;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+
+/**
+ * The core set of type facts.
+ */
+public enum TypeReachabilityFacts implements Fact<LoadedTypeDefinition> {
+    /**
+     * The class corresponding to the type is reachable in some way, requiring a `Class` instance to be emitted.
+     */
+    HAS_CLASS,
+    /**
+     * The class is found on the heap, either via instantiation or via the reachable initial heap.
+     */
+    IS_ON_HEAP,
+    /**
+     * The class is explicitly instantiated by reachable code.
+     */
+    IS_INSTANTIATED,
+    /**
+     * One or more methods of this class are provisionally directly invoked.
+     */
+    ELEMENT_IS_PROVISIONALLY_INVOKED,
+    /**
+     * One or more methods of this class are provisionally dispatch invoked.
+     */
+    ELEMENT_IS_PROVISIONALLY_DISPATCH_INVOKED,
+    /**
+     * A subtype of this type {@linkplain #HAS_CLASS has a present class}.
+     */
+    SUBTYPE_HAS_CLASS,
+    ;
+
+    @Override
+    public Class<LoadedTypeDefinition> getElementType() {
+        return LoadedTypeDefinition.class;
+    }
+}


### PR DESCRIPTION
This is the ~~first~~ ~~second~~ final cut at tracking global field reachability.

* Tracks reads and writes of fields independently
* **New:** Introduce and use a prototype facts API as per #1109 
* New field reachability info for every phase, with the previous phase result available, by way of facts API
* ~~A first pass at deleting accesses of dead fields~~ Dead field removal omitted; this belongs in an optimization BBB after we've accounted for such things as on-heap objects, constant values, and fields whose usages are introduced in later phases
* Demonstration of how per-phase attachments are meant to be used, by way of facts API
