### PR TITLE
Convenience methods to get unsigned byte, short, and int values

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -410,6 +410,19 @@ final class CNativeIntrinsics {
         intrinsics.registerIntrinsic(wordDesc, "longValue", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.J, List.of()), xxxValue);
         intrinsics.registerIntrinsic(wordDesc, "shortValue", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.S, List.of()), xxxValue);
 
+        intrinsics.registerIntrinsic(wordDesc, "ubyteValue", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of()), (builder, instance, target, arguments) -> {
+            WordType to = (WordType) target.getExecutable().getType().getReturnType();
+            return builder.extend(smartConvert(builder, instance, ctxt.getTypeSystem().getUnsignedInteger8Type(), true), to);
+        });
+        intrinsics.registerIntrinsic(wordDesc, "ushortValue", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of()), (builder, instance, target, arguments) -> {
+            WordType to = (WordType) target.getExecutable().getType().getReturnType();
+            return builder.extend(smartConvert(builder, instance, ctxt.getTypeSystem().getUnsignedInteger16Type(), true), to);
+        });
+        intrinsics.registerIntrinsic(wordDesc, "uintValue", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.J, List.of()), (builder, instance, target, arguments) -> {
+            WordType to = (WordType) target.getExecutable().getType().getReturnType();
+            return builder.extend(smartConvert(builder, instance, ctxt.getTypeSystem().getUnsignedInteger32Type(), true), to);
+        });
+
         InstanceIntrinsic isZero = (builder, instance, target, arguments) -> builder.isEq(instance, ctxt.getLiteralFactory().zeroInitializerLiteralOfType(instance.getType()));
 
         intrinsics.registerIntrinsic(wordDesc, "isZero", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of()), isZero);

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -599,13 +599,19 @@ public final class CNative {
 
         public native final int intValue();
 
+        public native final long uintValue();
+
         public final float floatValue() {
             return Float.intBitsToFloat(intValue());
         }
 
         public native final short shortValue();
 
+        public native final int ushortValue();
+
         public native final byte byteValue();
+
+        public native final int ubyteValue();
 
         public native final char charValue();
 


### PR DESCRIPTION
Instead of having to do `value.byteValue() & 0xff` you can do `value.ubyteValue()` for example.