### PR TITLE
Patcher bodging

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
@@ -147,8 +147,12 @@ public interface LoadedTypeDefinition extends DefinedTypeDefinition {
     }
 
     default FieldElement findField(String name) {
-        int idx = getFieldIndex(name);
-        return idx == - 1 ? null : getField(idx);
+        return findField(name, false);
+    }
+
+    default FieldElement findField(String name, boolean includeNoResolve) {
+        int idx = getFieldIndex(name, includeNoResolve);
+        return idx == -1 ? null : getField(idx);
     }
 
     /**

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/CoreClasses.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/CoreClasses.java
@@ -84,22 +84,21 @@ public final class CoreClasses {
         DefinedTypeDefinition jloDef = classContext.findDefinedType(OBJECT_INT_NAME);
         DefinedTypeDefinition jlcDef = classContext.findDefinedType(CLASS_INT_NAME);
         DefinedTypeDefinition jltDef = classContext.findDefinedType(THREAD_INT_NAME);
-        ClassTypeDescriptor jlcDesc = ClassTypeDescriptor.synthesize(classContext, CLASS_INT_NAME);
         LoadedTypeDefinition jlo = jloDef.load();
         LoadedTypeDefinition jlc = jlcDef.load();
         LoadedTypeDefinition jlt = jltDef.load();
         final TypeSystem ts = ctxt.getTypeSystem();
 
-        objectHeaderField = jlo.resolveField(BaseTypeDescriptor.V, "header", true);
-        objectTypeIdField = jlo.resolveField(BaseTypeDescriptor.V, "typeId", true);
+        objectHeaderField = jlo.findField("header", true);
+        objectTypeIdField = jlo.findField("typeId", true);
 
-        classTypeIdField = jlc.resolveField(BaseTypeDescriptor.V, "id", true);
-        classDimensionField = jlc.resolveField(BaseTypeDescriptor.V, "dimension", true);
-        arrayClassField = jlc.resolveField(jlcDesc, "arrayClass", true);
-        classInstanceSizeField = jlc.resolveField(BaseTypeDescriptor.I, "instanceSize", true);
-        classInstanceAlignField = jlc.resolveField(BaseTypeDescriptor.B, "instanceAlign", true);
+        classTypeIdField = jlc.findField("id", true);
+        classDimensionField = jlc.findField("dimension", true);
+        arrayClassField = jlc.findField("arrayClass", true);
+        classInstanceSizeField = jlc.findField("instanceSize", true);
+        classInstanceAlignField = jlc.findField("instanceAlign", true);
 
-        thrownField = jlt.resolveField(ClassTypeDescriptor.synthesize(classContext, THROWABLE_INT_NAME), "thrown", true);
+        thrownField = jlt.findField("thrown", true);
 
         // now define classes for arrays
         // todo: assign special type ID values to array types

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/ClassPatchInfo.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/ClassPatchInfo.java
@@ -150,6 +150,12 @@ final class ClassPatchInfo {
     void addField(final FieldPatchInfo fieldPatchInfo) {
         assert Thread.holdsLock(this);
         checkCommitted();
+        for (FieldPatchInfo injectedField : injectedFields) {
+            if (injectedField.getName().equals(fieldPatchInfo.getName())) {
+                // ignore
+                return;
+            }
+        }
         injectedFields = listWith(injectedFields, fieldPatchInfo);
     }
 
@@ -183,6 +189,12 @@ final class ClassPatchInfo {
     void addConstructor(final ConstructorPatchInfo constructorPatchInfo) {
         assert Thread.holdsLock(this);
         checkCommitted();
+        for (ConstructorPatchInfo injectedConstructor : injectedConstructors) {
+            if (injectedConstructor.getDescriptor().equals(constructorPatchInfo.getDescriptor())) {
+                // ignore
+                return;
+            }
+        }
         injectedConstructors = listWith(injectedConstructors, constructorPatchInfo);
     }
 
@@ -210,6 +222,12 @@ final class ClassPatchInfo {
         assert Thread.holdsLock(this);
         checkCommitted();
         injectedMethods = listWith(injectedMethods, methodPatchInfo);
+        for (MethodPatchInfo injectedMethod : injectedMethods) {
+            if (injectedMethod.getName().equals(methodPatchInfo.getName()) && injectedMethod.getDescriptor().equals(methodPatchInfo.getDescriptor())) {
+                // ignore
+                return;
+            }
+        }
     }
 
     void deleteMethod(final String name, final MethodDescriptor descriptor, String internalName, Annotation annotation) {


### PR DESCRIPTION
This change allows the patcher to safely inject the same member multiple times, and to safely add a member that is already present on the target type.

"Safe" in this context means "first one wins" so it is important to note that this is a temporary measure.  Warnings are only produced when overriding an existing field.