### PR TITLE
Reachability improvement for static fields

### DIFF
--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
@@ -1,24 +1,20 @@
 package org.qbicc.plugin.reachability;
 
-import io.smallrye.common.constraint.Assert;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.InterfaceObjectType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
-import org.qbicc.type.definition.element.BasicElement;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.InvokableElement;
 import org.qbicc.type.definition.element.MethodElement;
-
-import java.util.ArrayDeque;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An implementation of Rapid Type Analysis (RTA).
@@ -37,8 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
  *    class has already been instantiated.  If the class is only reachable, but not instantiated
  *    then these methods are added to a set of deferred instance methods.  If their defining class
  *    later is instantiated, these deferred methods are make invokable.
- * 4. We also handle class initialization semantics, to be able to determine which <clinit>
- *     methods become invokable.
  */
 public final class RapidTypeAnalysis implements ReachabilityAnalysis {
     private final ReachabilityInfo info;
@@ -71,7 +65,6 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
 
     public synchronized void processBuildtimeInstantiatedObjectType(LoadedTypeDefinition ltd, ExecutableElement currentElement) {
         processInstantiatedClass(ltd, true, true, currentElement);
-        processClassInitialization(ltd);
     }
 
     public synchronized void processReachableObjectLiteral(ObjectLiteral objectLiteral, ExecutableElement currentElement) {
@@ -87,10 +80,11 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
 
     public synchronized void processReachableExactInvocation(final InvokableElement target, ExecutableElement currentElement) {
         if (!ctxt.wasEnqueued(target)) {
+            processReachableType(target.getEnclosingType().load(), currentElement);
+
             if (target instanceof MethodElement me && !me.isStatic()) {
                 LoadedTypeDefinition definingClass = me.getEnclosingType().load();
                 if (!definingClass.isInterface() && !info.isInstantiatedClass(definingClass)) {
-                    info.addReachableClass(definingClass);
                     deferredExactMethods.add(me);
                     ReachabilityInfo.LOGGER.debugf("Deferring method %s (invoked exactly in %s, but no instantiated receiver)", target, currentElement);
                     return;
@@ -105,6 +99,7 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
     public synchronized void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement currentElement) {
         if (!info.isDispatchableMethod(target)) {
             LoadedTypeDefinition definingClass = target.getEnclosingType().load();
+            info.addReachableType(definingClass);
             if (definingClass.isInterface() || info.isInstantiatedClass(definingClass)) {
                 if (currentElement == null) {
                     ReachabilityInfo.LOGGER.debugf("\tadding method %s (dispatch mechanism induced)", target);
@@ -126,7 +121,6 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
                 }
             } else {
                 ReachabilityInfo.LOGGER.debugf("Deferring method %s (dispatched to in %s, but no instantiated receiver)", target, currentElement);
-                info.addReachableClass(definingClass);
                 deferredDispatchableMethods.add(target);
             }
         }
@@ -134,46 +128,14 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
 
     public synchronized void processReachableStaticFieldAccess(final FieldElement field, ExecutableElement currentElement) {
         if (!info.isAccessedStaticField(field)) {
+            processReachableType(field.getEnclosingType().load(), null);
             info.addAccessedStaticField(field);
             heapAnalyzer.traceHeap(ctxt, this, field, currentElement);
         }
     }
 
-    public synchronized void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement currentElement) {
-        if (info.isInitializedType(ltd)) return;
-        ReachabilityInfo.LOGGER.debugf("Initializing %s (static access to %s in %s)", ltd.getInternalName(), cause, currentElement);
-        if (ltd.isInterface()) {
-            info.addReachableInterface(ltd);
-            // JLS: accessing a static field/method of an interface only causes local <clinit> execution
-            info.addInitializedType(ltd);
-        } else {
-            // JLS: accessing a static field/method of a class <clinit> all the way up the class/interface hierarchy
-            processClassInitialization(ltd);
-        }
-    }
-
-    public synchronized void processClassInitialization(final LoadedTypeDefinition ltd) {
-        Assert.assertFalse(ltd.isInterface());
-        if (info.isInitializedType(ltd)) return;
-        info.addReachableClass(ltd);
-
-        if (ltd.hasSuperClass()) {
-            // force superclass initialization
-            processClassInitialization(ltd.getSuperClass());
-        }
-        info.addInitializedType(ltd);
-
-        // Annoyingly, because an intermediate interface could be marked initialized due to a static field
-        // access which doesn't cause the initialization of its superinterfaces, we can't short-circuit
-        // this walk up the entire interface hierarchy when we hit an already initialized interfaces.
-        ArrayDeque<LoadedTypeDefinition> worklist = new ArrayDeque<>(List.of(ltd.getInterfaces()));
-        while (!worklist.isEmpty()) {
-            LoadedTypeDefinition i = worklist.pop();
-            if (i.declaresDefaultMethods() && !info.isInitializedType(i)) {
-                info.addInitializedType(i);
-            }
-            worklist.addAll(List.of(i.getInterfaces()));
-        }
+    public synchronized void processReachableType(final LoadedTypeDefinition ltd, ExecutableElement currentElement) {
+        info.addReachableType(ltd);
     }
 
     public synchronized void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement currentElement) {

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -3,7 +3,6 @@ package org.qbicc.plugin.reachability;
 import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
-import org.qbicc.type.definition.element.BasicElement;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
@@ -29,9 +28,7 @@ interface ReachabilityAnalysis {
 
     void processReachableStaticFieldAccess(final FieldElement field, ExecutableElement currentElement);
 
-    void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement currentElement);
-
-    void processClassInitialization(final LoadedTypeDefinition ltd);
+    void processReachableType(final LoadedTypeDefinition ltd, ExecutableElement currentElement);
 
     void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement currentElement);
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -5,6 +5,7 @@ import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.BasicElement;
 import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.InvokableElement;
 import org.qbicc.type.definition.element.MethodElement;
@@ -25,6 +26,8 @@ interface ReachabilityAnalysis {
     void processReachableExactInvocation(final InvokableElement target, ExecutableElement currentElement);
 
     void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement currentElement);
+
+    void processReachableStaticFieldAccess(final FieldElement field, ExecutableElement currentElement);
 
     void processStaticElementInitialization(final LoadedTypeDefinition ltd, BasicElement cause, ExecutableElement currentElement);
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -165,6 +165,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, StaticFieldPointer pointer) {
             FieldElement f = pointer.getStaticField();
             param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.currentElement);
+            param.analysis.processReachableStaticFieldAccess(f, param.currentElement);
             return null;
         }
 
@@ -263,6 +264,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
             if (visitUnknown(param, (Node)node)) {
                 FieldElement f = node.getVariableElement();
                 param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.currentElement);
+                param.analysis.processReachableStaticFieldAccess(f, param.currentElement);
             }
             return null;
         }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -164,7 +164,6 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, StaticFieldPointer pointer) {
             FieldElement f = pointer.getStaticField();
-            param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.currentElement);
             param.analysis.processReachableStaticFieldAccess(f, param.currentElement);
             return null;
         }
