### PR TITLE
Add ability to emit source files for debugging

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/Vm.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Vm.java
@@ -387,4 +387,18 @@ public interface Vm {
      * @return the memory (not {@code null})
      */
     Memory getGlobal(GlobalVariableElement variableElement);
+
+    /**
+     * Get the application class loader, if it can be found.
+     *
+     * @return the application class loader or {@code null} if it cannot be found
+     */
+    VmClassLoader getAppClassLoader();
+
+    /**
+     * Get the platform class loader, if it can be found.
+     *
+     * @return the platform class loader or {@code null} if it cannot be found
+     */
+    VmClassLoader getPlatformClassLoader();
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -1136,6 +1136,27 @@ public final class VmImpl implements Vm {
         return startedThreads.toArray(VmThread[]::new);
     }
 
+    public VmClassLoader getAppClassLoader() {
+        try {
+            LoadedTypeDefinition clDef = ctxt.getBootstrapClassContext().findDefinedType("jdk/internal/loader/ClassLoaders").load();
+            VmClass classLoadersClass = clDef.getVmClass();
+            return (VmClassLoader) classLoadersClass.getStaticMemory().loadRef(classLoadersClass.indexOfStatic(clDef.findField("APP_LOADER")), SinglePlain);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    @Override
+    public VmClassLoader getPlatformClassLoader() {
+        try {
+            LoadedTypeDefinition clDef = ctxt.getBootstrapClassContext().findDefinedType("jdk/internal/loader/ClassLoaders").load();
+            VmClass classLoadersClass = clDef.getVmClass();
+            return (VmClassLoader) classLoadersClass.getStaticMemory().loadRef(classLoadersClass.indexOfStatic(clDef.findField("PLATFORM_LOADER")), SinglePlain);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
     @Override
     public VmClass getClassForDescriptor(VmClassLoader cl, TypeDescriptor descriptor) {
         if (cl == null) {

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -186,6 +186,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-source</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-thread-local</artifactId>
         </dependency>
         <dependency>

--- a/main/src/main/java/org/qbicc/main/DefaultArtifactRequestor.java
+++ b/main/src/main/java/org/qbicc/main/DefaultArtifactRequestor.java
@@ -147,7 +147,7 @@ public final class DefaultArtifactRequestor {
             }
             File jarFile = resultArtifact.getFile();
             File sourceFile = null;
-            ArtifactRequest sourceRequest = new ArtifactRequest(new DefaultArtifact(resultArtifact.getGroupId(), resultArtifact.getArtifactId(), "source", "jar", resultArtifact.getVersion()), null, null);
+            ArtifactRequest sourceRequest = new ArtifactRequest(new DefaultArtifact(resultArtifact.getGroupId(), resultArtifact.getArtifactId(), "sources", "jar", resultArtifact.getVersion()), null, null);
             try {
                 ArtifactResult sourceResult = system.resolveArtifact(session, sourceRequest);
                 if (sourceResult != null && sourceResult.isResolved() && !sourceResult.isMissing()) {

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -44,6 +44,7 @@
         <module>patcher</module>
         <module>reachability</module>
         <module>reflection</module>
+        <module>source</module>
         <module>thread-local</module>
         <module>try-catch</module>
         <module>verification</module>

--- a/plugins/source/pom.xml
+++ b/plugins/source/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.qbicc</groupId>
+        <artifactId>qbicc-plugin-parent</artifactId>
+        <version>0.58.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>qbicc-plugin-source</artifactId>
+
+    <name>Qbicc Plugin: Source output</name>
+    <description>Support for outputting reachable source code for debuggers</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-driver</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/plugins/source/src/main/java/org/qbicc/plugin/source/SourceEmittingElementHandler.java
+++ b/plugins/source/src/main/java/org/qbicc/plugin/source/SourceEmittingElementHandler.java
@@ -1,0 +1,78 @@
+package org.qbicc.plugin.source;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.driver.ClassPathElement;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
+
+/**
+ * A listener which copies source files all reachable program elements for use by the debugger.
+ */
+public final class SourceEmittingElementHandler implements Consumer<ExecutableElement> {
+    private final Path outputPath;
+    private final Map<ClassContext, List<ClassPathElement>> sourcePaths;
+    private final Map<ClassContext, Map<String, Set<String>>> visited = new ConcurrentHashMap<>();
+
+    /**
+     * Construct a new instance.
+     *
+     * @param outputPath the base directory for source output (must not be {@code null})
+     * @param sourcePaths the mapping of class path elements (must not be {@code null})
+     */
+    public SourceEmittingElementHandler(Path outputPath, Map<ClassContext, List<ClassPathElement>> sourcePaths) {
+        this.outputPath = outputPath;
+        this.sourcePaths = sourcePaths;
+    }
+
+    @Override
+    public void accept(ExecutableElement executableElement) {
+        LoadedTypeDefinition loaded = executableElement.getEnclosingType().load();
+        ClassContext classContext = loaded.getContext();
+        Map<String, Set<String>> visitedByPackage = visited.computeIfAbsent(classContext, SourceEmittingElementHandler::newConcurrentMap);
+        String packageName = loaded.getDescriptor() instanceof ClassTypeDescriptor ctd? ctd.getPackageName() : "";
+        Set<String> visitedBySourceFileName = visitedByPackage.computeIfAbsent(packageName, SourceEmittingElementHandler::newConcurrentSet);
+        String sourceFileName = executableElement.getSourceFileName();
+        if (sourceFileName != null && visitedBySourceFileName.add(sourceFileName)) {
+            List<ClassPathElement> elements = sourcePaths.get(classContext);
+            if (elements != null) {
+                // try to find the source file
+                String fullName = packageName.isEmpty() ? sourceFileName : packageName + '/' + sourceFileName;
+                for (ClassPathElement element : elements) {
+                    try {
+                        ClassPathElement.Resource resource = element.getResource(fullName);
+                        if (resource != null) {
+                            // we found it!
+                            Path writePath = outputPath.resolve(packageName);
+                            Files.createDirectories(writePath);
+                            try (InputStream stream = resource.openStream()) {
+                                Files.copy(stream, writePath.resolve(sourceFileName));
+                            }
+                        }
+                    } catch (IOException e) {
+                        // ignore this class path element
+                    }
+                }
+            }
+        }
+    }
+
+    private static <K, V> Map<K, V> newConcurrentMap(final Object ignored) {
+        return new ConcurrentHashMap<>();
+    }
+
+    private static <E> Set<E> newConcurrentSet(final Object ignored) {
+        return ConcurrentHashMap.newKeySet();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -507,6 +507,12 @@
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-plugin-source</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-plugin-thread-local</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
This PR gathers any resolved source JARs from the Maven resolution path and creates an output directory which contains all of the reachable source files.  You would then point the debugger to that directory with a single command, e.g. `(gdb) directory target/src`, and then you'd have complete source available.

The one problem is that we are not presently fetching source JARs during Maven artifact resolution, so I'm putting this into draft until there is occasion to fix that.

A future enhancement would be to also modify the non-Maven class path item specification function to support source directories, perhaps using some kind of magical syntax e.g. an `--app-path-source-file` which would use classpath syntax to add source paths for the application class path.

Another (much later) future enhancement would be to add a facility so that class loaders which are created within the application during build time have some way to register their corresponding source directories.