### PR TITLE
Reachability improvements

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/CompilationContext.java
+++ b/compiler/src/main/java/org/qbicc/context/CompilationContext.java
@@ -65,6 +65,8 @@ public interface CompilationContext extends DiagnosticContext {
 
     boolean wasEnqueued(ExecutableElement element);
 
+    int numberEnqueued();
+
     NativeMethodConfigurator getNativeMethodConfigurator();
 
     ExecutableElement dequeue();

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -87,6 +87,10 @@ public class TestClassContext implements ClassContext {
             return false;
         }
 
+        public int numberEnqueued() {
+            return 0;
+        }
+
         public NativeMethodConfigurator getNativeMethodConfigurator() {
             return null;
         }

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -342,6 +342,10 @@ final class CompilationContextImpl implements CompilationContext {
         queued.clear();
     }
 
+    public int numberEnqueued() {
+        return queued.size();
+    }
+
     public void registerEntryPoint(final ExecutableElement method) {
         enqueue(method);
         entryPoints.add(method);

--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
@@ -280,7 +280,7 @@ public class DispatchTables {
                 } else {
                     Function impl = methImpl.isNative() ? null : ctxt.getExactFunctionIfExists(methImpl);
                     if (impl == null) {
-                        if (!methImpl.isNative() && ReachabilityInfo.get(ctxt).isInvokableMethod(methImpl)) {
+                        if (!methImpl.isNative() && ReachabilityInfo.get(ctxt).isDispatchableMethod(methImpl)) {
                             ctxt.error(methImpl, "Missing method implementation for vtable of %s", cls.getInternalName());
                         } else {
                             MethodElement uleStub = methodFinder.getMethod("raiseUnsatisfiedLinkError");

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisInterMethodAnalysis.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisInterMethodAnalysis.java
@@ -176,7 +176,7 @@ public class EscapeAnalysisInterMethodAnalysis implements Consumer<CompilationCo
 
         // TODO this does not seem to be really working (that's why there's the workaround in CG.updateAfterInvokingMethod)
         private boolean isReachable(ExecutableElement executable) {
-            return executable instanceof MethodElement && rta.isInvokableMethod((MethodElement) executable);
+            return executable instanceof MethodElement && rta.isDispatchableMethod((MethodElement) executable);
         }
     }
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -3,9 +3,6 @@ package org.qbicc.plugin.reachability;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.ObjectLiteral;
-import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmArray;
-import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmStaticFieldBaseObject;
 import org.qbicc.interpreter.VmReferenceArray;
@@ -106,7 +103,7 @@ class BuildtimeHeapAnalyzer {
                     } else if (im.getType() instanceof PointerType) {
                         Pointer pointer = cur.getMemory().loadPointer(im.getOffset(), SinglePlain);
                         if (pointer instanceof StaticMethodPointer smp) {
-                            analysis.processReachableStaticInvoke(smp.getStaticMethod(), rootElement);
+                            analysis.processReachableExactInvocation(smp.getStaticMethod(), rootElement);
                         }
                     }
                 }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
@@ -45,8 +45,11 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
 
     private final BuildtimeHeapAnalyzer heapAnalyzer = new BuildtimeHeapAnalyzer();
 
-    // Set of reachable, but not yet invokable, instance methods
-    private final Set<MethodElement> deferredInstanceMethods = ConcurrentHashMap.newKeySet();
+    // Set of dispatchable, but not yet invokable, instance methods
+    private final Set<MethodElement> deferredDispatchableMethods = ConcurrentHashMap.newKeySet();
+
+    // Set of invoked, but not yet invokable, instance methods
+    private final Set<MethodElement> deferredExactMethods = ConcurrentHashMap.newKeySet();
 
     RapidTypeAnalysis(ReachabilityInfo info, CompilationContext ctxt) {
         this.info = info;
@@ -65,45 +68,55 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
         }
     }
 
-    public synchronized void processBuildtimeInstantiatedObjectType(LoadedTypeDefinition ltd, ExecutableElement originalElement) {
-        processInstantiatedClass(ltd, true, true, originalElement);
+    public synchronized void processBuildtimeInstantiatedObjectType(LoadedTypeDefinition ltd, ExecutableElement currentElement) {
+        processInstantiatedClass(ltd, true, true, currentElement);
         processClassInitialization(ltd);
     }
 
-    public synchronized void processReachableObjectLiteral(ObjectLiteral objectLiteral, ExecutableElement originalElement) {
-        heapAnalyzer.traceHeap(ctxt, this, objectLiteral.getValue(), originalElement);
+    public synchronized void processReachableObjectLiteral(ObjectLiteral objectLiteral, ExecutableElement currentElement) {
+        heapAnalyzer.traceHeap(ctxt, this, objectLiteral.getValue(), currentElement);
     }
 
-    public synchronized void processReachableRuntimeInitializer(final InitializerElement target, ExecutableElement originalElement) {
+    public synchronized void processReachableRuntimeInitializer(final InitializerElement target, ExecutableElement currentElement) {
         if (!ctxt.wasEnqueued(target)) {
-            ReachabilityInfo.LOGGER.debugf("Adding <rtinit> %s (potentially invoked from %s)", target, originalElement);
+            ReachabilityInfo.LOGGER.debugf("Adding <rtinit> %s (potentially invoked from %s)", target, currentElement);
             ctxt.enqueue(target);
         }
     }
 
-    public synchronized void processReachableExactInvocation(final InvokableElement target, ExecutableElement originalElement) {
+    public synchronized void processReachableExactInvocation(final InvokableElement target, ExecutableElement currentElement) {
         if (!ctxt.wasEnqueued(target)) {
-            ReachabilityInfo.LOGGER.debugf("Adding %s (invoked exactly in %s)", target, originalElement);
+            if (target instanceof MethodElement me && !me.isStatic()) {
+                LoadedTypeDefinition definingClass = me.getEnclosingType().load();
+                if (!definingClass.isInterface() && !info.isInstantiatedClass(definingClass)) {
+                    info.addReachableClass(definingClass);
+                    deferredExactMethods.add(me);
+                    ReachabilityInfo.LOGGER.debugf("Deferring method %s (invoked exactly in %s, but no instantiated receiver)", target, currentElement);
+                    return;
+                }
+            }
+
+            ReachabilityInfo.LOGGER.debugf("Adding %s %s (invoked exactly in %s)", target instanceof ConstructorElement ? "<init>" : "method", target, currentElement);
             ctxt.enqueue(target);
         }
     }
 
-    public synchronized void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement originalElement) {
-        if (!info.isInvokableMethod(target)) {
+    public synchronized void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement currentElement) {
+        if (!info.isDispatchableMethod(target)) {
             LoadedTypeDefinition definingClass = target.getEnclosingType().load();
             if (definingClass.isInterface() || info.isInstantiatedClass(definingClass)) {
-                if (originalElement == null) {
+                if (currentElement == null) {
                     ReachabilityInfo.LOGGER.debugf("\tadding method %s (dispatch mechanism induced)", target);
                 } else {
-                    ReachabilityInfo.LOGGER.debugf("Adding method %s (directly invoked in %s)", target, originalElement);
+                    ReachabilityInfo.LOGGER.debugf("Adding dispatched method %s (invoked in %s)", target, currentElement);
                 }
-                info.addInvokableMethod(target);
+                info.addDispatchableMethod(target);
                 ctxt.enqueue(target);
                 if (!target.isPrivate()) {
                     propagateInvokabilityToOverrides(target);
                     if (!definingClass.isInterface() && definingClass.getSuperClass() != null) {
                         // Because we are doing per-class vtables, we also need to ensure that if target overrides a
-                        // superclass method that the superclass method is also considered invoked to ensure compatible vtable layouts
+                        // superclass method that the superclass method is also considered dispatched to to ensure compatible vtable layouts
                         MethodElement superMethod = definingClass.getSuperClass().resolveMethodElementVirtual(target.getName(), target.getDescriptor());
                         if (superMethod != null) {
                             processReachableDispatchedInvocation(superMethod, null);
@@ -111,16 +124,16 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
                     }
                 }
             } else {
-                ReachabilityInfo.LOGGER.debugf("Deferring method %s (invoked in %s, but no instantiated receiver)", target, originalElement);
+                ReachabilityInfo.LOGGER.debugf("Deferring method %s (dispatched to in %s, but no instantiated receiver)", target, currentElement);
                 info.addReachableClass(definingClass);
-                deferredInstanceMethods.add(target);
+                deferredDispatchableMethods.add(target);
             }
         }
     }
 
-    public synchronized void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement originalElement) {
+    public synchronized void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement currentElement) {
         if (info.isInitializedType(ltd)) return;
-        ReachabilityInfo.LOGGER.debugf("Initializing %s (static access to %s in %s)", ltd.getInternalName(), cause, originalElement);
+        ReachabilityInfo.LOGGER.debugf("Initializing %s (static access to %s in %s)", ltd.getInternalName(), cause, currentElement);
         if (ltd.isInterface()) {
             info.addReachableInterface(ltd);
             // JLS: accessing a static field/method of an interface only causes local <clinit> execution
@@ -157,13 +170,13 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
         }
     }
 
-    public synchronized void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement originalElement) {
+    public synchronized void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement currentElement) {
         if (info.isInstantiatedClass(type)) return;
 
         if (onHeapType) {
-            ReachabilityInfo.LOGGER.debugf("Adding class %s (heap reachable from %s)", type.getDescriptor().getClassName(), originalElement);
+            ReachabilityInfo.LOGGER.debugf("Adding class %s (heap reachable from %s)", type.getDescriptor().getClassName(), currentElement);
         } else if (directlyInstantiated) {
-            ReachabilityInfo.LOGGER.debugf("Adding class %s (instantiated in %s)", type.getDescriptor().getClassName(), originalElement);
+            ReachabilityInfo.LOGGER.debugf("Adding class %s (instantiated in %s)", type.getDescriptor().getClassName(), currentElement);
         } else {
             ReachabilityInfo.LOGGER.debugf("\tadding ancestor class: %s", type.getDescriptor().getClassName());
         }
@@ -173,7 +186,7 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
         // It's critical that we recur to handle our superclass first.  That means all of its invokable/deferred methods
         // that we override will be processed before we process our own defined instance methods below.
         if (type.hasSuperClass()) {
-            processInstantiatedClass(type.getSuperClass(), false, false, originalElement);
+            processInstantiatedClass(type.getSuperClass(), false, false, currentElement);
         }
 
         // TODO: Now that we are explicitly tracking directly invoked deferred methods, we might be able to
@@ -181,21 +194,26 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
         //       adds overridden invoked methods to the deferred set in addReachableClass and processInvokableInstanceMethod
         //       It's not clear yet which of these options is simpler/more efficient/more maintainable...
 
-        // For every instance method that is not already invokable,
+        // For every instance method that is not already dispatchable,
         // check to see if it is either (a) a deferred invoked method or (b) overriding an invokable method and thus should be enqueued.
         for (MethodElement im : type.getInstanceMethods()) {
-            if (!info.isInvokableMethod(im)) {
-                if (isDeferredInstanceMethod(im)) {
-                    ReachabilityInfo.LOGGER.debugf("\tnewly reachable class: invoking deferred instance method: %s", im);
-                    deferredInstanceMethods.remove(im);
+            if (!info.isDispatchableMethod(im)) {
+                if (isDeferredDispatchableMethod(im)) {
+                    ReachabilityInfo.LOGGER.debugf("\tnewly reachable class: dispatching to deferred instance method: %s", im);
+                    deferredDispatchableMethods.remove(im);
                     processReachableDispatchedInvocation(im, null);
                 } else if (type.hasSuperClass()) {
                     MethodElement overiddenMethod = type.getSuperClass().resolveMethodElementVirtual(im.getName(), im.getDescriptor());
-                    if (overiddenMethod != null && info.isInvokableMethod(overiddenMethod)) {
-                        ReachabilityInfo.LOGGER.debugf("\tnewly reachable class: enqueued overriding instance method: %s", im);
-                        info.addInvokableMethod(im);
+                    if (overiddenMethod != null && info.isDispatchableMethod(overiddenMethod)) {
+                        ReachabilityInfo.LOGGER.debugf("\tnewly reachable class: dispatching to overriding instance method: %s", im);
+                        info.addDispatchableMethod(im);
                         ctxt.enqueue(im);
                     }
+                }
+                if (isDeferredExactMethod(im)) {
+                    ReachabilityInfo.LOGGER.debugf("\tnewly reachable class: invoking deferred exact method: %s", im);
+                    deferredExactMethods.remove(im);
+                    processReachableExactInvocation(im, null);
                 }
             }
         }
@@ -203,11 +221,12 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
         // For every invokable interface method, make sure my implementation of that method is invokable.
         for (LoadedTypeDefinition i : type.getInterfaces()) {
             for (MethodElement sig : i.getInstanceMethods()) {
-                if (info.isInvokableMethod(sig)) {
+                if (info.isDispatchableMethod(sig)) {
                     MethodElement impl = type.resolveMethodElementVirtual(sig.getName(), sig.getDescriptor());
-                    if (impl != null && !info.isInvokableMethod(impl)) {
-                        ReachabilityInfo.LOGGER.debugf("\tnewly reachable class: simulating invoke of implementing method:  %s", impl);
-                        deferredInstanceMethods.remove(impl); // might not be deferred, but remove is a no-op if it isn't present
+                    if (impl != null && !info.isDispatchableMethod(impl)) {
+                        ReachabilityInfo.LOGGER.debugf("\tnewly reachable class: simulating dispatch to implementing method:  %s", impl);
+                        deferredDispatchableMethods.remove(impl); // might not be deferred, but remove is a no-op if it isn't present
+                        deferredExactMethods.remove(impl); // might not be deferred, but remove is a no-op if it isn't present
                         processReachableDispatchedInvocation(impl, null);
                     }
                 }
@@ -216,20 +235,26 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
     }
 
     public void clear() {
-        deferredInstanceMethods.clear();
+        deferredDispatchableMethods.clear();
+        deferredExactMethods.clear();
         heapAnalyzer.clear();
     }
 
     public void reportStats() {
-        ReachabilityInfo.LOGGER.debugf("  Deferred instance methods:  %s", deferredInstanceMethods.size());
+        ReachabilityInfo.LOGGER.debugf("  Deferred dispatchable methods: %s", deferredDispatchableMethods.size());
+        ReachabilityInfo.LOGGER.debugf("  Deferred exact methods:        %s", deferredExactMethods.size());
     }
 
     /*
      * RTA Helper methods.
      */
 
-    boolean isDeferredInstanceMethod(MethodElement meth) {
-        return deferredInstanceMethods.contains(meth);
+    boolean isDeferredDispatchableMethod(MethodElement meth) {
+        return deferredDispatchableMethods.contains(meth);
+    }
+
+    boolean isDeferredExactMethod(MethodElement meth) {
+        return deferredExactMethods.contains(meth);
     }
 
     void propagateInvokabilityToOverrides(final MethodElement target) {
@@ -245,20 +270,20 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
                 } else if (info.isInstantiatedClass(c)) {
                     cand = c.resolveMethodElementVirtual(target.getName(), target.getDescriptor());
                 }
-                if (cand != null && !info.isInvokableMethod(cand)) {
-                    ReachabilityInfo.LOGGER.debugf("\tsimulating invokie of implementing method: %s", cand);
+                if (cand != null && !info.isDispatchableMethod(cand)) {
+                    ReachabilityInfo.LOGGER.debugf("\tsimulating dispatch to implementing method: %s", cand);
                     processReachableDispatchedInvocation(cand, null);
                 }
             });
         } else {
             // Traverse the instantiated subclasses of target's defining class and
-            // ensure that all overriding implementations of this method are marked invokable.
+            // ensure that all overriding implementations of this method are marked dispatchable.
             info.visitReachableSubclassesPreOrder(definingClass, (sc) -> {
                 if (info.isInstantiatedClass(sc)) {
                     MethodElement cand = sc.resolveMethodElementVirtual(target.getName(), target.getDescriptor());
-                    if (!info.isInvokableMethod(cand)) {
-                        ReachabilityInfo.LOGGER.debugf("\tadding method (subclass overrides): %s", cand);
-                        info.addInvokableMethod(cand);
+                    if (!info.isDispatchableMethod(cand)) {
+                        ReachabilityInfo.LOGGER.debugf("\tadding dispatchable method (subclass overrides): %s", cand);
+                        info.addDispatchableMethod(cand);
                         ctxt.enqueue(cand);
                     }
                 }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -4,7 +4,6 @@ import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.BasicElement;
-import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.InvokableElement;
@@ -17,21 +16,21 @@ import org.qbicc.type.definition.element.MethodElement;
 interface ReachabilityAnalysis {
      void processArrayElementType(ObjectType elemType);
 
-    void processBuildtimeInstantiatedObjectType(LoadedTypeDefinition ltd, ExecutableElement originalElement);
+    void processBuildtimeInstantiatedObjectType(LoadedTypeDefinition ltd, ExecutableElement currentElement);
 
-    void processReachableObjectLiteral(ObjectLiteral objectLiteral, ExecutableElement originalElement);
+    void processReachableObjectLiteral(ObjectLiteral objectLiteral, ExecutableElement currentElement);
 
-    void processReachableRuntimeInitializer(final InitializerElement target, ExecutableElement originalElement);
+    void processReachableRuntimeInitializer(final InitializerElement target, ExecutableElement currentElement);
 
-    void processReachableExactInvocation(final InvokableElement target, ExecutableElement originalElement);
+    void processReachableExactInvocation(final InvokableElement target, ExecutableElement currentElement);
 
-    void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement originalElement);
+    void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement currentElement);
 
-    void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement originalElement);
+    void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement currentElement);
 
     void processClassInitialization(final LoadedTypeDefinition ltd);
 
-    void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement originalElement);
+    void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement currentElement);
 
     void clear();
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -23,11 +23,9 @@ interface ReachabilityAnalysis {
 
     void processReachableRuntimeInitializer(final InitializerElement target, ExecutableElement originalElement);
 
-    void processReachableStaticInvoke(final InvokableElement target, ExecutableElement originalElement);
+    void processReachableExactInvocation(final InvokableElement target, ExecutableElement originalElement);
 
-    void processReachableConstructorInvoke(LoadedTypeDefinition ltd, ConstructorElement target, ExecutableElement originalElement);
-
-    void processReachableInstanceMethodInvoke(final MethodElement target, ExecutableElement originalElement);
+    void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement originalElement);
 
     void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement originalElement);
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -66,13 +66,13 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
     static final class ReachabilityContext {
         final CompilationContext ctxt;
-        private final ExecutableElement originalElement;
+        private final ExecutableElement currentElement;
         private final ReachabilityAnalysis analysis;
         final HashSet<Node> visited = new HashSet<>();
 
-        ReachabilityContext(CompilationContext ctxt, ExecutableElement originalElement) {
+        ReachabilityContext(CompilationContext ctxt, ExecutableElement currentElement) {
             this.ctxt = ctxt;
-            this.originalElement = originalElement;
+            this.currentElement = currentElement;
             this.analysis = ReachabilityInfo.get(ctxt).getAnalysis();
         }
     }
@@ -136,7 +136,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
         @Override
         public Void visit(ReachabilityContext param, ObjectLiteral value) {
-            param.analysis.processReachableObjectLiteral(value, param.originalElement);
+            param.analysis.processReachableObjectLiteral(value, param.currentElement);
             return null;
         }
 
@@ -149,22 +149,22 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
         @Override
         public Void visit(ReachabilityContext param, ReferenceAsPointer pointer) {
-            param.analysis.processReachableObjectLiteral(param.ctxt.getLiteralFactory().literalOf(pointer.getReference()), param.originalElement);
+            param.analysis.processReachableObjectLiteral(param.ctxt.getLiteralFactory().literalOf(pointer.getReference()), param.currentElement);
             return null;
         }
 
         @Override
         public Void visit(ReachabilityContext param, StaticFieldPointer pointer) {
             FieldElement f = pointer.getStaticField();
-            param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.originalElement);
+            param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.currentElement);
             return null;
         }
 
         @Override
         public Void visit(ReachabilityContext param, StaticMethodPointer pointer) {
             MethodElement target = pointer.getStaticMethod();
-            param.analysis.processStaticElementInitialization(target.getEnclosingType().load(), target, param.originalElement);
-            param.analysis.processReachableExactInvocation(target, param.originalElement);
+            param.analysis.processStaticElementInitialization(target.getEnclosingType().load(), target, param.currentElement);
+            param.analysis.processReachableExactInvocation(target, param.currentElement);
             return null;
         }
 
@@ -172,7 +172,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, ConstructorElementHandle node) {
             if (visitUnknown(param, (Node)node)) {
                 ConstructorElement target = node.getExecutable();
-                param.analysis.processReachableExactInvocation(target, param.originalElement);
+                param.analysis.processReachableExactInvocation(target, param.currentElement);
             }
             return null;
         }
@@ -181,7 +181,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, FunctionElementHandle node) {
             if (visitUnknown(param, (Node)node)) {
                 FunctionElement target = node.getExecutable();
-                param.analysis.processReachableExactInvocation(target, param.originalElement);
+                param.analysis.processReachableExactInvocation(target, param.currentElement);
             }
             return null;
         }
@@ -189,7 +189,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, ExactMethodElementHandle node) {
             if (visitUnknown(param, (Node)node)) {
-                param.analysis.processReachableDispatchedInvocation(node.getExecutable(), param.originalElement);
+                param.analysis.processReachableExactInvocation(node.getExecutable(), param.currentElement);
             }
             return null;
         }
@@ -197,7 +197,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, VirtualMethodElementHandle node) {
             if (visitUnknown(param, (Node)node)) {
-                param.analysis.processReachableDispatchedInvocation(node.getExecutable(), param.originalElement);
+                param.analysis.processReachableDispatchedInvocation(node.getExecutable(), param.currentElement);
             }
             return null;
         }
@@ -205,7 +205,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, InterfaceMethodElementHandle node) {
             if (visitUnknown(param, (Node)node)) {
-                param.analysis.processReachableDispatchedInvocation(node.getExecutable(), param.originalElement);
+                param.analysis.processReachableDispatchedInvocation(node.getExecutable(), param.currentElement);
             }
             return null;
         }
@@ -214,8 +214,8 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, StaticMethodElementHandle node) {
             if (visitUnknown(param, (Node)node)) {
                 MethodElement target = node.getExecutable();
-                param.analysis.processStaticElementInitialization(target.getEnclosingType().load(), target, param.originalElement);
-                param.analysis.processReachableExactInvocation(target, param.originalElement);
+                param.analysis.processStaticElementInitialization(target.getEnclosingType().load(), target, param.currentElement);
+                param.analysis.processReachableExactInvocation(target, param.currentElement);
             }
             return null;
         }
@@ -224,7 +224,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, New node) {
             if (visitUnknown(param, (Node)node)) {
                 LoadedTypeDefinition ltd = node.getClassObjectType().getDefinition().load();
-                param.analysis.processInstantiatedClass(ltd, true, false, param.originalElement);
+                param.analysis.processInstantiatedClass(ltd, true, false, param.currentElement);
                 param.analysis.processClassInitialization(ltd);
             }
             return null;
@@ -254,7 +254,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, StaticField node) {
             if (visitUnknown(param, (Node)node)) {
                 FieldElement f = node.getVariableElement();
-                param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.originalElement);
+                param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.currentElement);
             }
             return null;
         }
@@ -262,9 +262,9 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, InitCheck node) {
             if (visitUnknown(param, (Node)node)) {
-                param.analysis.processReachableRuntimeInitializer(node.getInitializerElement(), param.originalElement);
+                param.analysis.processReachableRuntimeInitializer(node.getInitializerElement(), param.currentElement);
                 MethodElement run = RuntimeMethodFinder.get(param.ctxt).getMethod("org/qbicc/runtime/main/Once", "run");
-                param.analysis.processReachableDispatchedInvocation(run, param.originalElement);
+                param.analysis.processReachableDispatchedInvocation(run, param.currentElement);
             }
             return null;
         }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
