### PR TITLE
Method handles progress

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -401,6 +401,18 @@ public interface BasicBlockBuilder extends Locatable {
 
     ValueHandle constructorOf(Value instance, ConstructorElement constructor, MethodDescriptor callSiteDescriptor, FunctionType callSiteType);
 
+    /**
+     * Convenience method to construct a constructor handle whose descriptor and type match the element's descriptor and type.
+     * <b>Do not override this method.</b>
+     *
+     * @param instance the object instance (must not be {@code null})
+     * @param constructor the constructor element (must not be {@code null})
+     * @return the value handle (not {@code null})
+     */
+    default ValueHandle constructorOf(Value instance, ConstructorElement constructor) {
+        return constructorOf(instance, constructor, constructor.getDescriptor(), constructor.getType());
+    }
+
     ValueHandle constructorOf(Value instance, TypeDescriptor owner, MethodDescriptor descriptor);
 
     ValueHandle functionOf(FunctionElement function);

--- a/compiler/src/main/java/org/qbicc/interpreter/VmStaticFieldBaseObject.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmStaticFieldBaseObject.java
@@ -1,0 +1,15 @@
+package org.qbicc.interpreter;
+
+/**
+ * A "fake" object used as the static field base for some class.
+ */
+public interface VmStaticFieldBaseObject extends VmObject {
+
+    /**
+     * Get the class for which this object represents the static field base.
+     *
+     * @return the class (not {@code null})
+     */
+    VmClass getEnclosedVmClass();
+
+}

--- a/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinition.java
@@ -192,6 +192,8 @@ public interface DefinedTypeDefinition extends TypeParameterContext,
 
     BootstrapMethod getBootstrapMethod(int index);
 
+    int getHiddenClassIndex();
+
     interface Builder extends Locatable {
         void setContext(ClassContext context);
 
@@ -248,6 +250,8 @@ public interface DefinedTypeDefinition extends TypeParameterContext,
         void setNestHost(String nestHost);
 
         void addNestMember(String nestMember);
+
+        void setHiddenClassIndex(int index);
 
         DefinedTypeDefinition build();
 
@@ -368,6 +372,10 @@ public interface DefinedTypeDefinition extends TypeParameterContext,
 
             default void addNestMember(String nestMember) {
                 getDelegate().addNestMember(nestMember);
+            }
+
+            default void setHiddenClassIndex(int index) {
+                getDelegate().setHiddenClassIndex(index);
             }
 
             default DefinedTypeDefinition build() {

--- a/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
@@ -84,6 +84,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
     final MethodDescriptor enclosingMethodDesc;
     final String nestHostClassName;
     final String[] nestMemberClassNames;
+    final int hiddenClassIndex;
 
     private volatile DefinedTypeDefinition loaded;
 
@@ -146,6 +147,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
         nestHostClassName = builder.nestHost;
         List<String> nestMembers = builder.nestMembers;
         nestMemberClassNames = nestMembers == null ? NO_STRINGS : nestMembers.toArray(String[]::new);
+        hiddenClassIndex = builder.hiddenClassIndex;
     }
 
     public ClassContext getContext() {
@@ -589,6 +591,10 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
         return bootstrapMethods.get(index);
     }
 
+    public int getHiddenClassIndex() {
+        return hiddenClassIndex;
+    }
+
     public boolean hasSuperClass() {
         return superClassName != null;
     }
@@ -638,6 +644,7 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
         MethodDescriptor enclosingMethodDesc;
         String nestHost;
         List<String> nestMembers;
+        int hiddenClassIndex = -1;
 
         public void setContext(final ClassContext context) {
             this.context = context;
@@ -877,6 +884,10 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
                 nestMembers = this.nestMembers = new ArrayList<>();
             }
             nestMembers.add(Assert.checkNotNullParam("nestMember", nestMember));
+        }
+
+        public void setHiddenClassIndex(final int index) {
+            this.hiddenClassIndex = index;
         }
 
         public void setName(final String internalName) {

--- a/compiler/src/main/java/org/qbicc/type/definition/DelegatingDefinedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DelegatingDefinedTypeDefinition.java
@@ -109,6 +109,10 @@ public abstract class DelegatingDefinedTypeDefinition implements DefinedTypeDefi
 
     public BootstrapMethod getBootstrapMethod(final int index) { return getDelegate().getBootstrapMethod(index); }
 
+    public int getHiddenClassIndex() {
+        return getDelegate().getHiddenClassIndex();
+    }
+
     public int hashCode() {
         return getDelegate().hashCode();
     }

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
@@ -565,6 +565,14 @@ public interface LoadedTypeDefinition extends DefinedTypeDefinition {
     VmClass getVmClass();
 
     /**
+     * Initialize the VM class.
+     *
+     * @param vmClass the VM class (must not be {@code null})
+     * @throws IllegalStateException if the VM class was already set
+     */
+    void setVmClass(VmClass vmClass);
+
+    /**
      * Get the class of the enclosing method, if any.
      *
      * @return the enclosing method's class, or {@code null} if there is none

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFileImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFileImpl.java
@@ -383,6 +383,9 @@ final class ClassFileImpl extends AbstractBufferBacked implements ClassFile, Enc
             int slash = name.lastIndexOf('/');
             String packageName = slash == -1 ? "" : ctxt.deduplicate(name.substring(0, slash));
             String className = slash == -1 ? name : ctxt.deduplicate(name.substring(slash + 1));
+            if (paramCtxt instanceof DefinedTypeDefinition dtd && dtd.internalPackageAndNameEquals(packageName, className)) {
+                return dtd.load().getType();
+            }
             return ctxt.resolveTypeFromClassName(packageName, className);
         }
     }

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -364,6 +364,9 @@ final class CompilationContextImpl implements CompilationContext {
     public Path getOutputDirectory(final DefinedTypeDefinition type) {
         Path base = outputDir;
         String internalName = type.getInternalName();
+        if (type.isHidden()) {
+            internalName += "~" + type.getHiddenClassIndex();
+        }
         int idx = internalName.indexOf('/');
         if (idx == -1) {
             return base.resolve(internalName);
@@ -516,7 +519,8 @@ final class CompilationContextImpl implements CompilationContext {
     private String getExactNameForElement(final ExecutableElement element, final FunctionType type) {
         // todo: encode class loader ID
         // todo: cache :-(
-        String internalDotName = element.getEnclosingType().getInternalName().replace('/', '.');
+        DefinedTypeDefinition enclosingType = element.getEnclosingType();
+        String internalDotName = enclosingType.load().getVmClass().getName().replace('/', '~');
         if (element instanceof InitializerElement) {
             return "clinit." + internalDotName;
         }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1405,7 +1405,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         VmObject receiver = handle.accept(GET_RECEIVER, this);
         DefinedTypeDefinition def = element.getEnclosingType();
         VmClassLoaderImpl cl = thread.vm.getClassLoaderForContext(def.getContext());
-        VmClassImpl clazz = cl.loadClass(def.getInternalName());
+        VmClassImpl clazz = (VmClassImpl) def.load().getVmClass();
         clazz.initialize(thread);
         VmInvokable invokable = clazz.getOrCompile(element);
         return invokable.invokeAny(thread, receiver, arguments);
@@ -1897,7 +1897,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     public Object visit(VmThreadImpl thread, New node) {
         DefinedTypeDefinition enclosingType = node.getElement().getEnclosingType();
         VmClassLoaderImpl cl = thread.vm.getClassLoaderForContext(enclosingType.getContext());
-        VmClassImpl clazz = cl.loadClass(node.getClassObjectType().getDefinition().getInternalName());
+        VmClassImpl clazz = (VmClassImpl) node.getClassObjectType().getDefinition().load().getVmClass();
         clazz.initialize(thread);
         return thread.vm.manuallyInitialize(clazz.newInstance());
     }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -288,7 +288,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
 
     @Override
     public String getName() {
-        return typeDefinition.getInternalName().replace("/", ".");
+        return ((VmString)memory.loadRef(indexOf(getVmClass().getTypeDefinition().findField("name")), SinglePlain)).getContent();
     }
 
     @Override
@@ -570,12 +570,13 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
 
     @Override
     public String toString() {
-        return "class " + getName();
+        return toString(new StringBuilder()).toString();
     }
 
     @Override
     StringBuilder toString(StringBuilder target) {
-        return target.append("class ").append(getName());
+        target.append(typeDefinition.isInterface() ? "interface" : "class");
+        return target.append(' ').append(getName());
     }
 
     boolean shouldBeInitialized() {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -33,7 +33,6 @@ import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
-import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
@@ -216,9 +215,8 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
 
     void postConstruct(VmImpl vm) {
         String name = typeDefinition.getInternalName().replace('/', '.');
-        if (typeDefinition.hasAllModifiersOf(ClassFile.I_ACC_HIDDEN)) {
-            VmClassLoaderImpl realClassLoader = vm.getClassLoaderForContext(typeDefinition.getContext());
-            name += "/" + realClassLoader.getHiddenClassSeq(name);
+        if (typeDefinition.isHidden()) {
+            name += "/" + typeDefinition.getHiddenClassIndex();
         }
         postConstruct(name, vm);
     }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -218,7 +218,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         String name = typeDefinition.getInternalName().replace('/', '.');
         if (typeDefinition.hasAllModifiersOf(ClassFile.I_ACC_HIDDEN)) {
             VmClassLoaderImpl realClassLoader = vm.getClassLoaderForContext(typeDefinition.getContext());
-            name += '/' + realClassLoader.getHiddenClassSeq(name);
+            name += "/" + realClassLoader.getHiddenClassSeq(name);
         }
         postConstruct(name, vm);
     }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -326,8 +326,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
                     // no superclass
                     return null;
                 } else {
-                    VmClassLoader classLoader = getVm().getClassLoaderForContext(def.getContext());
-                    superClass = (VmClassImpl) classLoader.loadClass(def.getInternalName());
+                    superClass = (VmClassImpl) def.getVmClass();
                 }
                 this.superClass = superClass;
             }
@@ -349,8 +348,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
                 int i = 0;
                 for (LoadedTypeDefinition def : typeDefinition.getInterfaces()) {
                     // load each interface
-                    VmClassLoader classLoader = getVm().getClassLoaderForContext(def.getContext());
-                    array[i] = (VmClassImpl) classLoader.loadClass(def.getInternalName());
+                    array[i] = (VmClassImpl) def.getVmClass();
                 }
                 newVal = List.of(array);
             }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -113,7 +113,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         staticLayoutInfo = Layout.get(ctxt).getStaticLayoutInfo(typeDefinition);
         staticMemory = staticLayoutInfo == null ? vmImpl.allocate(0) : vmImpl.allocate((int) staticLayoutInfo.getCompoundType().getSize());
         initializeConstantStaticFields();
-        staticFieldBase = staticLayoutInfo == null ? null : new VmStaticFieldBase(staticLayoutInfo, staticMemory);
+        staticFieldBase = staticLayoutInfo == null ? null : new VmStaticFieldBase(this, staticLayoutInfo, staticMemory);
     }
 
     VmClassImpl(VmImpl vmImpl, VmClassClassImpl classClass, @SuppressWarnings("unused") int primitivesOnly) {
@@ -144,7 +144,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         staticMemory = staticLayoutInfo == null ? vm.allocate(0) : vm.allocate((int) staticLayoutInfo.getCompoundType().getSize());
         superClass = new VmClassImpl(vm, (VmClassClassImpl) this, classContext.findDefinedType("java/lang/Object").load(), null);
         initializeConstantStaticFields();
-        staticFieldBase = staticLayoutInfo == null ? null : new VmStaticFieldBase(staticLayoutInfo, staticMemory);
+        staticFieldBase = staticLayoutInfo == null ? null : new VmStaticFieldBase(this, staticLayoutInfo, staticMemory);
     }
 
     void initializeConstantStaticFields() {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassLoaderImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassLoaderImpl.java
@@ -113,6 +113,9 @@ final class VmClassLoaderImpl extends VmObjectImpl implements VmClassLoader {
         }
         LoadedTypeDefinition loaded = defined.load();
         VmClassImpl vmClass = createVmClass(protectionDomain, vm, loaded, hidden);
+        if (hidden) {
+            loaded.setVmClass(vmClass);
+        }
         if (! hidden && this.defined.putIfAbsent(internalName, vmClass) != null) {
             VmThrowable throwable = vm.noClassDefFoundErrorClass.newInstance("Class already defined");
             VmThreadImpl thread = (VmThreadImpl) Vm.requireCurrentThread();
@@ -137,6 +140,9 @@ final class VmClassLoaderImpl extends VmObjectImpl implements VmClassLoader {
     }
 
     public VmClassImpl getOrDefineClass(LoadedTypeDefinition loaded) {
+        if (loaded.isHidden()) {
+            throw new IllegalArgumentException("Cannot getOrDefineClass for a hidden class");
+        }
         String internalName = loaded.getInternalName();
         VmClassImpl vmClass = defined.get(internalName);
         if (vmClass == null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassLoaderImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassLoaderImpl.java
@@ -105,6 +105,7 @@ final class VmClassLoaderImpl extends VmObjectImpl implements VmClassLoader {
         DefinedTypeDefinition.Builder builder = classContext.newTypeBuilder();
         classFile.accept(builder);
         if (hidden) {
+            builder.setHiddenClassIndex(getHiddenClassSeq(internalName));
             builder.addModifiers(ClassFile.I_ACC_HIDDEN);
         }
         DefinedTypeDefinition defined = builder.build();

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -1463,8 +1463,7 @@ public final class VmImpl implements Vm {
 
     private VmInvokable getInstanceInvoker(ExecutableElement element) {
         DefinedTypeDefinition enclosingType = element.getEnclosingType();
-        VmClassLoaderImpl classLoader = getClassLoaderForContext(enclosingType.getContext());
-        VmClassImpl loadedClass = classLoader.loadClass(enclosingType.getInternalName());
+        VmClassImpl loadedClass = (VmClassImpl) enclosingType.load().getVmClass();
         return loadedClass.getOrCompile(element);
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmPrimitiveClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmPrimitiveClassImpl.java
@@ -34,6 +34,11 @@ class VmPrimitiveClassImpl extends VmClassImpl implements VmPrimitiveClass {
     }
 
     @Override
+    StringBuilder toString(StringBuilder target) {
+        return target.append(getName());
+    }
+
+    @Override
     public BaseTypeDescriptor getDescriptor() {
         return descriptor;
     }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStaticFieldBase.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStaticFieldBase.java
@@ -1,7 +1,7 @@
 package org.qbicc.interpreter.impl;
 
 import org.qbicc.interpreter.VmClass;
-import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.VmStaticFieldBaseObject;
 import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.CompoundType;
@@ -11,19 +11,27 @@ import org.qbicc.type.definition.element.FieldElement;
 /**
  *
  */
-final class VmStaticFieldBase implements VmObject, Referenceable {
+final class VmStaticFieldBase implements VmStaticFieldBaseObject, Referenceable {
+    private final VmClassImpl vmClass;
     private final LayoutInfo staticLayout;
     private final MemoryImpl memory;
 
     /**
      * Construct a new instance.
      *
+     * @param vmClass the class for which this object exists
      * @param staticLayout the static layout
      * @param memory the static memory for the class
      */
-    VmStaticFieldBase(LayoutInfo staticLayout, MemoryImpl memory) {
+    VmStaticFieldBase(VmClassImpl vmClass, LayoutInfo staticLayout, MemoryImpl memory) {
+        this.vmClass = vmClass;
         this.staticLayout = staticLayout;
         this.memory = memory;
+    }
+
+    @Override
+    public VmClass getEnclosedVmClass() {
+        return vmClass;
     }
 
     @Override

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/AbstractFunction.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/AbstractFunction.java
@@ -143,7 +143,7 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
     protected final void appendNameAndType(final Appendable target) throws IOException {
         returnType.appendTo(target);
 
-        target.append(" @").append(name).append('(');
+        target.append(" @").append(LLVM.needsQuotes(name) ? LLVM.quoteString(name) : name).append('(');
 
         if (lastParam != null) {
             lastParam.appendTo(target);

--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
@@ -99,6 +99,7 @@ public class DispatchTables {
         MethodElement[] vtable = vtableVector.toArray(MethodElement.NO_METHODS);
 
         String vtableName = "vtable-" + cls.getInternalName().replace('/', '.');
+        if (cls.isHidden()) vtableName += "~" + cls.getHiddenClassIndex();
         TypeSystem ts = ctxt.getTypeSystem();
         CompoundType.Member[] functions = new CompoundType.Member[vtable.length];
         for (int i=0; i<vtable.length; i++) {
@@ -125,6 +126,7 @@ public class DispatchTables {
         // Build the CompoundType for the ITable using the (arbitrary) order of selectors in itableVector
         MethodElement[] itable = itableVector.toArray(MethodElement.NO_METHODS);
         String itableName = "itable-" + cls.getInternalName().replace('/', '.');
+        if (cls.isHidden()) itableName += "~" + cls.getHiddenClassIndex();
         TypeSystem ts = ctxt.getTypeSystem();
         CompoundType.Member[] functions = new CompoundType.Member[itable.length];
         for (int i=0; i<itable.length; i++) {

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -7,6 +7,7 @@ import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmArray;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.VmStaticFieldBaseObject;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
@@ -79,6 +80,11 @@ class BuildtimeHeapAnalyzer {
         CoreClasses coreClasses = CoreClasses.get(ctxt);
         while (!worklist.isEmpty()) {
             VmObject cur = worklist.pop();
+
+            if (cur instanceof VmStaticFieldBaseObject) {
+                // skip
+                continue;
+            }
 
             PhysicalObjectType ot = cur.getObjectType();
             if (ot instanceof ClassObjectType && !(cur instanceof VmClass || cur instanceof VmString)) {

--- a/plugins/reflection/pom.xml
+++ b/plugins/reflection/pom.xml
@@ -27,6 +27,10 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-intrinsics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-layout</artifactId>
         </dependency>
         <dependency>

--- a/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/ReflectionIntrinsics.java
+++ b/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/ReflectionIntrinsics.java
@@ -1,0 +1,168 @@
+package org.qbicc.plugin.reflection;
+
+
+import static org.qbicc.graph.atomic.AccessModes.SinglePlain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.driver.Phase;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.BlockEarlyTermination;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.interpreter.Thrown;
+import org.qbicc.interpreter.Vm;
+import org.qbicc.interpreter.VmClass;
+import org.qbicc.interpreter.VmClassLoader;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.VmReferenceArray;
+import org.qbicc.interpreter.VmString;
+import org.qbicc.plugin.intrinsics.InstanceIntrinsic;
+import org.qbicc.plugin.intrinsics.Intrinsics;
+import org.qbicc.type.FunctionType;
+import org.qbicc.type.TypeSystem;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.descriptor.ArrayTypeDescriptor;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
+import org.qbicc.type.descriptor.MethodDescriptor;
+import org.qbicc.type.descriptor.TypeDescriptor;
+import org.qbicc.type.methodhandle.MethodHandleKind;
+
+final class ReflectionIntrinsics {
+    private static final Logger log = Logger.getLogger("org.qbicc.plugin.reflection");
+
+    private ReflectionIntrinsics() {}
+
+    static void register(CompilationContext ctxt) {
+        Intrinsics intrinsics = Intrinsics.get(ctxt);
+        ClassContext classContext = ctxt.getBootstrapClassContext();
+        LiteralFactory lf = ctxt.getLiteralFactory();
+        TypeSystem ts = ctxt.getTypeSystem();
+
+        ClassTypeDescriptor methodHandleDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/invoke/MethodHandle");
+        ClassTypeDescriptor objDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/Object");
+        ClassTypeDescriptor methodTypeDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/invoke/MethodType");
+        ClassTypeDescriptor internalErrorDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/InternalError");
+        ClassTypeDescriptor throwableDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/Throwable");
+
+        ArrayTypeDescriptor objArrayDesc = ArrayTypeDescriptor.of(classContext, objDesc);
+
+        MethodDescriptor objArrayToObj = MethodDescriptor.synthesize(classContext, objDesc, List.of(objArrayDesc));
+        MethodDescriptor throwableToVoid = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of(throwableDesc));
+
+        LoadedTypeDefinition dmhDef = classContext.findDefinedType("java/lang/invoke/DirectMethodHandle").load();
+        FieldElement dmhMember = dmhDef.findField("member");
+        LoadedTypeDefinition dmhCtorDef = classContext.findDefinedType("java/lang/invoke/DirectMethodHandle$Constructor").load();
+        FieldElement dmhCtorInitMethod = dmhCtorDef.findField("initMethod");
+        FieldElement dmhCtorInstanceClass = dmhCtorDef.findField("instanceClass");
+
+        // mh.invoke(...) -> mh.asType(actualType).invokeExact(...)
+        InstanceIntrinsic invoke = (builder, instance, target, arguments) -> {
+            // Use first builder because we chain to other intrinsics!
+            MethodDescriptor descriptor = target.getCallSiteDescriptor();
+            Vm vm = Vm.requireCurrent();
+            BasicBlockBuilder fb = builder.getFirstBuilder();
+            try {
+                VmObject realType = vm.createMethodType(classContext, descriptor);
+                Value realHandle;
+                LoadedTypeDefinition mhDef = ctxt.getBootstrapClassContext().findDefinedType("java/lang/invoke/MethodHandle").load();
+                int asTypeIdx = mhDef.findMethodIndex(me -> me.nameEquals("asType"));
+                MethodElement asType = mhDef.getMethod(asTypeIdx);
+                if (instance instanceof ObjectLiteral) {
+                    // get the target statically
+                    realHandle = lf.literalOf((VmObject) vm.invokeExact(asType, ((ObjectLiteral) instance).getValue(), List.of(realType)));
+                } else {
+                    // get the target dynamically
+                    ValueHandle asTypeHandle = fb.exactMethodOf(instance, asType, asType.getDescriptor(), asType.getType());
+                    realHandle = fb.call(asTypeHandle, List.of(lf.literalOf(realType)));
+                }
+                ValueHandle invokeExactHandle = fb.exactMethodOf(realHandle, methodHandleDesc, "invokeExact", descriptor);
+                return fb.call(invokeExactHandle, arguments);
+            } catch (Thrown t) {
+                ctxt.warning(fb.getLocation(), "Failed to expand MethodHandle.invoke intrinsic: %s", t);
+                log.warnf(t, "Failed to expand MethodHandle.invoke intrinsic");
+                Value ie = fb.new_(internalErrorDesc);
+                fb.call(fb.constructorOf(ie, internalErrorDesc, throwableToVoid), List.of(lf.literalOf(t.getThrowable())));
+                throw new BlockEarlyTermination(fb.throw_(ie));
+            }
+        };
+        // this intrinsic MUST be added during ADD because `invoke` must always be converted.
+        intrinsics.registerIntrinsic(Phase.ADD, methodHandleDesc, "invoke", objArrayToObj, invoke);
+
+        // The actual method handle dispatcher
+        InstanceIntrinsic invokeExact = (builder, instance, target, arguments) -> {
+            Reflection reflection = Reflection.get(ctxt);
+            BasicBlockBuilder fb = builder.getFirstBuilder();
+            if (instance instanceof ObjectLiteral mhLit) {
+                FunctionType callSiteType = target.getCallSiteType();
+                MethodDescriptor callSiteDescriptor = target.getCallSiteDescriptor();
+                // replace with the target invocation type
+                Vm vm = Vm.requireCurrent();
+                LoadedTypeDefinition callerTypeDef = fb.getCurrentElement().getEnclosingType().load();
+                VmClass callerClass = callerTypeDef.getVmClass();
+                int refKind = MethodHandleKind.INVOKE_VIRTUAL.getId();
+                LoadedTypeDefinition mhDef = ctxt.getBootstrapClassContext().findDefinedType("java/lang/invoke/MethodHandle").load();
+                VmClass defClass = mhDef.getVmClass();
+                VmString name = vm.intern("invoke");
+                // MethodType from java.lang.invoke.MethodHandleNatives.findMethodHandleType
+                VmClass objClass = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Object").load().getVmClass();
+                VmClass classClass = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Class").load().getVmClass();
+                VmClassLoader cl = vm.getClassLoaderForContext(callerTypeDef.getContext());
+                VmClass retType = vm.getClassForDescriptor(cl, callSiteDescriptor.getReturnType());
+                List<TypeDescriptor> parameterDescs = callSiteDescriptor.getParameterTypes();
+                int paramCnt = parameterDescs.size();
+                VmReferenceArray pArray = vm.newArrayOf(classClass, paramCnt);
+                for (int i = 0; i < paramCnt; i ++) {
+                    pArray.store(i, vm.getClassForDescriptor(cl, parameterDescs.get(i)));
+                }
+                VmObject type = (VmObject) vm.invokeExact(reflection.methodHandleNativesFindMethodHandleType, null, List.of(
+                    retType,
+                    pArray
+                ));
+                // holds the *returned* appendix object
+                VmReferenceArray appendixResult = vm.newArrayOf(objClass, 2);
+                VmObject invokerMemberName = (VmObject) vm.invokeExact(reflection.methodHandleNativesLinkMethod, null, List.of(
+                    callerClass,
+                    Integer.valueOf(refKind),
+                    defClass,
+                    name,
+                    type,
+                    appendixResult
+                ));
+                // resolve it
+                vm.invokeExact(reflection.methodHandleNativesResolve, null, List.of(invokerMemberName));
+                int methodIdx = invokerMemberName.getMemory().load32(invokerMemberName.indexOf(reflection.memberNameIndexField), SinglePlain);
+                VmClass methodClazz = (VmClass) invokerMemberName.getMemory().loadRef(invokerMemberName.indexOf(reflection.memberNameClazzField), SinglePlain);
+                MethodElement method = methodClazz.getTypeDefinition().getMethod(methodIdx);
+                // the invoker will be static
+                List<Value> args = new ArrayList<>();
+                // add the method handle
+                args.add(mhLit);
+                // add arguments
+                args.addAll(arguments);
+                // add the type (optionally)
+                if (method.getType().getParameterCount() > args.size()) {
+                    args.add(lf.literalOf(type));
+                }
+                return fb.call(fb.staticMethod(method), args);
+            } else {
+                ctxt.warning(fb.getLocation(), "Non-constant method handles not yet supported");
+                Value ie = fb.new_(internalErrorDesc);
+                fb.call(fb.constructorOf(ie, internalErrorDesc, MethodDescriptor.VOID_METHOD_DESCRIPTOR), List.of());
+                throw new BlockEarlyTermination(fb.throw_(ie));
+            }
+        };
+
+        intrinsics.registerIntrinsic(Phase.ADD, methodHandleDesc, "invokeExact", objArrayToObj, invokeExact);
+
+    }
+}

--- a/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/ReflectionIntrinsics.java
+++ b/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/ReflectionIntrinsics.java
@@ -129,7 +129,7 @@ final class ReflectionIntrinsics {
                     pArray
                 ));
                 // holds the *returned* appendix object
-                VmReferenceArray appendixResult = vm.newArrayOf(objClass, 2);
+                VmReferenceArray appendixResult = vm.newArrayOf(objClass, 1);
                 VmObject invokerMemberName = (VmObject) vm.invokeExact(reflection.methodHandleNativesLinkMethod, null, List.of(
                     callerClass,
                     Integer.valueOf(refKind),

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/ClassLoadingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/ClassLoadingBasicBlockBuilder.java
@@ -165,6 +165,9 @@ public class ClassLoadingBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     }
 
     private boolean loadClass(ClassTypeDescriptor desc) {
+        if (desc == getCurrentElement().getEnclosingType().getDescriptor()) {
+            return true;
+        }
         final String typeName;
         if (desc.getPackageName().isEmpty()) {
             typeName = desc.getClassName();

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
@@ -351,6 +351,11 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
     }
 
     private DefinedTypeDefinition resolveDescriptor(final TypeDescriptor owner) {
+        DefinedTypeDefinition enclosingType = getCurrentElement().getEnclosingType();
+        if (owner == enclosingType.getDescriptor()) {
+            // special case - resolving on a hidden class
+            return enclosingType;
+        }
         if (owner instanceof ClassTypeDescriptor) {
             final String typeName;
             if (((ClassTypeDescriptor) owner).getPackageName().isEmpty()) {


### PR DESCRIPTION
Implements a number of features around method handles and hidden classes, and fixes a couple of side issues like improving the `toString` implementation of `VmClassImpl` and some filename and function name handling problems on the LLVM side.

The number of warnings should be generally reduced, though there are still known issues.  In any event, this seems like a reasonable checkpoint (assuming CI passes) as I continue to work through this.

Hidden classes are written with a file name like `org/foo/bar/Baz~123.ll` where `123` is the sequence number of the hidden class.  Since not all classes remain alive, there may be gaps in the sequence numbers of the classes that actually make it to `GENERATE`.