### PR TITLE
Use conversion methods for floating point to integer conversions

### DIFF
--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMIntrinsics.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMIntrinsics.java
@@ -21,6 +21,7 @@ import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.interpreter.VmString;
+import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.plugin.intrinsics.Intrinsics;
 import org.qbicc.plugin.intrinsics.StaticIntrinsic;
 import org.qbicc.type.FunctionType;
@@ -154,6 +155,55 @@ public final class LLVMIntrinsics {
         };
 
         intrinsics.registerIntrinsic(stdArgDesc, "va_arg", vaListClassToThing, saVaArg);
+
+        // Floating-point conversion intrinsics implemented by LLVM
+
+        ClassTypeDescriptor cNativeDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/CNative");
+
+        MethodDescriptor floatToInt = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of(BaseTypeDescriptor.F));
+        MethodDescriptor floatToLong = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.J, List.of(BaseTypeDescriptor.F));
+        MethodDescriptor doubleToInt = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of(BaseTypeDescriptor.D));
+        MethodDescriptor doubleToLong = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.J, List.of(BaseTypeDescriptor.D));
+
+        StaticIntrinsic floatToInt1 = (builder, target, arguments) -> {
+            TypeSystem ts = ctxt.getTypeSystem();
+            LiteralFactory lf = ctxt.getLiteralFactory();
+            FunctionType fnType = ts.getFunctionType(ts.getSignedInteger32Type(), ts.getFloat32Type());
+            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i32.f32", fnType);
+            return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
+        };
+
+        intrinsics.registerIntrinsic(cNativeDesc, "floatToInt1", floatToInt, floatToInt1);
+
+        StaticIntrinsic floatToLong1 = (builder, target, arguments) -> {
+            TypeSystem ts = ctxt.getTypeSystem();
+            LiteralFactory lf = ctxt.getLiteralFactory();
+            FunctionType fnType = ts.getFunctionType(ts.getSignedInteger64Type(), ts.getFloat32Type());
+            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i64.f32", fnType);
+            return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
+        };
+
+        intrinsics.registerIntrinsic(cNativeDesc, "floatToLong1", floatToLong, floatToLong1);
+
+        StaticIntrinsic doubleToInt1 = (builder, target, arguments) -> {
+            TypeSystem ts = ctxt.getTypeSystem();
+            LiteralFactory lf = ctxt.getLiteralFactory();
+            FunctionType fnType = ts.getFunctionType(ts.getSignedInteger32Type(), ts.getFloat64Type());
+            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i32.f64", fnType);
+            return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
+        };
+
+        intrinsics.registerIntrinsic(cNativeDesc, "doubleToInt1", doubleToInt, doubleToInt1);
+
+        StaticIntrinsic doubleToLong1 = (builder, target, arguments) -> {
+            TypeSystem ts = ctxt.getTypeSystem();
+            LiteralFactory lf = ctxt.getLiteralFactory();
+            FunctionType fnType = ts.getFunctionType(ts.getSignedInteger64Type(), ts.getFloat64Type());
+            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i64.f64", fnType);
+            return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
+        };
+
+        intrinsics.registerIntrinsic(cNativeDesc, "doubleToLong1", doubleToLong, doubleToLong1);
     }
 
     // flag values must match the LLVM runtime API class.

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -467,6 +467,74 @@ public final class CNative {
      */
     public static native <T, P extends ptr<T>> P refToPtr(T ref);
 
+    // intrinsic
+    @NoSideEffects
+    private static native int floatToInt1(float fv);
+
+    /**
+     * Method which implements conversions from {@code float} to {@code int} type.  This method implements
+     * the clamping semantics required for correct behavior.
+     *
+     * @param fv the {@code float} value
+     * @return the clamped {@code int} value
+     */
+    @NoSideEffects
+    @AutoQueued
+    public static int floatToInt(float fv) {
+        return floatToInt1(fv);
+    }
+
+    // intrinsic
+    @NoSideEffects
+    private static native long floatToLong1(float fv);
+
+    /**
+     * Method which implements conversions from {@code float} to {@code long} type.  This method implements
+     * the clamping semantics required for correct behavior.
+     *
+     * @param fv the {@code float} value
+     * @return the clamped {@code long} value
+     */
+    @NoSideEffects
+    @AutoQueued
+    public static long floatToLong(float fv) {
+        return floatToLong1(fv);
+    }
+
+    // intrinsic
+    @NoSideEffects
+    private static native int doubleToInt1(double dv);
+
+    /**
+     * Method which implements conversions from {@code double} to {@code int} type.  This method implements
+     * the clamping semantics required for correct behavior.
+     *
+     * @param dv the {@code double} value
+     * @return the clamped {@code int} value
+     */
+    @NoSideEffects
+    @AutoQueued
+    public static int doubleToInt(double dv) {
+        return doubleToInt1(dv);
+    }
+
+    // intrinsic
+    @NoSideEffects
+    private static native long doubleToLong1(double dv);
+
+    /**
+     * Method which implements conversions from {@code double} to {@code long} type.  This method implements
+     * the clamping semantics required for correct behavior.
+     *
+     * @param dv the {@code double} value
+     * @return the clamped {@code long} value
+     */
+    @NoSideEffects
+    @AutoQueued
+    public static long doubleToLong(double dv) {
+        return doubleToLong1(dv);
+    }
+
     // built-in
 
     /**


### PR DESCRIPTION
This allows `NumericalConversionBasicBlockBuilder` to be repeatable per #951.