@@ -146,13 +146,15 @@ public class ReachabilityInfo {
         if (elem instanceof MethodElement me) {
             ReachabilityInfo info = get(elem.getEnclosingType().getContext().getCompilationContext());
             if (me.isStatic()) {
-                info.analysis.processReachableStaticInvoke(me, null);
+                info.analysis.processReachableExactInvocation(me, null);
             } else {
-                info.analysis.processReachableInstanceMethodInvoke(me, null);
+                info.analysis.processReachableDispatchedInvocation(me, null);
             }
         } else if (elem instanceof ConstructorElement ce) {
             ReachabilityInfo info = get(elem.getEnclosingType().getContext().getCompilationContext());
-            info.analysis.processReachableConstructorInvoke(ce.getEnclosingType().load(), ce, null);
+            info.analysis.processInstantiatedClass(ce.getEnclosingType().load(), true, false, null);
+            info.analysis.processClassInitialization(ce.getEnclosingType().load());
+            info.analysis.processReachableExactInvocation(ce, null);
         }
     }
 
@@ -263,7 +265,7 @@ public class ReachabilityInfo {
                     MethodElement sm = si.resolveMethodElementInterface(im.getName(), im.getDescriptor());
                     if (sm != null && isInvokableMethod(sm)) {
                         LOGGER.debugf("\tnewly reachable interface: enqueued implementing method:  %s", im);
-                        analysis.processReachableInstanceMethodInvoke(im, null);
+                        analysis.processReachableDispatchedInvocation(im, null);
                         continue outer;
                     }
                 }


### PR DESCRIPTION
Separate the notion of an invokable method and a dispatchable method in reachability analysis.

Fixes #1143.  In theory this could have reduced the number of reachable methods, in practice it did not.  Remains to be seen if it will have more impact when we switch to a more precise reachability algorithm than RTA.

