### PR TITLE
add reporting of a few basic statistics of the serialized heap

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -117,6 +117,7 @@ import org.qbicc.plugin.patcher.PatcherTypeResolver;
 import org.qbicc.plugin.reachability.ReachabilityBlockBuilder;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.plugin.reflection.Reflection;
+import org.qbicc.plugin.serialization.BuildtimeHeap;
 import org.qbicc.plugin.serialization.ClassObjectSerializer;
 import org.qbicc.plugin.serialization.MethodDataStringsSerializer;
 import org.qbicc.plugin.serialization.ObjectLiteralSerializingVisitor;
@@ -482,6 +483,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, MethodDataStringsSerializer::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, StaticChecksBasicBlockBuilder::new);
                                 builder.addPostHook(Phase.LOWER, NativeXtorLoweringHook::process);
+                                builder.addPostHook(Phase.LOWER, BuildtimeHeap::reportStats);
 
                                 builder.addPreHook(Phase.GENERATE, new SupersDisplayEmitter());
                                 builder.addPreHook(Phase.GENERATE, new DispatchTableEmitter());
@@ -655,6 +657,8 @@ public class Main implements Callable<DiagnosticContext> {
         private boolean debugInterpreter;
         @CommandLine.Option(names = "--gc", defaultValue = "none", description = "Type of GC to use. Valid values: ${COMPLETION-CANDIDATES}")
         private GCType gc;
+        @CommandLine.Option(names = "--heap-stats")
+        private boolean heapStats;
         @CommandLine.Option(names = "--method-data-stats")
         private boolean methodDataStats;
         @CommandLine.Option(names = "--pie", negatable = true, defaultValue = "false", description = "[Disable|Enable] generation of position independent executable")
@@ -738,6 +742,9 @@ public class Main implements Callable<DiagnosticContext> {
             }
             if (debugInterpreter) {
                 Logger.getLogger("org.qbicc.interpreter").setLevel(Level.DEBUG);
+            }
+            if (heapStats) {
+                Logger.getLogger("org.qbicc.plugin.serialization.stats").setLevel(Level.DEBUG);
             }
             if (methodDataStats) {
                 Logger.getLogger("org.qbicc.plugin.methodinfo.stats").setLevel(Level.DEBUG);

--- a/main/src/main/resources/logging.properties
+++ b/main/src/main/resources/logging.properties
@@ -6,6 +6,7 @@ loggers=\
   org.qbicc.plugin.instanceofcheckcast.supers,\
   org.qbicc.plugin.methodinfo.stats,\
   org.qbicc.plugin.reachability.rta,\
+  org.qbicc.plugin.serialization.stats,\
   org.qbicc.plugin.stringpool.stats
 
 # Root logger configuration
@@ -17,6 +18,7 @@ logger.org.qbicc.plugin.dispatch.stats.level=INFO
 logger.org.qbicc.plugin.instanceofcheckcast.supers.level=INFO
 logger.org.qbicc.plugin.methodinfo.stats.level=INFO
 logger.org.qbicc.plugin.reachability.rta.level=INFO
+logger.org.qbicc.plugin.serialization.stats.level=INFO
 logger.org.qbicc.plugin.stringpool.stats.level=INFO
 
 


### PR DESCRIPTION
Just some basic stuff: Here's what it does right now.
```
[D] (org.qbicc.plugin.serialization.stats) LOWER: The initial heap contains 40,904 objects.
[D] (org.qbicc.plugin.serialization.stats) LOWER: The types with more than 5 instances are: 
[D] (org.qbicc.plugin.serialization.stats) LOWER:   14,017 instances of L[B;
[D] (org.qbicc.plugin.serialization.stats) LOWER:   13,840 instances of Ljava/lang/String;
[D] (org.qbicc.plugin.serialization.stats) LOWER:    1,758 instances of Ljava/lang/Class;
[D] (org.qbicc.plugin.serialization.stats) LOWER:    1,651 instances of Ljava/util/concurrent/ConcurrentHashMap$Node;
[D] (org.qbicc.plugin.serialization.stats) LOWER:    1,509 instances of L[L;
[D] (org.qbicc.plugin.serialization.stats) LOWER:    1,231 instances of Ljava/util/HashMap$Node;
[D] (org.qbicc.plugin.serialization.stats) LOWER:      476 instances of L[I;
[D] (org.qbicc.plugin.serialization.stats) LOWER:      355 instances of Ljava/lang/invoke/MethodType$ConcurrentWeakInternSet$WeakEntry;
[D] (org.qbicc.plugin.serialization.stats) LOWER:      355 instances of Ljava/lang/invoke/MethodType;
...
... about 60 more elided lines...
... 
[D] (org.qbicc.plugin.serialization.stats) LOWER:        6 instances of Ljava/lang/Module;
```
