### PR TITLE
Some alignment fixes and improvements

### DIFF
--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
@@ -14,6 +14,8 @@ final class Native {
 
     static final String ANN_ALIGN = className(align.class);
     static final String ANN_ALIGN_LIST = className(align.List.class);
+    static final String ANN_ALIGN_AS = className(align_as.class);
+    static final String ANN_ALIGN_AS_LIST = className(align_as.List.class);
     static final String ANN_ARRAY_SIZE = className(array_size.class);
     static final String ANN_CONST = className(c_const.class);
     static final String ANN_CONSTRUCTOR = className(constructor.class);

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -157,14 +157,14 @@ final class NativeInfo {
                                     if (conditionEvaluation.evaluateConditions(classContext, definedType, annotation)) {
                                         incomplete = true;
                                     }
-                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN)) {
+                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN) && annotatedAlign == 0) {
                                     if (conditionEvaluation.evaluateConditions(classContext, definedType, annotation)) {
                                         annotatedAlign = ((IntAnnotationValue)annotation.getValue("value")).intValue();
                                         if (annotatedAlign == Integer.MAX_VALUE) {
                                             annotatedAlign = ctxt.getTypeSystem().getMaxAlignment();
                                         }
                                     }
-                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_LIST)) {
+                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_LIST) && annotatedAlign == 0) {
                                     if (annotation.getValue("value") instanceof ArrayAnnotationValue aav) {
                                         int cnt = aav.getElementCount();
                                         for (int i = 0; i < cnt; i ++) {
@@ -185,7 +185,7 @@ final class NativeInfo {
                                             }
                                         }
                                     }
-                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_AS)) {
+                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_AS) && annotatedAlign == 0) {
                                     if (annotation.getValue("value") instanceof ClassAnnotationValue cav) {
                                         if (conditionEvaluation.evaluateConditions(classContext, definedType, annotation)) {
                                             ValueType resolvedType = classContext.resolveTypeFromDescriptor(
@@ -198,10 +198,13 @@ final class NativeInfo {
                                             annotatedAlign = resolvedType.getAlign();
                                         }
                                     }
-                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_AS_LIST)) {
+                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_AS_LIST) && annotatedAlign == 0) {
                                     if (annotation.getValue("value") instanceof ArrayAnnotationValue aav) {
                                         int cnt = aav.getElementCount();
                                         for (int i = 0; i < cnt; i ++) {
+                                            if (annotatedAlign != 0) {
+                                                break;
+                                            }
                                             if (aav.getValue(i) instanceof Annotation nested) {
                                                 ClassTypeDescriptor nestedDesc = nested.getDescriptor();
                                                 if (nestedDesc.packageAndClassNameEquals(Native.NATIVE_PKG, Native.ANN_ALIGN_AS)) {

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -29,6 +29,7 @@ import org.qbicc.type.ValueType;
 import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.annotation.AnnotationValue;
 import org.qbicc.type.annotation.ArrayAnnotationValue;
+import org.qbicc.type.annotation.ClassAnnotationValue;
 import org.qbicc.type.annotation.IntAnnotationValue;
 import org.qbicc.type.annotation.StringAnnotationValue;
 import org.qbicc.type.annotation.type.TypeAnnotation;
@@ -176,6 +177,44 @@ final class NativeInfo {
                                                             if (annotatedAlign == Integer.MAX_VALUE) {
                                                                 annotatedAlign = ctxt.getTypeSystem().getMaxAlignment();
                                                             }
+                                                            // stop searching for alignments
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_AS)) {
+                                    if (annotation.getValue("value") instanceof ClassAnnotationValue cav) {
+                                        if (conditionEvaluation.evaluateConditions(classContext, definedType, annotation)) {
+                                            ValueType resolvedType = classContext.resolveTypeFromDescriptor(
+                                                cav.getDescriptor(),
+                                                definedType,
+                                                TypeSignature.synthesize(classContext, definedType.getDescriptor()),
+                                                TypeAnnotationList.empty(),
+                                                TypeAnnotationList.empty()
+                                            );
+                                            annotatedAlign = resolvedType.getAlign();
+                                        }
+                                    }
+                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_AS_LIST)) {
+                                    if (annotation.getValue("value") instanceof ArrayAnnotationValue aav) {
+                                        int cnt = aav.getElementCount();
+                                        for (int i = 0; i < cnt; i ++) {
+                                            if (aav.getValue(i) instanceof Annotation nested) {
+                                                ClassTypeDescriptor nestedDesc = nested.getDescriptor();
+                                                if (nestedDesc.packageAndClassNameEquals(Native.NATIVE_PKG, Native.ANN_ALIGN_AS)) {
+                                                    if (nested.getValue("value") instanceof ClassAnnotationValue cav) {
+                                                        if (conditionEvaluation.evaluateConditions(classContext, definedType, nested)) {
+                                                            ValueType resolvedType = classContext.resolveTypeFromDescriptor(
+                                                                cav.getDescriptor(),
+                                                                definedType,
+                                                                TypeSignature.synthesize(classContext, definedType.getDescriptor()),
+                                                                TypeAnnotationList.empty(),
+                                                                TypeAnnotationList.empty()
+                                                            );
+                                                            annotatedAlign = resolvedType.getAlign();
                                                             // stop searching for alignments
                                                             break;
                                                         }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -27,6 +27,8 @@ import org.qbicc.type.CompoundType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.annotation.Annotation;
+import org.qbicc.type.annotation.AnnotationValue;
+import org.qbicc.type.annotation.ArrayAnnotationValue;
 import org.qbicc.type.annotation.IntAnnotationValue;
 import org.qbicc.type.annotation.StringAnnotationValue;
 import org.qbicc.type.annotation.type.TypeAnnotation;
@@ -159,6 +161,27 @@ final class NativeInfo {
                                         annotatedAlign = ((IntAnnotationValue)annotation.getValue("value")).intValue();
                                         if (annotatedAlign == Integer.MAX_VALUE) {
                                             annotatedAlign = ctxt.getTypeSystem().getMaxAlignment();
+                                        }
+                                    }
+                                } else if (annDesc.getClassName().equals(Native.ANN_ALIGN_LIST)) {
+                                    if (annotation.getValue("value") instanceof ArrayAnnotationValue aav) {
+                                        int cnt = aav.getElementCount();
+                                        for (int i = 0; i < cnt; i ++) {
+                                            if (aav.getValue(i) instanceof Annotation nested) {
+                                                ClassTypeDescriptor nestedDesc = nested.getDescriptor();
+                                                if (nestedDesc.getPackageName().equals(Native.NATIVE_PKG)) {
+                                                    if (nestedDesc.getClassName().equals(Native.ANN_ALIGN)) {
+                                                        if (conditionEvaluation.evaluateConditions(classContext, definedType, nested)) {
+                                                            annotatedAlign = ((IntAnnotationValue)nested.getValue("value")).intValue();
+                                                            if (annotatedAlign == Integer.MAX_VALUE) {
+                                                                annotatedAlign = ctxt.getTypeSystem().getMaxAlignment();
+                                                            }
+                                                            // stop searching for alignments
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -1405,6 +1405,39 @@ public final class CNative {
     }
 
     /**
+     * Explicitly specify the exact alignment of an object as being equal to the alignment of the given type.
+     * The alignment will not be probed.  Different alignments can be specified for different platforms.
+     */
+    @Target({ ElementType.TYPE, ElementType.FIELD })
+    @Retention(RetentionPolicy.CLASS)
+    @Repeatable(align_as.List.class)
+    @Documented
+    public @interface align_as {
+        Class<?> value();
+
+        /**
+         * Cause this annotation to take effect only if <em>all</em> of the given conditions return {@code true}.
+         *
+         * @return the condition classes
+         */
+        Class<? extends BooleanSupplier>[] when() default {};
+
+        /**
+         * Prevent this annotation from taking effect if <em>all</em> of the given conditions return {@code true}.
+         *
+         * @return the condition classes
+         */
+        Class<? extends BooleanSupplier>[] unless() default {};
+
+        @Target({ ElementType.TYPE, ElementType.FIELD })
+        @Retention(RetentionPolicy.CLASS)
+        @Documented
+        @interface List {
+            align_as[] value();
+        }
+    }
+
+    /**
      * Explicitly specify the exact offset of an object member.  The offset will not be probed.  Different offsets can
      * be specified for different platforms.
      */

--- a/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/Unwind.java
+++ b/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/Unwind.java
@@ -1,6 +1,7 @@
 package org.qbicc.runtime.unwind;
 
 import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.stdc.Stddef.*;
 import static org.qbicc.runtime.stdc.Stdint.*;
 
 import org.qbicc.runtime.Build;
@@ -73,7 +74,7 @@ public final class Unwind {
      * The header for a thrown exception.  The runtime is expected to create its own thrown structure which includes
      * this structure as a member.  The runtime is responsible for allocating and freeing instances.
      */
-    @align(Integer.MAX_VALUE) // Force to max_align_t; See https://github.com/qbicc/qbicc/pull/623 for discussion of problem with MacOS unwind.h
+    @align_as(max_align_t.class) // Force alignment; See https://github.com/qbicc/qbicc/pull/623 for discussion of problem with MacOS unwind.h
     public static final class struct__Unwind_Exception extends object {
         /**
          * "A language- and implementation-specific identifier of the kind of exception. It allows a personality routine


### PR DESCRIPTION
Support annotation multiplicity for the `@align` attribute. Add (and use) `@align_as` attribute which allows the alignment of a type to be specified in terms of another type, like in C.