### PR TITLE
add command line option to disable llvm compilation of output files

### DIFF
--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
@@ -7,16 +7,20 @@ import java.util.function.Consumer;
 
 public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContext> {
     private final boolean isPie;
+    private final boolean compileOutput;
 
-    public LLVMDefaultModuleCompileStage(boolean isPie) {
+    public LLVMDefaultModuleCompileStage(boolean isPie, boolean compileOutput) {
         this.isPie = isPie;
+        this.compileOutput = compileOutput;
     }
 
     @Override
     public void accept(CompilationContext context) {
         LLVMModuleGenerator generator = new LLVMModuleGenerator(context, isPie ? 2 : 0, isPie ? 2 : 0);
         Path modulePath = generator.processProgramModule(context.getProgramModule(context.getDefaultTypeDefinition()));
-        LLVMCompiler compiler = new LLVMCompiler(context, isPie);
-        compiler.compileModule(context, modulePath);
+        if (compileOutput) {
+            LLVMCompiler compiler = new LLVMCompiler(context, isPie);
+            compiler.compileModule(context, modulePath);
+        }
     }
 }


### PR DESCRIPTION
The llvm compilation of the generated .ll files represents about 75% of total wall clock compilation time. Allow the user a way to skip this stage if they are only interested in the generated .ll files (and not the actual executable).