### PR TITLE
Fix a bug where hidden classes cannot load themselves by name

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -785,9 +785,7 @@ public final class VmImpl implements Vm {
                     enclosing = enclosing.enclosing;
                 }
                 DefinedTypeDefinition def = enclosing.element.getEnclosingType();
-                VmClassLoaderImpl cl = ((VmThreadImpl)thread).vm.getClassLoaderForContext(def.getContext());
-                VmClassImpl clazz = cl.loadClass(def.getInternalName());
-                return clazz;
+                return def.load().getVmClass();
             });
             reflectClass.registerInvokable("getClassAccessFlags", (thread, target, args) -> {
                 VmClassImpl cls = (VmClassImpl)args.get(0);


### PR DESCRIPTION
Just use the definition that is already on hand.