@@ -172,7 +171,6 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, StaticMethodPointer pointer) {
             MethodElement target = pointer.getStaticMethod();
-            param.analysis.processStaticElementInitialization(target.getEnclosingType().load(), target, param.currentElement);
             param.analysis.processReachableExactInvocation(target, param.currentElement);
             return null;
         }
@@ -223,7 +221,6 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, StaticMethodElementHandle node) {
             if (visitUnknown(param, (Node)node)) {
                 MethodElement target = node.getExecutable();
-                param.analysis.processStaticElementInitialization(target.getEnclosingType().load(), target, param.currentElement);
                 param.analysis.processReachableExactInvocation(target, param.currentElement);
             }
             return null;
@@ -234,7 +231,6 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
             if (visitUnknown(param, (Node)node)) {
                 LoadedTypeDefinition ltd = node.getClassObjectType().getDefinition().load();
                 param.analysis.processInstantiatedClass(ltd, true, false, param.currentElement);
-                param.analysis.processClassInitialization(ltd);
             }
             return null;
         }
@@ -263,7 +259,6 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, StaticField node) {
             if (visitUnknown(param, (Node)node)) {
                 FieldElement f = node.getVariableElement();
-                param.analysis.processStaticElementInitialization(f.getEnclosingType().load(), f, param.currentElement);
                 param.analysis.processReachableStaticFieldAccess(f, param.currentElement);
             }
             return null;
@@ -285,7 +280,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
                 MethodElement methodElement = RuntimeMethodFinder.get(param.ctxt).getMethod("getClassFromTypeId");
                 param.ctxt.enqueue(methodElement);
                 if (node.getInput() instanceof TypeLiteral tl && tl.getValue() instanceof ClassObjectType cot) {
-                    param.analysis.processClassInitialization(cot.getDefinition().load());
+                    param.analysis.processReachableType(cot.getDefinition().load(), param.currentElement);
                 }
             }
             return null;

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
@@ -55,8 +55,6 @@ public class ReachabilityInfo {
     private final Map<LoadedTypeDefinition, Set<LoadedTypeDefinition>> interfaceHierarchy = new ConcurrentHashMap<>();
     // Tracks actually instantiated classes
     private final Set<LoadedTypeDefinition> instantiatedClasses = ConcurrentHashMap.newKeySet();
-    // Tracks classes and interfaces whose <clinit> was evaluated at build time
-    private final Set<LoadedTypeDefinition> initializedTypes = ConcurrentHashMap.newKeySet();
 
     // Set of reachable instance methods that are dispatched to (potentially invoked via vtable/itable dispatching tables)
     private final Set<MethodElement> dispatchableMethods = ConcurrentHashMap.newKeySet();
@@ -90,7 +88,6 @@ public class ReachabilityInfo {
         info.classHierarchy.clear();
         info.interfaceHierarchy.clear();
         info.instantiatedClasses.clear();
-        info.initializedTypes.clear();
         info.dispatchableMethods.clear();
         info.accessedStaticField.clear();
         info.analysis.clear();
@@ -102,7 +99,6 @@ public class ReachabilityInfo {
         LOGGER.debugf("  Reachable interfaces:          %s", info.interfaceHierarchy.size());
         LOGGER.debugf("  Reachable classes:             %s", info.classHierarchy.size());
         LOGGER.debugf("  Instantiated classes:          %s", info.instantiatedClasses.size());
-        LOGGER.debugf("  Initialized types:             %s", info.initializedTypes.size());
         LOGGER.debugf("  Reachable functions:           %s", ctxt.numberEnqueued());
         LOGGER.debugf("  Dispatchable instance methods: %s", info.dispatchableMethods.size());
         LOGGER.debugf("  Accessed static fields:        %s", info.accessedStaticField.size());
@@ -120,32 +116,27 @@ public class ReachabilityInfo {
         LoadedTypeDefinition cloneable = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Cloneable").load();
         LoadedTypeDefinition serializable = ctxt.getBootstrapClassContext().findDefinedType("java/io/Serializable").load();
         info.analysis.processInstantiatedClass(obj, true, false,null);
-        info.analysis.processClassInitialization(obj);
         info.addReachableInterface(cloneable);
         info.addReachableInterface(serializable);
         for (String d : desc) {
             LoadedTypeDefinition at = cc.getArrayLoadedTypeDefinition(d);
             info.addInterfaceEdge(at, cloneable);
             info.addInterfaceEdge(at, serializable);
-            info.addInitializedType(at);
             info.analysis.processInstantiatedClass(at, true, false,null);
         }
 
         LOGGER.debugf("Forcing java.lang.Class reachable/instantiated");
         LoadedTypeDefinition clz = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Class").load();
         info.analysis.processInstantiatedClass(clz, true, false,null);
-        info.analysis.processClassInitialization(clz);
 
         LOGGER.debugf("Forcing jdk.internal.misc.Unsafe reachable/instantiated");
         LoadedTypeDefinition unsafe = ctxt.getBootstrapClassContext().findDefinedType("jdk/internal/misc/Unsafe").load();
         info.analysis.processInstantiatedClass(unsafe, true, false,null);
-        info.analysis.processClassInitialization(unsafe);
 
         // The main Thread is instantiated in native code, and thus not visible to analysis.
         LOGGER.debugf("Forcing java.lang.Thread reachable/instantiated");
         LoadedTypeDefinition thr = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Thread").load();
         info.analysis.processInstantiatedClass(thr, true, false,null);
-        info.analysis.processClassInitialization(thr);
     }
 
     public static void processAutoQueuedElement(ExecutableElement elem) {
@@ -159,7 +150,6 @@ public class ReachabilityInfo {
         } else if (elem instanceof ConstructorElement ce) {
             ReachabilityInfo info = get(elem.getEnclosingType().getContext().getCompilationContext());
             info.analysis.processInstantiatedClass(ce.getEnclosingType().load(), true, false, null);
-            info.analysis.processClassInitialization(ce.getEnclosingType().load());
             info.analysis.processReachableExactInvocation(ce, null);
         }
     }
@@ -169,7 +159,7 @@ public class ReachabilityInfo {
     }
 
     public boolean isAccessedStaticField(FieldElement field) {
-        return dispatchableMethods.contains(field);
+        return accessedStaticField.contains(field);
     }
 
     public boolean isReachableClass(LoadedTypeDefinition type) {
@@ -178,10 +168,6 @@ public class ReachabilityInfo {
 
     public boolean isReachableInterface(LoadedTypeDefinition type) {
         return interfaceHierarchy.containsKey(type);
-    }
-
-    public boolean isInitializedType(LoadedTypeDefinition type) {
-        return initializedTypes.contains(type);
     }
 
     public boolean isInstantiatedClass(LoadedTypeDefinition type) {
@@ -300,14 +286,12 @@ public class ReachabilityInfo {
         instantiatedClasses.add(type);
     }
 
-    void addInitializedType(LoadedTypeDefinition type) {
-        if (isInitializedType(type)) return;
+    void addReachableType(LoadedTypeDefinition type) {
         if (type.isInterface()) {
             addReachableInterface(type);
         } else {
             addReachableClass(type);
         }
-        initializedTypes.add(type);
     }
 
     void addDispatchableMethod(MethodElement meth) {


### PR DESCRIPTION
Only consider static fields that are actually accessed in reachable code
as roots for tracing the build time heap to identify instantiated types.
This replace a more conservative approach in which all static fields
of initialized types were considered as heap roots.