### PR TITLE
Improvements to interpreter array-backed memory

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -700,4 +700,10 @@ public interface Memory {
     }
 
     Memory copy(long newSize);
+
+    Memory clone();
+
+    Memory cloneZeroed();
+
+    long getSize();
 }

--- a/compiler/src/main/java/org/qbicc/interpreter/Vm.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Vm.java
@@ -8,6 +8,7 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.Primitive;
+import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -215,6 +216,16 @@ public interface Vm {
      * @return the memory (not {@code null})
      */
     Memory allocate(int size);
+
+    /**
+     * Allocate memory of the given dimensions. The memory may be strongly typed (i.e. storing values that do
+     * not correspond to valid members of the given type may throw an exception).
+     *
+     * @param type the type to allocate
+     * @param count the number of copies of the type
+     * @return the memory
+     */
+    Memory allocate(ValueType type, long count);
 
     VmClass getClassForDescriptor(VmClassLoader cl, TypeDescriptor descriptor);
 

--- a/compiler/src/main/java/org/qbicc/interpreter/VmArray.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmArray.java
@@ -8,10 +8,15 @@ import org.qbicc.type.ArrayObjectType;
 public interface VmArray extends VmObject {
     int getLength();
 
-    long getArrayElementOffset(int index);
-
     ArrayObjectType getObjectType();
 
     @Override
     VmArrayClass getVmClass();
+
+    /**
+     * Get the raw array portion of this object.
+     *
+     * @return the raw array
+     */
+    Object getArray();
 }

--- a/compiler/src/main/java/org/qbicc/interpreter/VmReferenceArray.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmReferenceArray.java
@@ -9,6 +9,9 @@ public interface VmReferenceArray extends VmArray {
     @Override
     ReferenceArrayObjectType getObjectType();
 
+    @Override
+    VmObject[] getArray();
+
     /**
      * Directly store a value into the array.
      *

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
@@ -8,6 +8,7 @@ import java.lang.invoke.VarHandle;
 
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
 
 final class BigEndianMemoryImpl extends MemoryImpl {
     static final BigEndianMemoryImpl EMPTY = new BigEndianMemoryImpl(0);
@@ -388,7 +389,17 @@ final class BigEndianMemoryImpl extends MemoryImpl {
         return newMemory;
     }
 
-    protected MemoryImpl clone() {
+    public MemoryImpl clone() {
         return new BigEndianMemoryImpl(this);
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new BigEndianMemoryImpl(data.length);
+    }
+
+    @Override
+    public long getSize() {
+        return data.length;
     }
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1315,7 +1315,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
     @Override
     public Object visit(VmThreadImpl thread, ArrayLiteral node) {
-        MemoryImpl memory = thread.getVM().allocate((int) node.getType().getSize());
+        Memory memory = thread.getVM().allocate(node.getType(), 1);
         List<Literal> nodeValues = node.getValues();
         ValueType elementType = node.getType().getElementType();
         long elementSize = node.getType().getElementSize();
@@ -1503,7 +1503,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         boolean updated;
         CompoundType resultType = node.getType();
-        Memory result = thread.getVM().allocate((int) resultType.getSize());
+        Memory result = thread.getVM().allocate(resultType, 1);
         if (type instanceof ReferenceType) {
             VmObject expected = (VmObject) require(expect);
             VmObject resultVal = memory.compareAndExchangeRef(offset, expected, (VmObject) require(update), readAccessMode, writeAccessMode);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1879,9 +1879,9 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         VmArrayImpl outer = newArray(thread, type, size);
         if (dimOffs < dimensions.length - 1) {
             // nested arrays to fill
+            VmObject[] array = (VmObject[]) outer.getArray();
             for (int i = 0; i < size; i++) {
-                long offs = outer.getArrayElementOffset(i);
-                outer.getMemory().storeRef(offs, multiNewArray(thread, (ArrayObjectType) type.getElementType(), dimOffs + 1, dimensions), SinglePlain);
+                array[i] = multiNewArray(thread, (ArrayObjectType) type.getElementType(), dimOffs + 1, dimensions);
             }
         }
         return outer;

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/InvalidMemoryAccessException.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/InvalidMemoryAccessException.java
@@ -1,0 +1,50 @@
+package org.qbicc.interpreter.impl;
+
+import java.io.Serial;
+
+/**
+ * An exception indicating that a memory access would violate the strong type of the memory.
+ */
+public class InvalidMemoryAccessException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = -615690580354323808L;
+
+    /**
+     * Constructs a new {@code InvalidMemoryAccessException} instance.  The message is left blank ({@code null}), and no
+     * cause is specified.
+     */
+    public InvalidMemoryAccessException() {
+    }
+
+    /**
+     * Constructs a new {@code InvalidMemoryAccessException} instance with an initial message.  No
+     * cause is specified.
+     *
+     * @param msg the message
+     */
+    public InvalidMemoryAccessException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructs a new {@code InvalidMemoryAccessException} instance with an initial cause.  If
+     * a non-{@code null} cause is specified, its message is used to initialize the message of this
+     * {@code InvalidMemoryAccessException}; otherwise the message is left blank ({@code null}).
+     *
+     * @param cause the cause
+     */
+    public InvalidMemoryAccessException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new {@code InvalidMemoryAccessException} instance with an initial message and cause.
+     *
+     * @param msg   the message
+     * @param cause the cause
+     */
+    public InvalidMemoryAccessException(final String msg, final Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
@@ -8,6 +8,7 @@ import java.lang.invoke.VarHandle;
 
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
 
 final class LittleEndianMemoryImpl extends MemoryImpl {
     static final LittleEndianMemoryImpl EMPTY = new LittleEndianMemoryImpl(0);
@@ -388,7 +389,17 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
         return newMemory;
     }
 
-    protected MemoryImpl clone() {
+    public MemoryImpl clone() {
         return new LittleEndianMemoryImpl(this);
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new LittleEndianMemoryImpl(data.length);
+    }
+
+    @Override
+    public long getSize() {
+        return data.length;
     }
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
@@ -422,5 +422,5 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    protected abstract MemoryImpl clone();
+    public abstract MemoryImpl clone();
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmArrayImpl.java
@@ -1,6 +1,7 @@
 package org.qbicc.interpreter.impl;
 
 
+import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmArray;
 import org.qbicc.type.ArrayObjectType;
 
@@ -8,22 +9,17 @@ import org.qbicc.type.ArrayObjectType;
  *
  */
 abstract class VmArrayImpl extends VmObjectImpl implements VmArray {
-    private final int length;
 
-    VmArrayImpl(VmArrayClassImpl clazz, int size) {
-        super(clazz, size);
-        this.length = size;
+    VmArrayImpl(VmArrayClassImpl clazz, Memory arrayMemory) {
+        super(clazz, arrayMemory);
     }
 
     VmArrayImpl(VmArrayImpl original) {
         super(original);
-        this.length = original.length;
     }
 
     @Override
-    public int getLength() {
-        return length;
-    }
+    public abstract int getLength();
 
     @Override
     public ArrayObjectType getObjectType() {
@@ -39,6 +35,6 @@ abstract class VmArrayImpl extends VmObjectImpl implements VmArray {
     }
 
     StringBuilder toString(final StringBuilder target) {
-        return target.append(getVmClass().getElementType().getName()).append('[').append(length).append(']');
+        return target.append(getVmClass().getElementType().getName()).append('[').append(getLength()).append(']');
     }
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmBooleanArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmBooleanArrayImpl.java
@@ -1,21 +1,33 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.memory.BooleanArrayMemory;
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+
 /**
  *
  */
 final class VmBooleanArrayImpl extends VmArrayImpl {
+    private final BooleanArrayMemory arrayMemory;
 
     VmBooleanArrayImpl(VmImpl vm, int size) {
-        super(vm.booleanArrayClass, size);
+        super(vm.booleanArrayClass, MemoryFactory.wrap(new boolean[size]));
+        arrayMemory = (BooleanArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmBooleanArrayImpl(final VmBooleanArrayImpl original) {
         super(original);
+        arrayMemory = (BooleanArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().booleanArrayContentOffset + index;
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public boolean[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmByteArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmByteArrayImpl.java
@@ -1,34 +1,47 @@
 package org.qbicc.interpreter.impl;
 
+import java.util.Arrays;
+
+import org.qbicc.interpreter.memory.ByteArrayMemory;
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+
 /**
  *
  */
 final class VmByteArrayImpl extends VmArrayImpl {
+    private final ByteArrayMemory arrayMemory;
+
+    VmByteArrayImpl(VmImpl vm, byte[] orig) {
+        super(vm.byteArrayClass, MemoryFactory.wrap(orig, vm.getCompilationContext().getTypeSystem().getEndianness()));
+        arrayMemory = (ByteArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
+    }
 
     VmByteArrayImpl(VmImpl vm, int size) {
-        super(vm.byteArrayClass, size);
+        this(vm, new byte[size]);
     }
 
-    VmByteArrayImpl(final VmImpl vm, final byte[] bytes, int offs, int len) {
-        this(vm, bytes.length);
-        getMemory().storeMemory(getArrayElementOffset(0), bytes, offs, len);
-    }
-
-    VmByteArrayImpl(final VmImpl vm, final byte[] bytes) {
-        this(vm, bytes, 0, bytes.length);
-    }
-
-    VmByteArrayImpl(VmByteArrayImpl original) {
+    VmByteArrayImpl(final VmByteArrayImpl original) {
         super(original);
+        arrayMemory = (ByteArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().byteArrayContentOffset + index;
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public byte[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override
     protected VmByteArrayImpl clone() {
         return new VmByteArrayImpl(this);
+    }
+
+    public VmByteArrayImpl copyOfRange(final int off, final int len) {
+        return new VmByteArrayImpl(clazz.getVm(), Arrays.copyOfRange(getArray(), off, len));
     }
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmCharArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmCharArrayImpl.java
@@ -1,21 +1,33 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.memory.CharArrayMemory;
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+
 /**
  *
  */
 final class VmCharArrayImpl extends VmArrayImpl {
+    private final CharArrayMemory arrayMemory;
 
     VmCharArrayImpl(VmImpl vm, int size) {
-        super(vm.charArrayClass, size);
+        super(vm.charArrayClass, MemoryFactory.wrap(new char[size]));
+        arrayMemory = (CharArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmCharArrayImpl(final VmCharArrayImpl original) {
         super(original);
+        arrayMemory = (CharArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().charArrayContentOffset + ((long) index << 1);
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public char[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -607,9 +607,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
             } else {
                 insert = oldMembers.getLength();
                 newMembers = (VmRefArrayImpl) vm.newArrayOf(getVmClass(), insert + 1);
-                for (int i = 0; i < insert; i ++) {
-                    newMembers.store(i, oldMembers.getMemory().loadRef(oldMembers.getArrayElementOffset(i), SinglePlain));
-                }
+                System.arraycopy(oldMembers.getArray(), 0, newMembers.getArray(), 0, insert);
             }
             newMembers.store(insert, member);
             witness = (VmRefArrayImpl) getMemory().compareAndExchangeRef(nestMembersIdx, oldMembers, newMembers, SingleAcquire, SingleRelease);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -26,6 +26,7 @@ import org.qbicc.interpreter.VmPrimitiveClass;
 import org.qbicc.interpreter.VmReferenceArrayClass;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.interpreter.VmThrowable;
+import org.qbicc.interpreter.memory.MemoryFactory;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
@@ -76,7 +77,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
     /**
      * This is the memory which backs the static fields of this class, as defined by {@link #staticLayoutInfo}.
      */
-    private final MemoryImpl staticMemory;
+    private final Memory staticMemory;
 
     private volatile List<? extends VmClassImpl> interfaces;
     private volatile VmClassImpl superClass;
@@ -110,7 +111,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         CompilationContext ctxt = classContext.getCompilationContext();
         layoutInfo = typeDefinition.isInterface() ? null : Layout.get(ctxt).getInstanceLayoutInfo(typeDefinition);
         staticLayoutInfo = Layout.get(ctxt).getStaticLayoutInfo(typeDefinition);
-        staticMemory = staticLayoutInfo == null ? vmImpl.allocate(0) : vmImpl.allocate((int) staticLayoutInfo.getCompoundType().getSize());
+        staticMemory = staticLayoutInfo == null ? MemoryFactory.getEmpty() : vmImpl.allocate(staticLayoutInfo.getCompoundType(), 1);
         initializeConstantStaticFields();
         staticFieldBase = staticLayoutInfo == null ? null : new VmStaticFieldBase(this, staticLayoutInfo, staticMemory);
     }
@@ -140,7 +141,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         CompilationContext ctxt = classContext.getCompilationContext();
         layoutInfo = Layout.get(ctxt).getInstanceLayoutInfo(typeDefinition);
         staticLayoutInfo = Layout.get(ctxt).getStaticLayoutInfo(typeDefinition);
-        staticMemory = staticLayoutInfo == null ? vm.allocate(0) : vm.allocate((int) staticLayoutInfo.getCompoundType().getSize());
+        staticMemory = staticLayoutInfo == null ? MemoryFactory.getEmpty() : vm.allocate(staticLayoutInfo.getCompoundType(), 1);
         superClass = new VmClassImpl(vm, (VmClassClassImpl) this, classContext.findDefinedType("java/lang/Object").load(), null);
         initializeConstantStaticFields();
         staticFieldBase = staticLayoutInfo == null ? null : new VmStaticFieldBase(this, staticLayoutInfo, staticMemory);
@@ -366,7 +367,7 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
     }
 
     @Override
-    public MemoryImpl getStaticMemory() {
+    public Memory getStaticMemory() {
         return staticMemory;
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassLoaderImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassLoaderImpl.java
@@ -99,8 +99,7 @@ final class VmClassLoaderImpl extends VmObjectImpl implements VmClassLoader {
         if (! hidden && defined.containsKey(internalName)) {
             throw duplicateClass(vm);
         }
-        MemoryImpl memory = (MemoryImpl) content.getMemory();
-        ClassFile classFile = ClassFile.of(classContext, ByteBuffer.wrap(memory.getArray(), Math.toIntExact(content.getArrayElementOffset(0)), content.getLength()));
+        ClassFile classFile = ClassFile.of(classContext, ByteBuffer.wrap(((VmByteArrayImpl)content).getArray()));
         // todo: proper verification...
         DefinedTypeDefinition.Builder builder = classContext.newTypeBuilder();
         classFile.accept(builder);

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmDoubleArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmDoubleArrayImpl.java
@@ -1,21 +1,33 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.DoubleArrayMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+
 /**
  *
  */
 final class VmDoubleArrayImpl extends VmArrayImpl {
+    private final DoubleArrayMemory arrayMemory;
 
     VmDoubleArrayImpl(VmImpl vm, int size) {
-        super(vm.doubleArrayClass, size);
+        super(vm.doubleArrayClass, MemoryFactory.wrap(new double[size]));
+        arrayMemory = (DoubleArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmDoubleArrayImpl(final VmDoubleArrayImpl original) {
         super(original);
+        arrayMemory = (DoubleArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().doubleArrayContentOffset + ((long) index << 3);
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public double[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmFloatArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmFloatArrayImpl.java
@@ -1,21 +1,33 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.FloatArrayMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+
 /**
  *
  */
 final class VmFloatArrayImpl extends VmArrayImpl {
+    private final FloatArrayMemory arrayMemory;
 
     VmFloatArrayImpl(VmImpl vm, int size) {
-        super(vm.floatArrayClass, size);
+        super(vm.floatArrayClass, MemoryFactory.wrap(new float[size]));
+        arrayMemory = (FloatArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmFloatArrayImpl(final VmFloatArrayImpl original) {
         super(original);
+        arrayMemory = (FloatArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().floatArrayContentOffset + ((long) index << 2);
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public float[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -56,6 +56,7 @@ import org.qbicc.type.FloatType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.Primitive;
 import org.qbicc.type.UnsignedIntegerType;
+import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
@@ -1069,6 +1070,13 @@ public final class VmImpl implements Vm {
     @Override
     public MemoryImpl allocate(int size) {
         return emptyMemory.copy(size);
+    }
+
+    @Override
+    public Memory allocate(ValueType type, long count) {
+        // todo: typed memory
+        // todo: vector memory
+        return allocate(Math.toIntExact(type.getSize() * count));
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmIntArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmIntArrayImpl.java
@@ -1,21 +1,33 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.IntArrayMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+
 /**
  *
  */
 final class VmIntArrayImpl extends VmArrayImpl {
+    private final IntArrayMemory arrayMemory;
 
     VmIntArrayImpl(VmImpl vm, int size) {
-        super(vm.intArrayClass, size);
+        super(vm.intArrayClass, MemoryFactory.wrap(new int[size]));
+        arrayMemory = (IntArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmIntArrayImpl(final VmIntArrayImpl original) {
         super(original);
+        arrayMemory = (IntArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().intArrayContentOffset + ((long) index << 2);
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public int[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmLongArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmLongArrayImpl.java
@@ -1,21 +1,33 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.LongArrayMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+
 /**
  *
  */
 final class VmLongArrayImpl extends VmArrayImpl {
+    private final LongArrayMemory arrayMemory;
 
     VmLongArrayImpl(VmImpl vm, int size) {
-        super(vm.longArrayClass, size);
+        super(vm.longArrayClass, MemoryFactory.wrap(new long[size]));
+        arrayMemory = (LongArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmLongArrayImpl(final VmLongArrayImpl original) {
         super(original);
+        arrayMemory = (LongArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().longArrayContentOffset + ((long) index << 3);
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public long[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
@@ -15,9 +15,9 @@ import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.interpreter.VmThread;
+import org.qbicc.interpreter.memory.MemoryFactory;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
-import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.PhysicalObjectType;
@@ -61,12 +61,11 @@ class VmObjectImpl implements VmObject, Referenceable {
     /**
      * Construct a new array instance.
      * @param clazz the array class (must not be {@code null})
-     * @param arraySize the size of the array
+     * @param arrayMemory the array memory (must not be {@code null})
      */
-    VmObjectImpl(final VmArrayClassImpl clazz, final int arraySize) {
+    VmObjectImpl(final VmArrayClassImpl clazz, final Memory arrayMemory) {
         this.clazz = clazz;
-        ArrayObjectType arrayType = clazz.getInstanceObjectType();
-        memory = clazz.getVm().allocate((int) (clazz.getLayoutInfo().getCompoundType().getSize() + arraySize * arrayType.getElementType().getSize()));
+        memory = MemoryFactory.compose(clazz.getVm().allocate(clazz.getLayoutInfo().getCompoundType(), 1), arrayMemory);
     }
 
     /**

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
@@ -10,7 +10,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.qbicc.context.CompilationContext;
-import org.qbicc.interpreter.Thrown;
+import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmString;
@@ -36,7 +36,7 @@ class VmObjectImpl implements VmObject, Referenceable {
     /**
      * This is the backing memory of this object, as defined by {@link VmClassImpl#getLayoutInfo() clazz.layoutInfo}.
      */
-    final MemoryImpl memory;
+    final Memory memory;
     /**
      * This is the object monitor, which is lazily instantiated.
      */
@@ -55,7 +55,7 @@ class VmObjectImpl implements VmObject, Referenceable {
      */
     VmObjectImpl(final VmClassImpl clazz) {
         this.clazz = clazz;
-        memory = clazz.getVmClass().getVm().allocate((int) clazz.getLayoutInfo().getCompoundType().getSize());
+        memory = clazz.getVmClass().getVm().allocate(clazz.getLayoutInfo().getCompoundType(), 1);
     }
 
     /**
@@ -88,7 +88,7 @@ class VmObjectImpl implements VmObject, Referenceable {
     }
 
     @Override
-    public MemoryImpl getMemory() {
+    public Memory getMemory() {
         return memory;
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmRefArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmRefArrayImpl.java
@@ -2,28 +2,37 @@ package org.qbicc.interpreter.impl;
 
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmReferenceArray;
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+import org.qbicc.interpreter.memory.ReferenceArrayMemory;
 import org.qbicc.type.ReferenceArrayObjectType;
-
-import static org.qbicc.graph.atomic.AccessModes.SinglePlain;
+import org.qbicc.type.ReferenceType;
 
 /**
  *
  */
 final class VmRefArrayImpl extends VmArrayImpl implements VmReferenceArray {
+    private final ReferenceArrayMemory arrayMemory;
 
-    VmRefArrayImpl(VmArrayClassImpl clazz, final int size) {
-        super(clazz, size);
+    VmRefArrayImpl(VmArrayClassImpl clazz, int size) {
+        super(clazz, MemoryFactory.wrap(new VmObject[size], (ReferenceType) clazz.getInstanceObjectType().getElementType()));
+        arrayMemory = (ReferenceArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmRefArrayImpl(final VmRefArrayImpl original) {
         super(original);
+        arrayMemory = (ReferenceArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        VmImpl vm = getVmClass().getVm();
-        int refSize = vm.getCompilationContext().getTypeSystem().getReferenceSize();
-        return vm.refArrayContentOffset + (long) index * refSize;
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+
+    @Override
+    public VmObject[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override
@@ -33,7 +42,7 @@ final class VmRefArrayImpl extends VmArrayImpl implements VmReferenceArray {
 
     @Override
     public void store(int index, VmObject value) {
-        getMemory().storeRef(getArrayElementOffset(index), value, SinglePlain);
+        getArray()[index] = value;
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmShortArrayImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmShortArrayImpl.java
@@ -1,21 +1,33 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.memory.CompositeMemory;
+import org.qbicc.interpreter.memory.MemoryFactory;
+import org.qbicc.interpreter.memory.ShortArrayMemory;
+
 /**
  *
  */
 final class VmShortArrayImpl extends VmArrayImpl {
+    private final ShortArrayMemory arrayMemory;
 
     VmShortArrayImpl(VmImpl vm, int size) {
-        super(vm.shortArrayClass, size);
+        super(vm.shortArrayClass, MemoryFactory.wrap(new short[size]));
+        arrayMemory = (ShortArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     VmShortArrayImpl(final VmShortArrayImpl original) {
         super(original);
+        arrayMemory = (ShortArrayMemory) ((CompositeMemory)getMemory()).getSubMemory(1);
     }
 
     @Override
-    public long getArrayElementOffset(int index) {
-        return getVmClass().getVm().shortArrayContentOffset + ((long) index << 1);
+    public int getLength() {
+        return arrayMemory.getArray().length;
+    }
+
+    @Override
+    public short[] getArray() {
+        return arrayMemory.getArray();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStaticFieldBase.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStaticFieldBase.java
@@ -1,5 +1,6 @@
 package org.qbicc.interpreter.impl;
 
+import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmStaticFieldBaseObject;
 import org.qbicc.plugin.layout.LayoutInfo;
@@ -14,7 +15,7 @@ import org.qbicc.type.definition.element.FieldElement;
 final class VmStaticFieldBase implements VmStaticFieldBaseObject, Referenceable {
     private final VmClassImpl vmClass;
     private final LayoutInfo staticLayout;
-    private final MemoryImpl memory;
+    private final Memory memory;
 
     /**
      * Construct a new instance.
@@ -23,7 +24,7 @@ final class VmStaticFieldBase implements VmStaticFieldBaseObject, Referenceable 
      * @param staticLayout the static layout
      * @param memory the static memory for the class
      */
-    VmStaticFieldBase(VmClassImpl vmClass, LayoutInfo staticLayout, MemoryImpl memory) {
+    VmStaticFieldBase(VmClassImpl vmClass, LayoutInfo staticLayout, Memory memory) {
         this.vmClass = vmClass;
         this.staticLayout = staticLayout;
         this.memory = memory;
@@ -50,7 +51,7 @@ final class VmStaticFieldBase implements VmStaticFieldBaseObject, Referenceable 
     }
 
     @Override
-    public MemoryImpl getMemory() {
+    public Memory getMemory() {
         return memory;
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStringImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStringImpl.java
@@ -7,6 +7,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
+import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmArray;
 import org.qbicc.interpreter.VmString;
 
@@ -41,7 +42,7 @@ final class VmStringImpl extends VmObjectImpl implements VmString {
             }
         }
         VmArray byteArray = vm.allocateArray(bytes);
-        MemoryImpl memory = getMemory();
+        Memory memory = getMemory();
         memory.store8(vm.stringCoderOffset, latin1 ? 0 : 1, SinglePlain);
         memory.storeRef(vm.stringValueOffset, byteArray, SinglePlain);
     }
@@ -62,11 +63,11 @@ final class VmStringImpl extends VmObjectImpl implements VmString {
             return content;
         }
         VmImpl vm = getVmClass().getVm();
-        MemoryImpl memory = getMemory();
+        Memory memory = getMemory();
         int coder = memory.load8(vm.stringCoderOffset, SingleAcquire);
         VmByteArrayImpl array = (VmByteArrayImpl) memory.loadRef(vm.stringValueOffset, SingleAcquire);
         Charset charset = coder == 0 ? StandardCharsets.ISO_8859_1 : StandardCharsets.UTF_16BE;
-        byte[] rawArray = array.getMemory().getArray();
+        byte[] rawArray = ((MemoryImpl)array.getMemory()).getArray();
         String newContent = new String(rawArray, vm.byteArrayContentOffset, array.getLength(), charset);
         for (;;) {
             if (contentHandle.compareAndSet(this, null, newContent)) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStringImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmStringImpl.java
@@ -41,7 +41,7 @@ final class VmStringImpl extends VmObjectImpl implements VmString {
                 bytes = content.getBytes(StandardCharsets.UTF_16LE);
             }
         }
-        VmArray byteArray = vm.allocateArray(bytes);
+        VmArray byteArray = vm.newByteArray(bytes);
         Memory memory = getMemory();
         memory.store8(vm.stringCoderOffset, latin1 ? 0 : 1, SinglePlain);
         memory.storeRef(vm.stringValueOffset, byteArray, SinglePlain);
@@ -67,8 +67,7 @@ final class VmStringImpl extends VmObjectImpl implements VmString {
         int coder = memory.load8(vm.stringCoderOffset, SingleAcquire);
         VmByteArrayImpl array = (VmByteArrayImpl) memory.loadRef(vm.stringValueOffset, SingleAcquire);
         Charset charset = coder == 0 ? StandardCharsets.ISO_8859_1 : StandardCharsets.UTF_16BE;
-        byte[] rawArray = ((MemoryImpl)array.getMemory()).getArray();
-        String newContent = new String(rawArray, vm.byteArrayContentOffset, array.getLength(), charset);
+        String newContent = new String(array.getArray(), charset);
         for (;;) {
             if (contentHandle.compareAndSet(this, null, newContent)) {
                 return newContent;

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableImpl.java
@@ -2,6 +2,7 @@ package org.qbicc.interpreter.impl;
 
 import org.qbicc.graph.Node;
 import org.qbicc.graph.Value;
+import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmThrowable;
@@ -35,7 +36,7 @@ final class VmThrowableImpl extends VmObjectImpl implements VmThrowable {
         } else {
             backTrace = currentFrame.getBackTrace();
         }
-        MemoryImpl memory = getMemory();
+        Memory memory = getMemory();
         LoadedTypeDefinition throwableClassDef = ((VmImpl)Vm.requireCurrent()).throwableClass.getTypeDefinition();
         Layout interpLayout = Layout.get(throwableClassDef.getContext().getCompilationContext());
         LayoutInfo layout = interpLayout.getInstanceLayoutInfo(throwableClassDef);
@@ -64,7 +65,7 @@ final class VmThrowableImpl extends VmObjectImpl implements VmThrowable {
             ExecutableElement frameElement = ip.getElement();
             VmObjectImpl ste = vm.stackTraceElementClass.newInstance();
             vm.manuallyInitialize(ste);
-            MemoryImpl steMemory = ste.getMemory();
+            Memory steMemory = ste.getMemory();
             // initialize the stack trace element
             DefinedTypeDefinition frameClassDef = frameElement.getEnclosingType();
             VmClassImpl frameClass = vm.getClassLoaderForContext(frameClassDef.getContext()).getOrDefineClass(frameClassDef.load());

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableImpl.java
@@ -5,6 +5,7 @@ import org.qbicc.graph.Value;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmClass;
+import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmThrowable;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
@@ -60,6 +61,7 @@ final class VmThrowableImpl extends VmObjectImpl implements VmThrowable {
         int fileNameIdx = layout.getMember(steClassDef.findField("fileName")).getOffset();
         int methodNameIdx = layout.getMember(steClassDef.findField("methodName")).getOffset();
         Node[] backTrace = this.backTrace;
+        VmObject[] steArray = ((VmRefArrayImpl) array).getArray();
         for (int i = 0; i < backTrace.length; i++) {
             Node ip = backTrace[i];
             ExecutableElement frameElement = ip.getElement();
@@ -84,7 +86,7 @@ final class VmThrowableImpl extends VmObjectImpl implements VmThrowable {
                 methodName = "<unknown>";
             }
             steMemory.storeRef(methodNameIdx, vm.intern(methodName), SinglePlain);
-            array.getMemory().storeRef(array.getArrayElementOffset(i), ste, SinglePlain);
+            steArray[i] = ste;
         }
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/BooleanArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/BooleanArrayMemory.java
@@ -1,0 +1,199 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.GlobalAcquire;
+import static org.qbicc.graph.atomic.AccessModes.GlobalPlain;
+import static org.qbicc.graph.atomic.AccessModes.GlobalRelease;
+import static org.qbicc.graph.atomic.AccessModes.SingleOpaque;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by a {@code boolean} array which can be directly accessed.
+ */
+public final class BooleanArrayMemory implements Memory {
+    private static final VarHandle h8 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, boolean[].class);
+
+    private final boolean[] array;
+
+    BooleanArrayMemory(boolean[] array) {
+        this.array = array;
+    }
+
+    public boolean[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return array[Math.toIntExact(index)] ? 1 : 0;
+        } else if (SingleOpaque.includes(mode)) {
+            return ((boolean) h8.getOpaque(array, Math.toIntExact(index))) ? 1 : 0;
+        } else if (GlobalAcquire.includes(mode)) {
+            return ((boolean) h8.getAcquire(array, Math.toIntExact(index))) ? 1 : 0;
+        } else {
+            return ((boolean) h8.getVolatile(array, Math.toIntExact(index))) ? 1 : 0;
+        }
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[(int) index] = (value & 1) != 0;
+        } else if (SingleOpaque.includes(mode)) {
+            h8.setOpaque(array, Math.toIntExact(index), (value & 1) != 0);
+        } else if (GlobalRelease.includes(mode)) {
+            h8.setRelease(array, Math.toIntExact(index), (value & 1) != 0);
+        } else {
+            h8.setVolatile(array, Math.toIntExact(index), (value & 1) != 0);
+        }
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            boolean val = (load8(index, readMode) & 1) != 0;
+            if (val == ((expect & 1) != 0)) {
+                store8(index, update, writeMode);
+            }
+            return val ? 1 : 0;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return ((boolean) h8.compareAndExchangeAcquire(array, Math.toIntExact(index), (expect & 1) != 0, (update & 1) != 0)) ? 1 : 0;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return ((boolean) h8.compareAndExchangeRelease(array, Math.toIntExact(index), (expect & 1) != 0, (update & 1) != 0)) ? 1 : 0;
+        } else {
+            return ((boolean) h8.compareAndExchange(array, Math.toIntExact(index), (expect & 1) != 0, (update & 1) != 0)) ? 1 : 0;
+        }
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new BooleanArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize)));
+    }
+
+    @Override
+    public Memory clone() {
+        return new BooleanArrayMemory(array.clone());
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new BooleanArrayMemory(new boolean[array.length]);
+    }
+
+    @Override
+    public long getSize() {
+        return array.length;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ByteArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ByteArrayMemory.java
@@ -1,0 +1,353 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.*;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by a {@code byte} array which can be directly accessed.
+ */
+public abstract class ByteArrayMemory implements Memory {
+    private static final VarHandle h8 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, byte[].class);
+
+    final byte[] array;
+
+    ByteArrayMemory(byte[] array) {
+        this.array = array;
+    }
+
+    public byte[] getArray() {
+        return array;
+    }
+
+    abstract VarHandle h16();
+    abstract VarHandle h32();
+    abstract VarHandle h64();
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return array[Math.toIntExact(index)] & 0xff;
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h8.getOpaque(array, Math.toIntExact(index)) & 0xff;
+        } else if (GlobalAcquire.includes(mode)) {
+            return (int) h8.getAcquire(array, Math.toIntExact(index)) & 0xff;
+        } else {
+            return (int) h8.getVolatile(array, Math.toIntExact(index)) & 0xff;
+        }
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return (int) h16().get(array, Math.toIntExact(index)) & 0xff;
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h16().getOpaque(array, Math.toIntExact(index)) & 0xff;
+        } else if (GlobalAcquire.includes(mode)) {
+            return (int) h16().getAcquire(array, Math.toIntExact(index)) & 0xff;
+        } else {
+            return (int) h16().getVolatile(array, Math.toIntExact(index)) & 0xff;
+        }
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return (int) h32().get(array, Math.toIntExact(index)) & 0xff;
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h32().getOpaque(array, Math.toIntExact(index)) & 0xff;
+        } else if (GlobalAcquire.includes(mode)) {
+            return (int) h32().getAcquire(array, Math.toIntExact(index)) & 0xff;
+        } else {
+            return (int) h32().getVolatile(array, Math.toIntExact(index)) & 0xff;
+        }
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return (long) h64().get(array, Math.toIntExact(index)) & 0xff;
+        } else if (SingleOpaque.includes(mode)) {
+            return (long) h64().getOpaque(array, Math.toIntExact(index)) & 0xff;
+        } else if (GlobalAcquire.includes(mode)) {
+            return (long) h64().getAcquire(array, Math.toIntExact(index)) & 0xff;
+        } else {
+            return (long) h64().getVolatile(array, Math.toIntExact(index)) & 0xff;
+        }
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[(int) index] = (byte) value;
+        } else if (SingleOpaque.includes(mode)) {
+            h8.setOpaque(array, Math.toIntExact(index), (byte) value);
+        } else if (GlobalRelease.includes(mode)) {
+            h8.setRelease(array, Math.toIntExact(index), (byte) value);
+        } else {
+            h8.setVolatile(array, Math.toIntExact(index), (byte) value);
+        }
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            h16().set(array, Math.toIntExact(index), (short) value);
+        } else if (SingleOpaque.includes(mode)) {
+            h16().setOpaque(array, Math.toIntExact(index), (short) value);
+        } else if (GlobalRelease.includes(mode)) {
+            h16().setRelease(array, Math.toIntExact(index), (short) value);
+        } else {
+            h16().setVolatile(array, Math.toIntExact(index), (short) value);
+        }
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            h32().set(array, Math.toIntExact(index), value);
+        } else if (SingleOpaque.includes(mode)) {
+            h32().setOpaque(array, Math.toIntExact(index), value);
+        } else if (GlobalRelease.includes(mode)) {
+            h32().setRelease(array, Math.toIntExact(index), value);
+        } else {
+            h32().setVolatile(array, Math.toIntExact(index), value);
+        }
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            h64().set(array, Math.toIntExact(index), value);
+        } else if (SingleOpaque.includes(mode)) {
+            h64().setOpaque(array, Math.toIntExact(index), value);
+        } else if (GlobalRelease.includes(mode)) {
+            h64().setRelease(array, Math.toIntExact(index), value);
+        } else {
+            h64().setVolatile(array, Math.toIntExact(index), value);
+        }
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load8(index, readMode) & 0xff;
+            if (val == (expect & 0xff)) {
+                store8(index, update, writeMode);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) h8.compareAndExchangeAcquire(array, Math.toIntExact(index), (byte) expect, (byte) update) & 0xff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) h8.compareAndExchangeRelease(array, Math.toIntExact(index), (byte) expect, (byte) update) & 0xff;
+        } else {
+            return (int) h8.compareAndExchange(array, Math.toIntExact(index), (byte) expect, (byte) update) & 0xff;
+        }
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load16(index, readMode) & 0xffff;
+            if (val == (expect & 0xffff)) {
+                store16(index, update, writeMode);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) h16().compareAndExchangeAcquire(array, Math.toIntExact(index), (short) expect, (short) update) & 0xffff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) h16().compareAndExchangeRelease(array, Math.toIntExact(index), (short) expect, (short) update) & 0xffff;
+        } else {
+            return (int) h16().compareAndExchange(array, Math.toIntExact(index), (short) expect, (short) update) & 0xffff;
+        }
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = load32(index, readMode);
+            if (val == expect) {
+                store32(index, update, writeMode);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) h32().compareAndExchangeAcquire(array, Math.toIntExact(index), expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) h32().compareAndExchangeRelease(array, Math.toIntExact(index), expect, update);
+        } else {
+            return (int) h32().compareAndExchange(array, Math.toIntExact(index), expect, update);
+        }
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = load64(index, readMode);
+            if (val == expect) {
+                store64(index, update, writeMode);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (long) h64().compareAndExchangeAcquire(array, Math.toIntExact(index), expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (long) h64().compareAndExchangeRelease(array, Math.toIntExact(index), expect, update);
+        } else {
+            return (long) h64().compareAndExchange(array, Math.toIntExact(index), expect, update);
+        }
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public abstract Memory clone();
+
+    @Override
+    public long getSize() {
+        return array.length;
+    }
+
+    static final class BE extends ByteArrayMemory {
+        private static final VarHandle h16 = MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.BIG_ENDIAN);
+        private static final VarHandle h32 = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
+        private static final VarHandle h64 = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
+
+        BE(byte[] array) {
+            super(array);
+        }
+
+        @Override
+        VarHandle h16() {
+            return h16;
+        }
+
+        @Override
+        VarHandle h32() {
+            return h32;
+        }
+
+        @Override
+        VarHandle h64() {
+            return h64;
+        }
+
+        @Override
+        public Memory copy(long newSize) {
+            return new BE(Arrays.copyOf(array, Math.toIntExact(newSize)));
+        }
+
+        @Override
+        public Memory clone() {
+            return new BE(array.clone());
+        }
+
+        @Override
+        public Memory cloneZeroed() {
+            return new BE(new byte[array.length]);
+        }
+    }
+
+    static final class LE extends ByteArrayMemory {
+        private static final VarHandle h16 = MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+        private static final VarHandle h32 = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+        private static final VarHandle h64 = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+
+        LE(byte[] array) {
+            super(array);
+        }
+
+        @Override
+        VarHandle h16() {
+            return h16;
+        }
+
+        @Override
+        VarHandle h32() {
+            return h32;
+        }
+
+        @Override
+        VarHandle h64() {
+            return h64;
+        }
+
+        @Override
+        public Memory copy(long newSize) {
+            return new LE(Arrays.copyOf(array, Math.toIntExact(newSize)));
+        }
+
+        @Override
+        public Memory clone() {
+            return new LE(array.clone());
+        }
+
+        @Override
+        public Memory cloneZeroed() {
+            return new LE(new byte[array.length]);
+        }
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/CharArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/CharArrayMemory.java
@@ -1,0 +1,199 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.GlobalAcquire;
+import static org.qbicc.graph.atomic.AccessModes.GlobalPlain;
+import static org.qbicc.graph.atomic.AccessModes.GlobalRelease;
+import static org.qbicc.graph.atomic.AccessModes.SingleOpaque;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by a {@code char} array which can be directly accessed.
+ */
+public final class CharArrayMemory implements Memory {
+    private static final VarHandle h16 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, char[].class);
+
+    private final char[] array;
+
+    CharArrayMemory(char[] array) {
+        this.array = array;
+    }
+
+    public char[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return array[Math.toIntExact(index >>> 1)] & 0xffff;
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h16.getOpaque(array, Math.toIntExact(index >>> 1)) & 0xffff;
+        } else if (GlobalAcquire.includes(mode)) {
+            return (int) h16.getAcquire(array, Math.toIntExact(index >>> 1)) & 0xffff;
+        } else {
+            return (int) h16.getVolatile(array, Math.toIntExact(index >>> 1)) & 0xffff;
+        }
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[Math.toIntExact(index >>> 1)] = (char) value;
+        } else if (SingleOpaque.includes(mode)) {
+            h16.setOpaque(array, Math.toIntExact(index >>> 1), (char) value);
+        } else if (GlobalRelease.includes(mode)) {
+            h16.setRelease(array, Math.toIntExact(index >>> 1), (char) value);
+        } else {
+            h16.setVolatile(array, Math.toIntExact(index >>> 1), (char) value);
+        }
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = array[Math.toIntExact(index >>> 1)] & 0xffff;
+            if (val == (expect & 0xffff)) {
+                array[Math.toIntExact(index >>> 1)] = (char) update;
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) h16.compareAndExchangeAcquire(array, Math.toIntExact(index >>> 1), (char) expect, (char) update) & 0xffff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) h16.compareAndExchangeRelease(array, Math.toIntExact(index >>> 1), (char) expect, (char) update) & 0xffff;
+        } else {
+            return (int) h16.compareAndExchange(array, Math.toIntExact(index >>> 1), (char) expect, (char) update) & 0xffff;
+        }
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new CharArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize >>> 1)));
+    }
+
+    @Override
+    public Memory clone() {
+        return new CharArrayMemory(array.clone());
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new CharArrayMemory(new char[array.length]);
+    }
+
+    @Override
+    public long getSize() {
+        return (long) array.length << 1;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/CompositeMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/CompositeMemory.java
@@ -1,0 +1,477 @@
+package org.qbicc.interpreter.memory;
+
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory that is backed by multiple other concatenated memories of possibly varying sizes.
+ */
+public final class CompositeMemory implements Memory {
+    private final Memory[] memories;
+    private final long[] offsets;
+    private final long size;
+
+    CompositeMemory(Memory[] memories) {
+        this.memories = memories;
+        offsets = new long[memories.length];
+        long offset = 0;
+        for (int i = 0; i < memories.length; i ++) {
+            offsets[i] = offset;
+            offset += memories[i].getSize();
+        }
+        size = offset;
+    }
+
+    CompositeMemory(Memory[] memories, long[] offsets, long size) {
+        this.memories = memories;
+        this.offsets = offsets;
+        this.size = size;
+    }
+
+    private int getDelegateIndex(final long index) {
+        if (index < 0) {
+            throw new IndexOutOfBoundsException(index);
+        }
+        int which = Arrays.binarySearch(offsets, index);
+        if (which < 0) {
+            // we want the element *before* the insertion point
+            which = -which - 2;
+        }
+        return which;
+    }
+
+    public Memory getSubMemory(int index) {
+        return memories[index];
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        int which = getDelegateIndex(index);
+        return memories[which].load8(index - offsets[which], mode);
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        int which = getDelegateIndex(index);
+        return memories[which].load16(index - offsets[which], mode);
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        int which = getDelegateIndex(index);
+        return memories[which].load32(index - offsets[which], mode);
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        int which = getDelegateIndex(index);
+        return memories[which].load64(index - offsets[which], mode);
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        int which = getDelegateIndex(index);
+        return memories[which].loadRef(index - offsets[which], mode);
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        int which = getDelegateIndex(index);
+        return memories[which].loadType(index - offsets[which], mode);
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        int which = getDelegateIndex(index);
+        return memories[which].loadPointer(index - offsets[which], mode);
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        int which = getDelegateIndex(index);
+        memories[which].store8(index - offsets[which], value, mode);
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        int which = getDelegateIndex(index);
+        memories[which].store16(index - offsets[which], value, mode);
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        int which = getDelegateIndex(index);
+        memories[which].store32(index - offsets[which], value, mode);
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        int which = getDelegateIndex(index);
+        memories[which].store64(index - offsets[which], value, mode);
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        int which = getDelegateIndex(index);
+        memories[which].storeRef(index - offsets[which], value, mode);
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        int which = getDelegateIndex(index);
+        memories[which].storeType(index - offsets[which], value, mode);
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        int which = getDelegateIndex(index);
+        memories[which].storePointer(index - offsets[which], value, mode);
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].compareAndExchange8(index - offsets[which], expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].compareAndExchange16(index - offsets[which], expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].compareAndExchange32(index - offsets[which], expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].compareAndExchange64(index - offsets[which], expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].compareAndExchangeRef(index - offsets[which], expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].compareAndExchangeType(index - offsets[which], expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].compareAndExchangePointer(index - offsets[which], expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSet8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSet8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSet16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSet16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSet32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSet32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndSet64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSet64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public VmObject getAndSetRef(long index, VmObject value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetRef(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public ValueType getAndSetType(long index, ValueType value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetType(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndAdd8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndAdd8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndAdd16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndAdd16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndAdd32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndAdd32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndAdd64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndAdd64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseAnd8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseAnd8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseAnd16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseAnd16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseAnd32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseAnd32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndBitwiseAnd64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseAnd64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseNand8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseNand8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseNand16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseNand16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseNand32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseNand32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndBitwiseNand64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseNand64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseOr8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseOr8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseOr16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseOr16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseOr32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseOr32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndBitwiseOr64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseOr64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseXor8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseXor8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseXor16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseXor16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndBitwiseXor32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseXor32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndBitwiseXor64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndBitwiseXor64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMaxSigned8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxSigned8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMaxSigned16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxSigned16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMaxSigned32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxSigned32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndSetMaxSigned64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxSigned64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMaxUnsigned8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxUnsigned8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMaxUnsigned16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxUnsigned16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMaxUnsigned32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxUnsigned32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndSetMaxUnsigned64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMaxUnsigned64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMinSigned8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinSigned8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMinSigned16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinSigned16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMinSigned32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinSigned32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndSetMinSigned64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinSigned64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMinUnsigned8(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinUnsigned8(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMinUnsigned16(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinUnsigned16(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public int getAndSetMinUnsigned32(long index, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinUnsigned32(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public long getAndSetMinUnsigned64(long index, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int which = getDelegateIndex(index);
+        return memories[which].getAndSetMinUnsigned64(index - offsets[which], value, readMode, writeMode);
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        final int which = getDelegateIndex(newSize);
+        if (which == 0) {
+            return memories[0].copy(newSize);
+        }
+        Memory[] clones = new Memory[which + 1];
+        for (int i = 0; i < which; i ++) {
+            clones[i] = memories[i].clone();
+        }
+        clones[which] = memories[which].copy(newSize - offsets[which]);
+        return new CompositeMemory(clones, Arrays.copyOf(offsets, which + 1), newSize);
+    }
+
+    @Override
+    public Memory clone() {
+        Memory[] clones = new Memory[memories.length];
+        for (int i = 0; i < memories.length; i ++) {
+            clones[i] = memories[i].clone();
+        }
+        return new CompositeMemory(clones, offsets, size);
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        Memory[] clones = new Memory[memories.length];
+        for (int i = 0; i < memories.length; i ++) {
+            clones[i] = memories[i].cloneZeroed();
+        }
+        return new CompositeMemory(clones, offsets, size);
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/DoubleArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/DoubleArrayMemory.java
@@ -1,0 +1,199 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.GlobalAcquire;
+import static org.qbicc.graph.atomic.AccessModes.GlobalPlain;
+import static org.qbicc.graph.atomic.AccessModes.GlobalRelease;
+import static org.qbicc.graph.atomic.AccessModes.SingleOpaque;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by a {@code double} array which can be directly accessed.
+ */
+public final class DoubleArrayMemory implements Memory {
+    private static final VarHandle h64 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, double[].class);
+
+    private final double[] array;
+
+    DoubleArrayMemory(double[] array) {
+        this.array = array;
+    }
+
+    public double[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return Double.doubleToRawLongBits(array[Math.toIntExact(index >>> 3)]);
+        } else if (SingleOpaque.includes(mode)) {
+            return Double.doubleToRawLongBits((double) h64.getOpaque(array, Math.toIntExact(index >>> 3)));
+        } else if (GlobalAcquire.includes(mode)) {
+            return Double.doubleToRawLongBits((double) h64.getAcquire(array, Math.toIntExact(index >>> 3)));
+        } else {
+            return Double.doubleToRawLongBits((double) h64.getVolatile(array, Math.toIntExact(index >>> 3)));
+        }
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[Math.toIntExact(index >>> 3)] = Double.longBitsToDouble(value);
+        } else if (SingleOpaque.includes(mode)) {
+            h64.setOpaque(array, Math.toIntExact(index >>> 3), Double.longBitsToDouble(value));
+        } else if (GlobalRelease.includes(mode)) {
+            h64.setRelease(array, Math.toIntExact(index >>> 3), Double.longBitsToDouble(value));
+        } else {
+            h64.setVolatile(array, Math.toIntExact(index >>> 3), Double.longBitsToDouble(value));
+        }
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            double val = array[Math.toIntExact(index >>> 3)];
+            if (val == expect) {
+                array[Math.toIntExact(index >>> 3)] = Double.longBitsToDouble(update);
+            }
+            return Double.doubleToRawLongBits(val);
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return Double.doubleToRawLongBits((double) h64.compareAndExchangeAcquire(array, Math.toIntExact(index >>> 3), Double.longBitsToDouble(expect), Double.longBitsToDouble(update)));
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return Double.doubleToRawLongBits((double) h64.compareAndExchangeRelease(array, Math.toIntExact(index >>> 3), Double.longBitsToDouble(expect), Double.longBitsToDouble(update)));
+        } else {
+            return Double.doubleToRawLongBits((double) h64.compareAndExchange(array, Math.toIntExact(index >>> 3), Double.longBitsToDouble(expect), Double.longBitsToDouble(update)));
+        }
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new DoubleArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize >>> 3)));
+    }
+
+    @Override
+    public Memory clone() {
+        return new DoubleArrayMemory(array.clone());
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new DoubleArrayMemory(new double[array.length]);
+    }
+
+    @Override
+    public long getSize() {
+        return (long) array.length << 3;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/FloatArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/FloatArrayMemory.java
@@ -1,0 +1,199 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.GlobalAcquire;
+import static org.qbicc.graph.atomic.AccessModes.GlobalPlain;
+import static org.qbicc.graph.atomic.AccessModes.GlobalRelease;
+import static org.qbicc.graph.atomic.AccessModes.SingleOpaque;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by an {@code float} array which can be directly accessed.
+ */
+public final class FloatArrayMemory implements Memory {
+    private static final VarHandle h32 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, float[].class);
+
+    private final float[] array;
+
+    FloatArrayMemory(float[] array) {
+        this.array = array;
+    }
+
+    public float[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return Float.floatToRawIntBits(array[Math.toIntExact(index >>> 2)]);
+        } else if (SingleOpaque.includes(mode)) {
+            return Float.floatToRawIntBits((float) h32.getOpaque(array, Math.toIntExact(index >>> 2)));
+        } else if (GlobalAcquire.includes(mode)) {
+            return Float.floatToRawIntBits((float) h32.getAcquire(array, Math.toIntExact(index >>> 2)));
+        } else {
+            return Float.floatToRawIntBits((float) h32.getVolatile(array, Math.toIntExact(index >>> 2)));
+        }
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[Math.toIntExact(index >>> 2)] = Float.intBitsToFloat(value);
+        } else if (SingleOpaque.includes(mode)) {
+            h32.setOpaque(array, Math.toIntExact(index >>> 2), Float.intBitsToFloat(value));
+        } else if (GlobalRelease.includes(mode)) {
+            h32.setRelease(array, Math.toIntExact(index >>> 2), Float.intBitsToFloat(value));
+        } else {
+            h32.setVolatile(array, Math.toIntExact(index >>> 2), Float.intBitsToFloat(value));
+        }
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            float val = array[Math.toIntExact(index >>> 2)];
+            if (val == expect) {
+                array[Math.toIntExact(index >>> 2)] = Float.intBitsToFloat(update);
+            }
+            return Float.floatToRawIntBits(val);
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return Float.floatToRawIntBits((float) h32.compareAndExchangeAcquire(array, Math.toIntExact(index >>> 2), Float.intBitsToFloat(expect), Float.intBitsToFloat(update)));
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return Float.floatToRawIntBits((float) h32.compareAndExchangeRelease(array, Math.toIntExact(index >>> 2), Float.intBitsToFloat(expect), Float.intBitsToFloat(update)));
+        } else {
+            return Float.floatToRawIntBits((float) h32.compareAndExchange(array, Math.toIntExact(index >>> 2), Float.intBitsToFloat(expect), Float.intBitsToFloat(update)));
+        }
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new FloatArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize >>> 2)));
+    }
+
+    @Override
+    public Memory clone() {
+        return new FloatArrayMemory(array.clone());
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new FloatArrayMemory(new float[array.length]);
+    }
+
+    @Override
+    public long getSize() {
+        return (long) array.length << 2;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/IntArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/IntArrayMemory.java
@@ -1,0 +1,199 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.GlobalAcquire;
+import static org.qbicc.graph.atomic.AccessModes.GlobalPlain;
+import static org.qbicc.graph.atomic.AccessModes.GlobalRelease;
+import static org.qbicc.graph.atomic.AccessModes.SingleOpaque;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by an {@code int} array which can be directly accessed.
+ */
+public final class IntArrayMemory implements Memory {
+    private static final VarHandle h32 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, int[].class);
+
+    private final int[] array;
+
+    IntArrayMemory(int[] array) {
+        this.array = array;
+    }
+
+    public int[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return array[Math.toIntExact(index >>> 2)];
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h32.getOpaque(array, Math.toIntExact(index >>> 2));
+        } else if (GlobalAcquire.includes(mode)) {
+            return (int) h32.getAcquire(array, Math.toIntExact(index >>> 2));
+        } else {
+            return (int) h32.getVolatile(array, Math.toIntExact(index >>> 2));
+        }
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[Math.toIntExact(index >>> 2)] = value;
+        } else if (SingleOpaque.includes(mode)) {
+            h32.setOpaque(array, Math.toIntExact(index >>> 2), value);
+        } else if (GlobalRelease.includes(mode)) {
+            h32.setRelease(array, Math.toIntExact(index >>> 2), value);
+        } else {
+            h32.setVolatile(array, Math.toIntExact(index >>> 2), value);
+        }
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = array[Math.toIntExact(index >>> 2)];
+            if (val == expect) {
+                array[Math.toIntExact(index >>> 2)] = update;
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) h32.compareAndExchangeAcquire(array, Math.toIntExact(index >>> 2), expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) h32.compareAndExchangeRelease(array, Math.toIntExact(index >>> 2), expect, update);
+        } else {
+            return (int) h32.compareAndExchange(array, Math.toIntExact(index >>> 2), expect, update);
+        }
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new IntArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize >>> 2)));
+    }
+
+    @Override
+    public Memory clone() {
+        return new IntArrayMemory(array.clone());
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new IntArrayMemory(new int[array.length]);
+    }
+
+    @Override
+    public long getSize() {
+        return (long) array.length << 2;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/LongArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/LongArrayMemory.java
@@ -1,0 +1,199 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.GlobalAcquire;
+import static org.qbicc.graph.atomic.AccessModes.GlobalPlain;
+import static org.qbicc.graph.atomic.AccessModes.GlobalRelease;
+import static org.qbicc.graph.atomic.AccessModes.SingleOpaque;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by a {@code long} array which can be directly accessed.
+ */
+public final class LongArrayMemory implements Memory {
+    private static final VarHandle h64 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, long[].class);
+
+    private final long[] array;
+
+    LongArrayMemory(long[] array) {
+        this.array = array;
+    }
+
+    public long[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return array[Math.toIntExact(index >>> 3)];
+        } else if (SingleOpaque.includes(mode)) {
+            return (long) h64.getOpaque(array, Math.toIntExact(index >>> 3));
+        } else if (GlobalAcquire.includes(mode)) {
+            return (long) h64.getAcquire(array, Math.toIntExact(index >>> 3));
+        } else {
+            return (long) h64.getVolatile(array, Math.toIntExact(index >>> 3));
+        }
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[Math.toIntExact(index >>> 3)] = value;
+        } else if (SingleOpaque.includes(mode)) {
+            h64.setOpaque(array, Math.toIntExact(index >>> 3), value);
+        } else if (GlobalRelease.includes(mode)) {
+            h64.setRelease(array, Math.toIntExact(index >>> 3), value);
+        } else {
+            h64.setVolatile(array, Math.toIntExact(index >>> 3), value);
+        }
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = array[Math.toIntExact(index >>> 3)];
+            if (val == expect) {
+                array[Math.toIntExact(index >>> 3)] = update;
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (long) h64.compareAndExchangeAcquire(array, Math.toIntExact(index >>> 3), expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (long) h64.compareAndExchangeRelease(array, Math.toIntExact(index >>> 3), expect, update);
+        } else {
+            return (long) h64.compareAndExchange(array, Math.toIntExact(index >>> 3), expect, update);
+        }
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new LongArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize >>> 3)));
+    }
+
+    @Override
+    public Memory clone() {
+        return new LongArrayMemory(array.clone());
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new LongArrayMemory(new long[array.length]);
+    }
+
+    @Override
+    public long getSize() {
+        return (long) array.length << 3;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
@@ -1,0 +1,135 @@
+package org.qbicc.interpreter.memory;
+
+import java.nio.ByteOrder;
+
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.type.ReferenceType;
+
+/**
+ * Factory methods for producing memory instances.
+ */
+public final class MemoryFactory {
+    private MemoryFactory() {}
+
+    private static final Memory EMPTY = new ByteArrayMemory.LE(new byte[0]);
+
+    /**
+     * Get an empty memory.  The memory may have any type (or none) and is not guaranteed to be extendable or copyable.
+     *
+     * @return an empty memory (not {@code null})
+     */
+    public static Memory getEmpty() {
+        return EMPTY;
+    }
+
+    public static Memory replicate(Memory first, int nCopies) {
+        if (nCopies == 1) {
+            return first;
+        } else {
+            return new VectorMemory(first, nCopies);
+        }
+    }
+
+    public static Memory compose(Memory... memories) {
+        if (memories == null || memories.length == 0) {
+            return EMPTY;
+        } else if (memories.length == 1) {
+            return memories[0];
+        } else {
+            return new CompositeMemory(memories);
+        }
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static ByteArrayMemory wrap(byte[] array, ByteOrder byteOrder) {
+        return byteOrder == ByteOrder.BIG_ENDIAN ? new ByteArrayMemory.BE(array) : new ByteArrayMemory.LE(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static ShortArrayMemory wrap(short[] array) {
+        return new ShortArrayMemory(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static IntArrayMemory wrap(int[] array) {
+        return new IntArrayMemory(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static LongArrayMemory wrap(long[] array) {
+        return new LongArrayMemory(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static CharArrayMemory wrap(char[] array) {
+        return new CharArrayMemory(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static FloatArrayMemory wrap(float[] array) {
+        return new FloatArrayMemory(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static DoubleArrayMemory wrap(double[] array) {
+        return new DoubleArrayMemory(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static BooleanArrayMemory wrap(boolean[] array) {
+        return new BooleanArrayMemory(array);
+    }
+
+    /**
+     * Wrap the given array as a memory of the same size and type.
+     * The size of a reference is acquired from the given type.
+     *
+     * @param array the array to wrap (must not be {@code null})
+     * @param refType the reference type (must not be {@code null})
+     * @return the wrapper memory (must not be {@code null})
+     */
+    public static ReferenceArrayMemory wrap(VmObject[] array, ReferenceType refType) {
+        return new ReferenceArrayMemory(array, refType);
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ReferenceArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ReferenceArrayMemory.java
@@ -1,0 +1,206 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.GlobalAcquire;
+import static org.qbicc.graph.atomic.AccessModes.GlobalPlain;
+import static org.qbicc.graph.atomic.AccessModes.GlobalRelease;
+import static org.qbicc.graph.atomic.AccessModes.SingleOpaque;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ReferenceType;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by a reference array which can be directly accessed.
+ */
+public final class ReferenceArrayMemory implements Memory {
+    private static final VarHandle hr = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, VmObject[].class);
+
+    private final VmObject[] array;
+    private final int shift;
+
+    ReferenceArrayMemory(VmObject[] array, ReferenceType refType) {
+        this(array, Long.numberOfTrailingZeros(refType.getSize()));
+    }
+
+    private ReferenceArrayMemory(VmObject[] array, int shift) {
+        this.array = array;
+        this.shift = shift;
+    }
+
+    public VmObject[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return array[Math.toIntExact(index >>> shift)];
+        } else if (SingleOpaque.includes(mode)) {
+            return (VmObject) hr.getOpaque(array, Math.toIntExact(index >>> shift));
+        } else if (GlobalAcquire.includes(mode)) {
+            return (VmObject) hr.getAcquire(array, Math.toIntExact(index >>> shift));
+        } else {
+            return (VmObject) hr.getVolatile(array, Math.toIntExact(index >>> shift));
+        }
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[Math.toIntExact(index >>> shift)] = value;
+        } else if (SingleOpaque.includes(mode)) {
+            hr.setOpaque(array, Math.toIntExact(index >>> shift), value);
+        } else if (GlobalRelease.includes(mode)) {
+            hr.setRelease(array, Math.toIntExact(index >>> shift), value);
+        } else {
+            hr.setVolatile(array, Math.toIntExact(index >>> shift), value);
+        }
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            VmObject val = array[Math.toIntExact(index >>> shift)];
+            if (val == expect) {
+                array[Math.toIntExact(index >>> shift)] = update;
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (VmObject) hr.compareAndExchangeAcquire(array, Math.toIntExact(index >>> shift), expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (VmObject) hr.compareAndExchangeRelease(array, Math.toIntExact(index >>> shift), expect, update);
+        } else {
+            return (VmObject) hr.compareAndExchange(array, Math.toIntExact(index >>> shift), expect, update);
+        }
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new ReferenceArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize >>> shift)), shift);
+    }
+
+    @Override
+    public Memory clone() {
+        return new ReferenceArrayMemory(array.clone(), shift);
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new ReferenceArrayMemory(new VmObject[array.length], shift);
+    }
+
+    @Override
+    public long getSize() {
+        return 0;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ShortArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ShortArrayMemory.java
@@ -1,0 +1,196 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.*;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory region which is backed by a {@code short} array which can be directly accessed.
+ */
+public final class ShortArrayMemory implements Memory {
+    private static final VarHandle h16 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, short[].class);
+
+    private final short[] array;
+
+    ShortArrayMemory(short[] array) {
+        this.array = array;
+    }
+
+    public short[] getArray() {
+        return array;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            return array[Math.toIntExact(index >>> 1)] & 0xffff;
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) h16.getOpaque(array, Math.toIntExact(index >>> 1)) & 0xffff;
+        } else if (GlobalAcquire.includes(mode)) {
+            return (int) h16.getAcquire(array, Math.toIntExact(index >>> 1)) & 0xffff;
+        } else {
+            return (int) h16.getVolatile(array, Math.toIntExact(index >>> 1)) & 0xffff;
+        }
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        if (GlobalPlain.includes(mode)) {
+            array[Math.toIntExact(index >>> 1)] = (short) value;
+        } else if (SingleOpaque.includes(mode)) {
+            h16.setOpaque(array, Math.toIntExact(index >>> 1), (short) value);
+        } else if (GlobalRelease.includes(mode)) {
+            h16.setRelease(array, Math.toIntExact(index >>> 1), (short) value);
+        } else {
+            h16.setVolatile(array, Math.toIntExact(index >>> 1), (short) value);
+        }
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = array[Math.toIntExact(index >>> 1)] & 0xffff;
+            if (val == (expect & 0xffff)) {
+                array[Math.toIntExact(index >>> 1)] = (short) update;
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) h16.compareAndExchangeAcquire(array, Math.toIntExact(index >>> 1), (short) expect, (short) update) & 0xffff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) h16.compareAndExchangeRelease(array, Math.toIntExact(index >>> 1), (short) expect, (short) update) & 0xffff;
+        } else {
+            return (int) h16.compareAndExchange(array, Math.toIntExact(index >>> 1), (short) expect, (short) update) & 0xffff;
+        }
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new ShortArrayMemory(Arrays.copyOf(array, Math.toIntExact(newSize >>> 1)));
+    }
+
+    @Override
+    public Memory clone() {
+        return new ShortArrayMemory(array.clone());
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new ShortArrayMemory(new short[array.length]);
+    }
+
+    @Override
+    public long getSize() {
+        return (long) array.length << 1;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/VectorMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/VectorMemory.java
@@ -1,0 +1,236 @@
+package org.qbicc.interpreter.memory;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory which is backed by an array of a uniform delegate memory.
+ */
+public final class VectorMemory implements Memory {
+    private final long divisor;
+    private final Memory[] memories;
+
+    /**
+     * Create a memory backed by a given memory followed by {@code count - 1}
+     * clones of the given memory.
+     *
+     * @param first the first memory in the array (must not be {@code null})
+     * @param count the number of copies to make.
+     */
+    VectorMemory(Memory first, int count) {
+        if (count < 1) {
+            throw new IllegalArgumentException("Must have at least one element");
+        }
+        memories = new Memory[count];
+        memories[0] = first;
+        for (int i = 1; i < count; i ++) {
+            memories[i] = first.clone();
+        }
+        divisor = first.getSize();
+    }
+
+    VectorMemory(final VectorMemory orig, final boolean zero) {
+        divisor = orig.divisor;
+        final int count = orig.memories.length;
+        memories = new Memory[count];
+        for (int i = 0; i < count; i ++) {
+            final Memory origMemory = orig.memories[i];
+            memories[i] = zero ? origMemory.cloneZeroed() : origMemory.clone();
+        }
+    }
+
+    VectorMemory(final VectorMemory orig, final int newCount) {
+        divisor = orig.divisor;
+        final int oldCount = orig.memories.length;
+        final int count = Math.min(oldCount, newCount);
+        memories = new Memory[newCount];
+        for (int i = 0; i < count; i ++) {
+            memories[i] = orig.memories[i].clone();
+        }
+        for (int i = oldCount; i < newCount; i ++) {
+            memories[i] = orig.memories[oldCount - 1].cloneZeroed();
+        }
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].load8(offset, mode);
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].load16(offset, mode);
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].load32(offset, mode);
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].load64(offset, mode);
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].loadRef(offset, mode);
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].loadType(offset, mode);
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].loadPointer(offset, mode);
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        memories[number].store8(offset, value, mode);
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        memories[number].store16(offset, value, mode);
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        memories[number].store32(offset, value, mode);
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        memories[number].store64(offset, value, mode);
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        memories[number].storeRef(offset, value, mode);
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        memories[number].storeType(offset, value, mode);
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        memories[number].storePointer(offset, value, mode);
+    }
+
+    @Override
+    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].compareAndExchange8(offset, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].compareAndExchange16(offset, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].compareAndExchange32(offset, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].compareAndExchange64(offset, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].compareAndExchangeRef(offset, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].compareAndExchangeType(offset, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        int number = (int) (index / divisor);
+        long offset = index % divisor;
+        return memories[number].compareAndExchangePointer(offset, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        // round up
+        return new VectorMemory(this, (int) ((newSize + divisor - 1) / divisor));
+    }
+
+    @Override
+    public Memory clone() {
+        return new VectorMemory(this, false);
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return new VectorMemory(this, true);
+    }
+
+    @Override
+    public long getSize() {
+        return memories.length * divisor;
+    }
+}

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -8,6 +8,7 @@ import org.qbicc.interpreter.VmArray;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmStaticFieldBaseObject;
+import org.qbicc.interpreter.VmReferenceArray;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
@@ -104,12 +105,7 @@ class BuildtimeHeapAnalyzer {
             } else if (ot instanceof ReferenceArrayObjectType) {
                 analysis.processArrayElementType(((ReferenceArrayObjectType) ot).getLeafElementType());
 
-                FieldElement contentsField = coreClasses.getRefArrayContentField();
-                LayoutInfo info = interpreterLayout.getInstanceLayoutInfo(contentsField.getEnclosingType());
-                Memory memory = cur.getMemory();
-                int length = memory.load32(info.getMember(coreClasses.getArrayLengthField()).getOffset(), SinglePlain);
-                for (int i=0; i<length; i++) {
-                    VmObject e = memory.loadRef(((VmArray) cur).getArrayElementOffset(i), SinglePlain);
+                for (VmObject e : ((VmReferenceArray) cur).getArray()) {
                     if (e != null && !visited.containsKey(e)) {
                         worklist.add(e);
                         visited.put(e, Boolean.TRUE);

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -19,6 +19,7 @@ import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmArray;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.VmReferenceArray;
 import org.qbicc.object.Data;
 import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Linkage;
@@ -338,8 +339,9 @@ public class BuildtimeHeap {
         populateMemberMap(concreteType.load(), objType, objLayout, memLayout, memory, memberMap);
 
         List<Literal> elements = new ArrayList<>(length);
+        VmObject[] elementArray = ((VmReferenceArray) value).getArray();
         for (int i=0; i<length; i++) {
-            VmObject e = memory.loadRef(value.getArrayElementOffset(i), SinglePlain);
+            VmObject e = elementArray[i];
             if (e == null) {
                 elements.add(lf.zeroInitializerLiteralOfType(at.getElementType()));
             } else {
@@ -373,41 +375,45 @@ public class BuildtimeHeap {
 
         Literal arrayContentsLiteral;
         if (contentsField.equals(coreClasses.getByteArrayContentField())) {
-            byte[] contents = new byte[length];
-            for (int i=0; i<length; i++) {
-                contents[i] = (byte)memory.load8(value.getArrayElementOffset(i), SinglePlain);
-            }
+            byte[] contents = (byte[]) value.getArray();
             arrayContentsLiteral = lf.literalOf(ctxt.getTypeSystem().getArrayType(at.getElementType(), length), contents);
         } else {
             List<Literal> elements = new ArrayList<>(length);
             if (contentsField.equals(coreClasses.getBooleanArrayContentField())) {
+                boolean[] contents = (boolean[]) value.getArray();
                 for (int i=0; i<length; i++) {
-                    elements.add(lf.literalOf(memory.load8(value.getArrayElementOffset(i), SinglePlain) != 0));
+                    elements.add(lf.literalOf(contents[i]));
                 }
             } else if (contentsField.equals(coreClasses.getShortArrayContentField())) {
+                short[] contents = (short[]) value.getArray();
                 for (int i=0; i<length; i++) {
-                    elements.add(lf.literalOf(ts.getSignedInteger16Type(), memory.load16(value.getArrayElementOffset(i), SinglePlain)));
+                    elements.add(lf.literalOf(contents[i]));
                 }
             } else if (contentsField.equals(coreClasses.getCharArrayContentField())) {
+                char[] contents = (char[]) value.getArray();
                 for (int i=0; i<length; i++) {
-                    elements.add(lf.literalOf(ts.getUnsignedInteger16Type(), memory.load16(value.getArrayElementOffset(i), SinglePlain)));
+                    elements.add(lf.literalOf(contents[i]));
                 }
             } else if (contentsField.equals(coreClasses.getIntArrayContentField())) {
+                int[] contents = (int[]) value.getArray();
                 for (int i=0; i<length; i++) {
-                    elements.add(lf.literalOf(ts.getSignedInteger32Type(), memory.load32(value.getArrayElementOffset(i), SinglePlain)));
+                    elements.add(lf.literalOf(contents[i]));
                 }
             } else if (contentsField.equals(coreClasses.getLongArrayContentField())) {
+                long[] contents = (long[]) value.getArray();
                 for (int i=0; i<length; i++) {
-                    elements.add(lf.literalOf(ts.getSignedInteger64Type(), memory.load64(value.getArrayElementOffset(i), SinglePlain)));
+                    elements.add(lf.literalOf(contents[i]));
                 }
             } else if (contentsField.equals(coreClasses.getFloatArrayContentField())) {
+                float[] contents = (float[]) value.getArray();
                 for (int i=0; i<length; i++) {
-                    elements.add(lf.literalOf(ts.getFloat32Type(), memory.loadFloat(value.getArrayElementOffset(i), SinglePlain)));
+                    elements.add(lf.literalOf(contents[i]));
                 }
             } else {
                 Assert.assertTrue((contentsField.equals(coreClasses.getDoubleArrayContentField())));
+                double[] contents = (double[]) value.getArray();
                 for (int i=0; i<length; i++) {
-                    elements.add(lf.literalOf(ts.getFloat64Type(), memory.loadDouble(value.getArrayElementOffset(i), SinglePlain)));
+                    elements.add(lf.literalOf(contents[i]));
                 }
             }
             arrayContentsLiteral = lf.literalOf(ctxt.getTypeSystem().getArrayType(at.getElementType(), length), elements);


### PR DESCRIPTION
This lays more (indirect) groundwork for handling pointers in the interpreter and also typed memory. It also eases debugging when you can directly access the array backing a `VmArray` and inspect it in the debugger.