### PR TITLE
include method name in itable/vtable member name

### DIFF
--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
@@ -104,7 +104,7 @@ public class DispatchTables {
         CompoundType.Member[] functions = new CompoundType.Member[vtable.length];
         for (int i=0; i<vtable.length; i++) {
             FunctionType funType = ctxt.getFunctionTypeForElement(vtable[i]);
-            functions[i] = ts.getCompoundTypeMember("m"+i, funType.getPointer(), i*ts.getPointerSize(), ts.getPointerAlignment());
+            functions[i] = ts.getCompoundTypeMember("m"+i+"."+vtable[i].getName(), funType.getPointer(), i*ts.getPointerSize(), ts.getPointerAlignment());
         }
         CompoundType vtableType = ts.getCompoundType(CompoundType.Tag.STRUCT, vtableName, vtable.length * ts.getPointerSize(),
             ts.getPointerAlignment(), () -> List.of(functions));
@@ -131,7 +131,7 @@ public class DispatchTables {
         CompoundType.Member[] functions = new CompoundType.Member[itable.length];
         for (int i=0; i<itable.length; i++) {
             FunctionType funType = ctxt.getFunctionTypeForElement(itable[i]);
-            functions[i] = ts.getCompoundTypeMember("m"+i, funType.getPointer(), i*ts.getPointerSize(), ts.getPointerAlignment());
+            functions[i] = ts.getCompoundTypeMember("m"+i+"."+itable[i].getName(), funType.getPointer(), i*ts.getPointerSize(), ts.getPointerAlignment());
         }
         CompoundType itableType = ts.getCompoundType(CompoundType.Tag.STRUCT, itableName, itable.length * ts.getPointerSize(),
             ts.getPointerAlignment(), () -> List.of(functions));


### PR DESCRIPTION
Small improvement that makes it much easier to see what is happening in the .ll files

The method name gets put in the comment field in the table declaration and at the call site (when we load the function pointer from the struct member).
