### PR TITLE
Further pointer support

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -399,6 +399,15 @@ public interface BasicBlockBuilder extends Locatable {
 
     ValueHandle staticMethod(TypeDescriptor owner, String name, MethodDescriptor descriptor);
 
+    /**
+     * Create a handle for a static method pointer. The call site type must match the pointer's type. This differs
+     * from a plain pointer handle in that static method pointers can be lowered to the appropriate function shape.
+     *
+     * @param pointer the static method pointer (must not be {@code null})
+     * @return the value handle (not {@code null})
+     */
+    ValueHandle staticMethodPointer(Value pointer);
+
     ValueHandle constructorOf(Value instance, ConstructorElement constructor, MethodDescriptor callSiteDescriptor, FunctionType callSiteType);
 
     /**

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -205,6 +205,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().staticMethod(owner, name, descriptor);
     }
 
+    public ValueHandle staticMethodPointer(final Value pointer) {
+        return getDelegate().staticMethodPointer(pointer);
+    }
+
     public ValueHandle constructorOf(Value instance, ConstructorElement constructor, MethodDescriptor callSiteDescriptor, FunctionType callSiteType) {
         return getDelegate().constructorOf(instance, constructor, callSiteDescriptor, callSiteType);
     }

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -23,6 +23,7 @@ import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.MethodHandleLiteral;
 import org.qbicc.graph.literal.NullLiteral;
 import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.graph.literal.PointerLiteral;
 import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
@@ -795,6 +796,10 @@ public interface Node {
             public Value visit(final Copier param, final PhiValue node) {
                 param.enqueue(node);
                 return param.getBlockBuilder().phi(node.getType(), param.copyBlock(node.getPinnedBlock()), node.possibleValuesAreNullable() ? NO_FLAGS : NOT_NULL_FLAGS);
+            }
+
+            public Value visit(final Copier param, final PointerLiteral node) {
+                return node;
             }
 
             public Value visit(final Copier param, final PopCount node) {

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -851,6 +851,10 @@ public interface Node {
                 return param.getBlockBuilder().staticMethod(node.getExecutable(), node.getCallSiteDescriptor(), node.getCallSiteType());
             }
 
+            public ValueHandle visit(Copier param, StaticMethodPointerHandle node) {
+                return param.getBlockBuilder().staticMethodPointer(param.copyValue(node.getStaticMethodPointer()));
+            }
+
             public Node visit(final Copier param, final Store node) {
                 param.copyNode(node.getDependency());
                 return param.getBlockBuilder().store(param.copyValueHandle(node.getValueHandle()), param.copyValue(node.getValue()), node.getAccessMode());

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -497,6 +497,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         throw new IllegalStateException("Unresolved static method");
     }
 
+    public ValueHandle staticMethodPointer(Value pointer) {
+        return new StaticMethodPointerHandle(element, line, bci, pointer);
+    }
+
     public ValueHandle constructorOf(Value instance, ConstructorElement constructor, MethodDescriptor callSiteDescriptor, FunctionType callSiteType) {
         return new ConstructorElementHandle(element, line, bci, constructor, instance, callSiteDescriptor, callSiteType);
     }

--- a/compiler/src/main/java/org/qbicc/graph/StaticMethodPointerHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/StaticMethodPointerHandle.java
@@ -1,0 +1,75 @@
+package org.qbicc.graph;
+
+import org.qbicc.graph.atomic.AccessMode;
+import org.qbicc.graph.atomic.AccessModes;
+import org.qbicc.type.FunctionType;
+import org.qbicc.type.PointerType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * A handle for a pointer to a static method.
+ */
+public final class StaticMethodPointerHandle extends AbstractValueHandle {
+    private final Value staticMethodPointer;
+
+    StaticMethodPointerHandle(ExecutableElement element, int line, int bci, Value staticMethodPointer) {
+        super(null, element, line, bci);
+        // check type of pointer early
+        //noinspection RedundantClassCall
+        FunctionType.class.cast(PointerType.class.cast(staticMethodPointer.getType()).getPointeeType());
+        this.staticMethodPointer = staticMethodPointer;
+    }
+
+    @Override
+    int calcHashCode() {
+        return staticMethodPointer.hashCode();
+    }
+
+    @Override
+    public PointerType getPointerType() {
+        return (PointerType) staticMethodPointer.getType();
+    }
+
+    @Override
+    public boolean isConstantLocation() {
+        return staticMethodPointer.isConstant();
+    }
+
+    @Override
+    public boolean isValueConstant() {
+        return staticMethodPointer.isConstant();
+    }
+
+    @Override
+    public AccessMode getDetectedMode() {
+        return AccessModes.SingleUnshared;
+    }
+
+    public Value getStaticMethodPointer() {
+        return staticMethodPointer;
+    }
+
+    @Override
+    public <T, R> R accept(ValueHandleVisitor<T, R> visitor, T param) {
+        return visitor.visit(param, this);
+    }
+
+    @Override
+    public <T> long accept(ValueHandleVisitorLong<T> visitor, T param) {
+        return visitor.visit(param, this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof StaticMethodPointerHandle ph && equals(ph);
+    }
+
+    public boolean equals(StaticMethodPointerHandle other) {
+        return this == other || other != null && staticMethodPointer.equals(other.staticMethodPointer);
+    }
+
+    @Override
+    String getNodeName() {
+        return "StaticMethodPointer";
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitor.java
@@ -68,6 +68,10 @@ public interface ValueHandleVisitor<T, R> {
         return visitUnknown(param, node);
     }
 
+    default R visit(T param, StaticMethodPointerHandle node) {
+        return visitUnknown(param, node);
+    }
+
     default R visit(T param, UnsafeHandle node) {
         return visitUnknown(param, node);
     }
@@ -160,6 +164,11 @@ public interface ValueHandleVisitor<T, R> {
 
         @Override
         default R visit(T param, StaticMethodElementHandle node) {
+            return getDelegateValueHandleVisitor().visit(param, node);
+        }
+
+        @Override
+        default R visit(T param, StaticMethodPointerHandle node) {
             return getDelegateValueHandleVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitorLong.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueHandleVisitorLong.java
@@ -68,6 +68,10 @@ public interface ValueHandleVisitorLong<T> {
         return visitUnknown(param, node);
     }
 
+    default long visit(T param, StaticMethodPointerHandle node) {
+        return visitUnknown(param, node);
+    }
+
     default long visit(T param, UnsafeHandle node) {
         return visitUnknown(param, node);
     }

--- a/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
@@ -13,6 +13,7 @@ import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.MethodHandleLiteral;
 import org.qbicc.graph.literal.NullLiteral;
 import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.graph.literal.PointerLiteral;
 import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
@@ -309,6 +310,10 @@ public interface ValueVisitor<T, R> {
     }
 
     default R visit(T param, PhiValue node) {
+        return visitUnknown(param, node);
+    }
+
+    default R visit(T param, PointerLiteral node) {
         return visitUnknown(param, node);
     }
 
@@ -668,6 +673,10 @@ public interface ValueVisitor<T, R> {
         }
 
         default R visit(T param, PhiValue node) {
+            return getDelegateValueVisitor().visit(param, node);
+        }
+
+        default R visit(T param, PointerLiteral node) {
             return getDelegateValueVisitor().visit(param, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/literal/LiteralFactory.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/LiteralFactory.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import org.qbicc.graph.BlockLabel;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.object.ProgramObject;
+import org.qbicc.pointer.Pointer;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.CompoundType;
@@ -75,6 +76,8 @@ public interface LiteralFactory {
     Literal valueConvertLiteral(Literal value, WordType toType);
 
     Literal elementOfLiteral(Literal value, Literal index);
+
+    PointerLiteral literalOf(Pointer value);
 
     static LiteralFactory create(TypeSystem typeSystem) {
         return new LiteralFactory() {
@@ -249,6 +252,12 @@ public interface LiteralFactory {
                 } else {
                     throw new IllegalArgumentException("Invalid input type: " + inputType);
                 }
+            }
+
+            @Override
+            public PointerLiteral literalOf(Pointer value) {
+                Assert.checkNotNullParam("value", value);
+                return new PointerLiteral(value);
             }
         };
     }

--- a/compiler/src/main/java/org/qbicc/graph/literal/PointerLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/PointerLiteral.java
@@ -1,0 +1,59 @@
+package org.qbicc.graph.literal;
+
+import org.qbicc.graph.ValueVisitor;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.PointerType;
+import org.qbicc.type.ValueType;
+
+/**
+ * A literal referring to some program object.
+ */
+public final class PointerLiteral extends Literal {
+    private final Pointer pointer;
+
+    PointerLiteral(Pointer pointer) {
+        this.pointer = pointer;
+    }
+
+    @Override
+    public StringBuilder toString(StringBuilder b) {
+        return b.append(pointer);
+    }
+
+    @Override
+    public PointerType getType() {
+        return pointer.getType();
+    }
+
+    public ValueType getValueType() {
+        return getType().getPointeeType();
+    }
+
+    public Pointer getPointer() {
+        return pointer;
+    }
+
+    @Override
+    public <T, R> R accept(ValueVisitor<T, R> visitor, T param) {
+        return visitor.visit(param, this);
+    }
+
+    @Override
+    public boolean isZero() {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Literal other) {
+        return other instanceof PointerLiteral pol && equals(pol);
+    }
+
+    public boolean equals(PointerLiteral other) {
+        return this == other || other != null && pointer.equals(other.pointer);
+    }
+
+    @Override
+    public int hashCode() {
+        return pointer.hashCode();
+    }
+}

--- a/compiler/src/main/java/org/qbicc/pointer/IntegerAsPointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/IntegerAsPointer.java
@@ -8,7 +8,7 @@ import org.qbicc.type.PointerType;
 public final class IntegerAsPointer extends RootPointer {
     private final long value;
 
-    IntegerAsPointer(PointerType type, long value) {
+    public IntegerAsPointer(PointerType type, long value) {
         super(type);
         this.value = value;
     }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -145,6 +145,7 @@ import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmInvokable;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmThrowable;
+import org.qbicc.interpreter.pointer.MemoryPointer;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
@@ -1931,8 +1932,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
     @Override
     public Object visit(VmThreadImpl thread, StackAllocation node) {
-        // todo return new MemoryAllocation(node.getType(), node.getCount())
-        throw new UnsupportedOperationException("stack allocation");
+        return new MemoryPointer(node.getType(), thread.vm.allocate(node.getType().getPointeeType(), unboxLong(node.getCount())));
     }
 
     ///////////

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -135,6 +135,7 @@ import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.NullLiteral;
 import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.graph.literal.PointerLiteral;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.graph.literal.UndefinedLiteral;
@@ -1348,13 +1349,18 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     }
 
     @Override
+    public Object visit(VmThreadImpl param, NullLiteral node) {
+        return null;
+    }
+
+    @Override
     public Object visit(VmThreadImpl thread, ObjectLiteral node) {
         return node.getValue();
     }
 
     @Override
-    public Object visit(VmThreadImpl param, NullLiteral node) {
-        return null;
+    public Object visit(VmThreadImpl param, PointerLiteral node) {
+        return node.getPointer();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -105,6 +105,7 @@ import org.qbicc.graph.Shr;
 import org.qbicc.graph.StackAllocation;
 import org.qbicc.graph.StaticField;
 import org.qbicc.graph.StaticMethodElementHandle;
+import org.qbicc.graph.StaticMethodPointerHandle;
 import org.qbicc.graph.Store;
 import org.qbicc.graph.Sub;
 import org.qbicc.graph.Switch;
@@ -2274,6 +2275,11 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         @Override
         public ExecutableElement visit(Frame frame, StaticMethodElementHandle node) {
             return node.getExecutable();
+        }
+
+        @Override
+        public ExecutableElement visit(Frame frame, StaticMethodPointerHandle node) {
+            return ((StaticMethodPointer)frame.require(node.getStaticMethodPointer())).getStaticMethod();
         }
     };
 

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -82,6 +82,7 @@ import org.qbicc.plugin.llvm.LLVMCompileStage;
 import org.qbicc.plugin.llvm.LLVMGenerator;
 import org.qbicc.plugin.lowering.FunctionLoweringElementHandler;
 import org.qbicc.plugin.lowering.InvocationLoweringBasicBlockBuilder;
+import org.qbicc.plugin.lowering.MemberPointerCopier;
 import org.qbicc.plugin.lowering.StaticFieldLoweringBasicBlockBuilder;
 import org.qbicc.plugin.lowering.ThrowExceptionHelper;
 import org.qbicc.plugin.lowering.ThrowLoweringBasicBlockBuilder;
@@ -486,6 +487,7 @@ public class Main implements Callable<DiagnosticContext> {
                                     builder.addCopyFactory(Phase.LOWER, PhiOptimizerVisitor::new);
                                 }
                                 builder.addCopyFactory(Phase.LOWER, BooleanAccessCopier::new);
+                                builder.addCopyFactory(Phase.LOWER, MemberPointerCopier::new);
                                 builder.addCopyFactory(Phase.LOWER, ObjectLiteralSerializingVisitor::new);
 
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ThrowLoweringBasicBlockBuilder::new);

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotNodeVisitor.java
@@ -128,6 +128,7 @@ import org.qbicc.graph.UnsafeHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueReturn;
+import org.qbicc.graph.ValueVisitor;
 import org.qbicc.graph.VirtualMethodElementHandle;
 import org.qbicc.graph.Xor;
 import org.qbicc.graph.literal.BitCastLiteral;
@@ -140,6 +141,7 @@ import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.MethodHandleLiteral;
 import org.qbicc.graph.literal.NullLiteral;
 import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.graph.literal.PointerLiteral;
 import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
@@ -1230,6 +1232,10 @@ public class DotNodeVisitor implements NodeVisitor.Delegating<Appendable, String
         nl(param);
         phiQueue.add(node);
         return delegate.visit(param, node);
+    }
+
+    public String visit(final Appendable param, final PointerLiteral node) {
+        return literal(param, "pointer");
     }
 
     public String visit(final Appendable param, final PopCount node) {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
@@ -17,6 +17,7 @@ import org.qbicc.graph.FunctionElementHandle;
 import org.qbicc.graph.InterfaceMethodElementHandle;
 import org.qbicc.graph.PhiValue;
 import org.qbicc.graph.StaticMethodElementHandle;
+import org.qbicc.graph.StaticMethodPointerHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.ValueHandleVisitor;
@@ -255,6 +256,17 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
         FunctionDeclaration decl = ctxt.getImplicitSection(originalElement).declareFunction(function);
         final LiteralFactory lf = ctxt.getLiteralFactory();
         return pointerHandle(lf.literalOf(decl));
+    }
+
+    @Override
+    public ValueHandle visit(ArrayList<Value> args, StaticMethodPointerHandle node) {
+        Value pointer = node.getStaticMethodPointer();
+        final BasicBlockBuilder fb = getFirstBuilder();
+        // insert current thread only
+        ValueHandle currentThread = fb.currentThread();
+        args.add(0, fb.load(currentThread, SingleUnshared));
+        // pointer type should already have been converted by MemberPointerCopier
+        return fb.pointerHandle(pointer);
     }
 
     @Override

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
@@ -1,0 +1,85 @@
+package org.qbicc.plugin.lowering;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.Node;
+import org.qbicc.graph.NodeVisitor;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.ValueHandle;
+import org.qbicc.graph.literal.PointerLiteral;
+import org.qbicc.object.DataDeclaration;
+import org.qbicc.object.Function;
+import org.qbicc.object.Section;
+import org.qbicc.plugin.layout.Layout;
+import org.qbicc.plugin.layout.LayoutInfo;
+import org.qbicc.pointer.ElementPointer;
+import org.qbicc.pointer.InstanceFieldPointer;
+import org.qbicc.pointer.MemberPointer;
+import org.qbicc.pointer.MemoryPointer;
+import org.qbicc.pointer.OffsetPointer;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.pointer.ProgramObjectPointer;
+import org.qbicc.pointer.StaticFieldPointer;
+import org.qbicc.pointer.StaticMethodPointer;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.definition.element.MethodElement;
+
+/**
+ *
+ */
+public final class MemberPointerCopier implements NodeVisitor.Delegating<Node.Copier, Value, Node, BasicBlock, ValueHandle> {
+    private final CompilationContext ctxt;
+    private final NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle> delegate;
+
+    public MemberPointerCopier(CompilationContext ctxt, NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle> delegate) {
+        this.ctxt = ctxt;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public NodeVisitor<Node.Copier, Value, Node, BasicBlock, ValueHandle> getDelegateNodeVisitor() {
+        return delegate;
+    }
+
+    @Override
+    public Value visit(Node.Copier param, PointerLiteral node) {
+        Pointer oldPtr = node.getPointer();
+        Pointer newPtr = lowerPointer(param, oldPtr);
+        return newPtr == oldPtr ? getDelegateValueVisitor().visit(param, node) : ctxt.getLiteralFactory().literalOf(newPtr);
+    }
+
+    private Pointer lowerPointer(Node.Copier copier, Pointer pointer) {
+        if (pointer instanceof StaticMethodPointer smp) {
+            MethodElement method = smp.getStaticMethod();
+            Function function = ctxt.getExactFunction(method);
+            Section section = ctxt.getImplicitSection(copier.getBlockBuilder().getCurrentElement());
+            DataDeclaration decl = section.declareData(function);
+            return ProgramObjectPointer.of(decl);
+        } else if (pointer instanceof StaticFieldPointer sfp) {
+            FieldElement field = sfp.getStaticField();
+            GlobalVariableElement global = Lowering.get(ctxt).getStaticsGlobalForType(field.getEnclosingType().load());
+            DefinedTypeDefinition fieldHolder = field.getEnclosingType();
+            Section section = ctxt.getImplicitSection(copier.getBlockBuilder().getCurrentElement());
+            DataDeclaration decl = section.declareData(field, global.getName(), global.getType());
+            LayoutInfo layoutInfo = Layout.get(ctxt).getStaticLayoutInfo(fieldHolder);
+            assert layoutInfo != null; // field exists so layout is non empty
+            return new MemberPointer(ProgramObjectPointer.of(decl), layoutInfo.getMember(field));
+        } else if (pointer instanceof ElementPointer ep) {
+            return new ElementPointer(lowerPointer(copier, ep.getArrayPointer()), ep.getIndex());
+        } else if (pointer instanceof MemberPointer mp) {
+            return new MemberPointer(lowerPointer(copier, mp.getStructurePointer()), mp.getMember());
+        } else if (pointer instanceof OffsetPointer op) {
+            return lowerPointer(copier, op.getBasePointer()).offsetByElements(op.getOffset());
+        } else if (pointer instanceof InstanceFieldPointer ifp) {
+            FieldElement field = ifp.getFieldElement();
+            return new MemberPointer(lowerPointer(copier, ifp.getObjectPointer()), Layout.get(ctxt).getInstanceLayoutInfo(field.getEnclosingType()).getMember(field));
+        } else if (pointer instanceof MemoryPointer) {
+            throw new UnsupportedOperationException("Lowering arbitrary memory is not supported");
+        } else {
+            return pointer;
+        }
+    }
+
+}

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -27,12 +27,14 @@ import org.qbicc.object.Section;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
+import org.qbicc.pointer.Pointer;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.PhysicalObjectType;
+import org.qbicc.type.PointerType;
 import org.qbicc.type.Primitive;
 import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
@@ -316,6 +318,13 @@ public class BuildtimeHeap {
                     memberMap.put(om, lf.zeroInitializerLiteralOfType(om.getType()));
                 } else {
                     memberMap.put(om, lf.bitcastLiteral(serializeVmObject(contents), (WordType) om.getType()));
+                }
+            } else if (im.getType() instanceof PointerType pt) {
+                Pointer pointer = memory.loadPointer(im.getOffset(), SinglePlain);
+                if (pointer == null) {
+                    memberMap.put(om, lf.nullLiteralOfType(pt));
+                } else {
+                    memberMap.put(om, lf.literalOf(pointer));
                 }
             } else {
                 throw new UnsupportedOperationException("Serialization of unsupported member type: " + im.getType());


### PR DESCRIPTION
Add more support for manipulating pointer values in the interpreter, and ensure that pointers to static methods and fields can be properly lowered, including reachability support.