### PR TITLE
One more fix for small type IDs

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -572,10 +572,12 @@ public final class CoreIntrinsics {
         ClassTypeDescriptor stringDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/String");
         ClassTypeDescriptor mdDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/stackwalk/MethodData");
         ClassTypeDescriptor jlsteDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/StackTraceElement");
+        ClassTypeDescriptor typeIdDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/CNative$type_id");
 
         MethodDescriptor voidToIntDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of());
         MethodDescriptor intToLongDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.J, List.of(BaseTypeDescriptor.I));
         MethodDescriptor intToIntDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of(BaseTypeDescriptor.I));
+        MethodDescriptor intToTypeIdDesc = MethodDescriptor.synthesize(classContext, typeIdDesc, List.of(BaseTypeDescriptor.I));
         MethodDescriptor intToStringDesc = MethodDescriptor.synthesize(classContext, stringDesc, List.of(BaseTypeDescriptor.I));
         MethodDescriptor steIntToVoidDesc = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of(jlsteDesc, BaseTypeDescriptor.I));
 
@@ -685,7 +687,7 @@ public final class CoreIntrinsics {
             return builder.load(builder.memberOf(minfoHandle, minfoType.getMember("typeId")));
         };
 
-        intrinsics.registerIntrinsic(Phase.LOWER, mdDesc, "getTypeId", intToIntDesc, getTypeId);
+        intrinsics.registerIntrinsic(Phase.LOWER, mdDesc, "getTypeId", intToTypeIdDesc, getTypeId);
 
         StaticIntrinsic getModifiers = (builder, target, arguments) -> {
             GlobalVariable gmdVariable = (GlobalVariable) builder.globalVariable(mdTypes.getAndRegisterGlobalMethodData(builder.getCurrentElement()));

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -11,7 +11,7 @@ public final class MethodData {
     public static native String getFileName(int minfoIndex);
     public static native String getMethodName(int minfoIndex);
     public static native String getMethodDesc(int minfoIndex);
-    public static native int getTypeId(int minfoIndex);
+    public static native type_id getTypeId(int minfoIndex);
     public static native int getModifiers(int minfoIndex);
 
     public static String getClassName(int minfoIndex) {
@@ -19,7 +19,7 @@ public final class MethodData {
     }
 
     public static Class<?> getClass(int minfoIndex) {
-        type_id typeId = word(getTypeId(minfoIndex));
+        type_id typeId = getTypeId(minfoIndex);
         return CompilerIntrinsics.getClassFromTypeId(typeId, word(0));
     }
 


### PR DESCRIPTION
It papers over another problem which is that an implicit cast from (small) type_id to short integer results in a `bitcast` of `i16` to `i16` at the LLVM level, so that would need investigating at some point.  But, this solution slightly improves the existing code anyway so we can solve the other later.