### PR TITLE
Allow $_native classes to also contain static helper methods

### DIFF
--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBasicBlockBuilder.java
@@ -151,7 +151,7 @@ public class NativeBasicBlockBuilder extends DelegatingBasicBlockBuilder {
             return pointerHandle(ctxt.getLiteralFactory().literalOf(ctxt.getImplicitSection(getRootElement())
                 .declareFunction(null, functionInfo.getName(), functionInfo.getType())));
         }
-        return super.staticMethod(deNative(owner), name, deNative(descriptor));
+        return super.staticMethod(owner, name, deNative(descriptor));
     }
 
     @Override


### PR DESCRIPTION
It's not clear exactly what semantics we want, but I think we probably want to allow static helper methods to be defined in $_native classes.  If so, then we need to allow those helpers to be resolved without denativing the owning class.

The example that motivated this change is https://github.com/qbicc/qbicc-class-library/blob/1bf1162aac92b5a57c3d459435018a257862a6f8/java.base/src/main/java/java/util/TimeZone%24_native.java#L26.  Without this fix, this invoke won't be resolved correctly.

I think the only alternative is to force helper methods to be defined in separate classes, which is certainly possible, but feels awkward.