### PR TITLE
Type resolver simplifications

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/ClassContext.java
+++ b/compiler/src/main/java/org/qbicc/context/ClassContext.java
@@ -8,7 +8,6 @@ import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.interpreter.VmClassLoader;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.DescriptorTypeResolver;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -46,7 +45,7 @@ public interface ClassContext extends DescriptorTypeResolver {
 
     void defineClass(String name, DefinedTypeDefinition definition);
 
-    ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations);
+    ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature);
 
     /**
      * Get the entirety of the resource with the given name, or {@code null} if no such resource could be found.

--- a/compiler/src/main/java/org/qbicc/type/definition/DescriptorTypeResolver.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DescriptorTypeResolver.java
@@ -2,7 +2,6 @@ package org.qbicc.type.definition;
 
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.type.descriptor.TypeDescriptor;
 import org.qbicc.type.generic.TypeParameterContext;
 import org.qbicc.type.generic.TypeSignature;
@@ -28,16 +27,14 @@ public interface DescriptorTypeResolver {
      * @param descriptor the type descriptor (must not be {@code null})
      * @param paramCtxt the type parameter context (must not be {@code null})
      * @param signature the type signature (must not be {@code null})
-     * @param visibleAnnotations the visible type annotations list in this use site (must not be {@code null})
-     * @param invisibleAnnotations the invisible type annotations list in this use site (must not be {@code null})
      * @return the resolved type
      */
-    ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations);
+    ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature);
 
-    ValueType resolveTypeFromMethodDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations);
+    ValueType resolveTypeFromMethodDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature);
 
-    ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visible, final TypeAnnotationList invisible);
-        
+    ArrayObjectType resolveArrayObjectTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature);
+
     interface Delegating extends DescriptorTypeResolver {
         DescriptorTypeResolver getDelegate();
 
@@ -45,16 +42,16 @@ public interface DescriptorTypeResolver {
             return getDelegate().resolveTypeFromClassName(packageName, internalName);
         }
 
-        default ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations) {
-            return getDelegate().resolveTypeFromDescriptor(descriptor, paramCtxt, signature, visibleAnnotations, invisibleAnnotations);
+        default ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature) {
+            return getDelegate().resolveTypeFromDescriptor(descriptor, paramCtxt, signature);
         }
 
-        default public ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visible, final TypeAnnotationList invisible) {
-            return getDelegate().resolveArrayObjectTypeFromDescriptor(descriptor, paramCtxt, signature, visible, invisible);
+        default ArrayObjectType resolveArrayObjectTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature) {
+            return getDelegate().resolveArrayObjectTypeFromDescriptor(descriptor, paramCtxt, signature);
         }
 
-        default ValueType resolveTypeFromMethodDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations) {
-            return getDelegate().resolveTypeFromMethodDescriptor(descriptor, paramCtxt, signature, visibleAnnotations, invisibleAnnotations);
+        default ValueType resolveTypeFromMethodDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature) {
+            return getDelegate().resolveTypeFromMethodDescriptor(descriptor, paramCtxt, signature);
         }
     }
 }

--- a/compiler/src/main/java/org/qbicc/type/definition/ParameterResolver.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/ParameterResolver.java
@@ -1,0 +1,19 @@
+package org.qbicc.type.definition;
+
+import org.qbicc.type.definition.element.InvokableElement;
+import org.qbicc.type.definition.element.ParameterElement;
+
+/**
+ * A resolver for a method parameter.
+ */
+public interface ParameterResolver {
+    /**
+     * Resolve the parameter element from the given builder.
+     *
+     * @param element the enclosing invokable element (must not be {@code null})
+     * @param index the index of the parameter, starting at 0
+     * @param builder the parameter element builder
+     * @return the resolved parameter element (must not be {@code null})
+     */
+    ParameterElement resolveParameter(InvokableElement element, int index, ParameterElement.Builder builder);
+}

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFileImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFileImpl.java
@@ -378,7 +378,7 @@ final class ClassFileImpl extends AbstractBufferBacked implements ClassFile, Enc
         if (name.startsWith("[")) {
             TypeDescriptor desc = (TypeDescriptor) getDescriptorConstant(nameIdx);
             // todo: acquire the correct signature and type annotation info from the bytecode index and method info
-            return ctxt.resolveTypeFromDescriptor(desc, paramCtxt, TypeSignature.synthesize(ctxt, desc), TypeAnnotationList.empty(), TypeAnnotationList.empty());
+            return ctxt.resolveTypeFromDescriptor(desc, paramCtxt, TypeSignature.synthesize(ctxt, desc));
         } else {
             int slash = name.lastIndexOf('/');
             String packageName = slash == -1 ? "" : ctxt.deduplicate(name.substring(0, slash));

--- a/compiler/src/main/java/org/qbicc/type/definition/element/LocalVariableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/LocalVariableElement.java
@@ -42,9 +42,8 @@ public final class LocalVariableElement extends VariableElement {
             return classContext.resolveTypeFromMethodDescriptor(
                             getTypeDescriptor(),
                             paramCtxt,
-                            getTypeSignature(),
-                            getVisibleTypeAnnotations(),
-                            getInvisibleTypeAnnotations());
+                            getTypeSignature()
+            );
         }
         return super.resolveTypeDescriptor(classContext, paramCtxt);
     }

--- a/compiler/src/main/java/org/qbicc/type/definition/element/ParameterElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/ParameterElement.java
@@ -31,9 +31,8 @@ public final class ParameterElement extends VariableElement {
         return classContext.resolveTypeFromMethodDescriptor(
                         getTypeDescriptor(),
                         paramCtxt,
-                        getTypeSignature(),
-                        getVisibleTypeAnnotations(),
-                        getInvisibleTypeAnnotations());
+                        getTypeSignature()
+        );
     }
 
     public interface Builder extends VariableElement.Builder {

--- a/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
@@ -90,9 +90,8 @@ public abstract class VariableElement extends AnnotatedElement implements NamedE
         return classContext.resolveTypeFromDescriptor(
                         getTypeDescriptor(),
                         paramCtxt,
-                        getTypeSignature(),
-                        getVisibleTypeAnnotations(),
-                        getInvisibleTypeAnnotations());
+                        getTypeSignature()
+        );
     }
 
     public boolean isFinal() {

--- a/compiler/src/main/java/org/qbicc/type/generic/ArrayTypeSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/ArrayTypeSignature.java
@@ -1,9 +1,14 @@
 package org.qbicc.type.generic;
 
 import java.nio.ByteBuffer;
+import java.util.Set;
 
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.descriptor.ArrayTypeDescriptor;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
  *
@@ -11,9 +16,13 @@ import org.qbicc.type.descriptor.ArrayTypeDescriptor;
 public final class ArrayTypeSignature extends ReferenceTypeSignature {
     private final TypeSignature elementTypeSignature;
 
-    ArrayTypeSignature(final TypeSignature elementTypeSignature) {
-        super(elementTypeSignature.hashCode() * 19 + ArrayTypeSignature.class.hashCode());
+    ArrayTypeSignature(final TypeSignature elementTypeSignature, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(elementTypeSignature.hashCode() * 19 + ArrayTypeSignature.class.hashCode(), annotations);
         this.elementTypeSignature = elementTypeSignature;
+    }
+
+    ArrayTypeSignature(final TypeSignature elementTypeSignature) {
+        this(elementTypeSignature, Maps.immutable.empty());
     }
 
     public TypeSignature getElementTypeSignature() {
@@ -30,6 +39,36 @@ public final class ArrayTypeSignature extends ReferenceTypeSignature {
 
     public StringBuilder toString(final StringBuilder target) {
         return elementTypeSignature.toString(target.append('['));
+    }
+
+    @Override
+    public ArrayTypeSignature withAnnotation(Annotation annotation) {
+        return (ArrayTypeSignature) super.withAnnotation(annotation);
+    }
+
+    @Override
+    public ArrayTypeSignature withAnnotations(Set<Annotation> set) {
+        return (ArrayTypeSignature) super.withAnnotations(set);
+    }
+
+    @Override
+    public ArrayTypeSignature withOnlyAnnotations(Set<Annotation> set) {
+        return (ArrayTypeSignature) super.withOnlyAnnotations(set);
+    }
+
+    @Override
+    public ArrayTypeSignature withoutAnnotation(Annotation annotation) {
+        return (ArrayTypeSignature) super.withoutAnnotation(annotation);
+    }
+
+    @Override
+    public ArrayTypeSignature withoutAnnotation(ClassTypeDescriptor descriptor) {
+        return (ArrayTypeSignature) super.withoutAnnotation(descriptor);
+    }
+
+    @Override
+    ArrayTypeSignature replacingAnnotationMap(ImmutableMap<ClassTypeDescriptor, Annotation> newMap) {
+        return new ArrayTypeSignature(elementTypeSignature, newMap);
     }
 
     public ArrayTypeDescriptor asDescriptor(final ClassContext classContext) {

--- a/compiler/src/main/java/org/qbicc/type/generic/BaseTypeSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/BaseTypeSignature.java
@@ -2,9 +2,14 @@ package org.qbicc.type.generic;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.Set;
 
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.impl.factory.Iterables;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
  *
@@ -25,7 +30,11 @@ public final class BaseTypeSignature extends TypeSignature {
     private final String fullName;
 
     private BaseTypeSignature(final String shortName, final String fullName) {
-        super(Objects.hash(BaseTypeSignature.class, shortName, fullName));
+        this(shortName, fullName, Iterables.iMap());
+    }
+
+    private BaseTypeSignature(final String shortName, final String fullName, final ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(Objects.hash(BaseTypeSignature.class, shortName, fullName), annotations);
         this.shortName = shortName;
         this.fullName = fullName;
     }
@@ -36,6 +45,10 @@ public final class BaseTypeSignature extends TypeSignature {
 
     public String getFullName() {
         return fullName;
+    }
+
+    public int getCodePoint() {
+        return shortName.charAt(0);
     }
 
     public boolean equals(final TypeSignature other) {
@@ -58,22 +71,52 @@ public final class BaseTypeSignature extends TypeSignature {
         return target.append(shortName);
     }
 
+    @Override
+    public BaseTypeSignature withAnnotation(Annotation annotation) {
+        return (BaseTypeSignature) super.withAnnotation(annotation);
+    }
+
+    @Override
+    public BaseTypeSignature withAnnotations(Set<Annotation> set) {
+        return (BaseTypeSignature) super.withAnnotations(set);
+    }
+
+    @Override
+    public BaseTypeSignature withOnlyAnnotations(Set<Annotation> set) {
+        return (BaseTypeSignature) super.withOnlyAnnotations(set);
+    }
+
+    @Override
+    public BaseTypeSignature withoutAnnotation(Annotation annotation) {
+        return (BaseTypeSignature) super.withoutAnnotation(annotation);
+    }
+
+    @Override
+    public BaseTypeSignature withoutAnnotation(ClassTypeDescriptor descriptor) {
+        return (BaseTypeSignature) super.withoutAnnotation(descriptor);
+    }
+
+    @Override
+    BaseTypeSignature replacingAnnotationMap(ImmutableMap<ClassTypeDescriptor, Annotation> newMap) {
+        return new BaseTypeSignature(shortName, fullName, newMap);
+    }
+
     static BaseTypeSignature parse(ByteBuffer buf) {
         return forChar(next(buf));
     }
 
     static BaseTypeSignature forChar(final int i) {
-        switch (i) {
-            case 'B': return B;
-            case 'C': return C;
-            case 'D': return D;
-            case 'F': return F;
-            case 'I': return I;
-            case 'J': return J;
-            case 'S': return S;
-            case 'V': return V;
-            case 'Z': return Z;
-            default: throw parseError();
-        }
+        return switch (i) {
+            case 'B' -> B;
+            case 'C' -> C;
+            case 'D' -> D;
+            case 'F' -> F;
+            case 'I' -> I;
+            case 'J' -> J;
+            case 'S' -> S;
+            case 'V' -> V;
+            case 'Z' -> Z;
+            default -> throw parseError();
+        };
     }
 }

--- a/compiler/src/main/java/org/qbicc/type/generic/ClassTypeSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/ClassTypeSignature.java
@@ -5,7 +5,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
@@ -15,8 +17,8 @@ public abstract class ClassTypeSignature extends ThrowsSignature {
     private final String identifier;
     private final List<TypeArgument> typeArguments;
 
-    ClassTypeSignature(final int hashCode, final String identifier, final List<TypeArgument> typeArguments) {
-        super(Objects.hash(identifier, typeArguments) * 19 + hashCode);
+    ClassTypeSignature(final int hashCode, final String identifier, final List<TypeArgument> typeArguments, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(Objects.hash(identifier, typeArguments) * 19 + hashCode, annotations);
         this.identifier = identifier;
         this.typeArguments = typeArguments;
     }

--- a/compiler/src/main/java/org/qbicc/type/generic/NestedClassTypeSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/NestedClassTypeSignature.java
@@ -3,8 +3,12 @@ package org.qbicc.type.generic;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
@@ -13,9 +17,13 @@ import org.qbicc.type.descriptor.ClassTypeDescriptor;
 public final class NestedClassTypeSignature extends ClassTypeSignature {
     private final ClassTypeSignature enclosing;
 
-    NestedClassTypeSignature(final ClassTypeSignature enclosing, final String identifier, final List<TypeArgument> typeArguments) {
-        super(Objects.hash(NestedClassTypeSignature.class, enclosing), identifier, typeArguments);
+    NestedClassTypeSignature(final ClassTypeSignature enclosing, final String identifier, final List<TypeArgument> typeArguments, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(Objects.hash(NestedClassTypeSignature.class, enclosing), identifier, typeArguments, annotations);
         this.enclosing = enclosing;
+    }
+
+    NestedClassTypeSignature(final ClassTypeSignature enclosing, final String identifier, final List<TypeArgument> typeArguments) {
+        this(enclosing, identifier, typeArguments, Maps.immutable.empty());
     }
 
     public ClassTypeSignature getEnclosing() {
@@ -59,6 +67,41 @@ public final class NestedClassTypeSignature extends ClassTypeSignature {
                 b.appendCodePoint(codePoint(buf));
             }
         }
+    }
+
+    @Override
+    public NestedClassTypeSignature withAnnotation(Annotation annotation) {
+        return (NestedClassTypeSignature) super.withAnnotation(annotation);
+    }
+
+    @Override
+    public NestedClassTypeSignature withAnnotations(Set<Annotation> set) {
+        return (NestedClassTypeSignature) super.withAnnotations(set);
+    }
+
+    @Override
+    public NestedClassTypeSignature withOnlyAnnotations(Set<Annotation> set) {
+        return (NestedClassTypeSignature) super.withOnlyAnnotations(set);
+    }
+
+    @Override
+    public NestedClassTypeSignature withNoAnnotations() {
+        return (NestedClassTypeSignature) super.withNoAnnotations();
+    }
+
+    @Override
+    public NestedClassTypeSignature withoutAnnotation(Annotation annotation) {
+        return (NestedClassTypeSignature) super.withoutAnnotation(annotation);
+    }
+
+    @Override
+    public NestedClassTypeSignature withoutAnnotation(ClassTypeDescriptor descriptor) {
+        return (NestedClassTypeSignature) super.withoutAnnotation(descriptor);
+    }
+
+    @Override
+    NestedClassTypeSignature replacingAnnotationMap(ImmutableMap<ClassTypeDescriptor, Annotation> newMap) {
+        return new NestedClassTypeSignature(enclosing, getIdentifier(), getTypeArguments(), newMap);
     }
 
     ClassTypeDescriptor makeDescriptor(final ClassContext classContext) {

--- a/compiler/src/main/java/org/qbicc/type/generic/ReferenceTypeSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/ReferenceTypeSignature.java
@@ -2,14 +2,17 @@ package org.qbicc.type.generic;
 
 import java.nio.ByteBuffer;
 
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
  *
  */
-public abstract class ReferenceTypeSignature extends org.qbicc.type.generic.TypeSignature {
-    ReferenceTypeSignature(final int hashCode) {
-        super(hashCode);
+public abstract class ReferenceTypeSignature extends TypeSignature {
+    ReferenceTypeSignature(final int hashCode, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(hashCode, annotations);
     }
 
     public final boolean equals(final TypeSignature other) {

--- a/compiler/src/main/java/org/qbicc/type/generic/ThrowsSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/ThrowsSignature.java
@@ -2,14 +2,17 @@ package org.qbicc.type.generic;
 
 import java.nio.ByteBuffer;
 
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
 
 /**
  *
  */
 public abstract class ThrowsSignature extends ReferenceTypeSignature {
-    ThrowsSignature(final int hashCode) {
-        super(hashCode);
+    ThrowsSignature(final int hashCode, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(hashCode, annotations);
     }
 
     public final boolean equals(final ReferenceTypeSignature other) {

--- a/compiler/src/main/java/org/qbicc/type/generic/TopLevelClassTypeSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/TopLevelClassTypeSignature.java
@@ -3,8 +3,12 @@ package org.qbicc.type.generic;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 import org.qbicc.type.descriptor.TypeDescriptor;
 
@@ -15,7 +19,11 @@ public final class TopLevelClassTypeSignature extends ClassTypeSignature {
     private final String packageName;
 
     TopLevelClassTypeSignature(final String packageName, final String identifier, final List<TypeArgument> typeArguments) {
-        super(Objects.hash(TopLevelClassTypeSignature.class, packageName), identifier, typeArguments);
+        this(packageName, identifier, typeArguments, Maps.immutable.empty());
+    }
+
+    TopLevelClassTypeSignature(final String packageName, final String identifier, final List<TypeArgument> typeArguments, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(Objects.hash(TopLevelClassTypeSignature.class, packageName), identifier, typeArguments, annotations);
         this.packageName = packageName;
     }
 
@@ -37,6 +45,41 @@ public final class TopLevelClassTypeSignature extends ClassTypeSignature {
             target.append(packageName).append('/');
         }
         return simpleString(target);
+    }
+
+    @Override
+    public TopLevelClassTypeSignature withAnnotation(Annotation annotation) {
+        return (TopLevelClassTypeSignature) super.withAnnotation(annotation);
+    }
+
+    @Override
+    public TopLevelClassTypeSignature withAnnotations(Set<Annotation> set) {
+        return (TopLevelClassTypeSignature) super.withAnnotations(set);
+    }
+
+    @Override
+    public TopLevelClassTypeSignature withOnlyAnnotations(Set<Annotation> set) {
+        return (TopLevelClassTypeSignature) super.withOnlyAnnotations(set);
+    }
+
+    @Override
+    public TopLevelClassTypeSignature withNoAnnotations() {
+        return (TopLevelClassTypeSignature) super.withNoAnnotations();
+    }
+
+    @Override
+    public TopLevelClassTypeSignature withoutAnnotation(Annotation annotation) {
+        return (TopLevelClassTypeSignature) super.withoutAnnotation(annotation);
+    }
+
+    @Override
+    public TopLevelClassTypeSignature withoutAnnotation(ClassTypeDescriptor descriptor) {
+        return (TopLevelClassTypeSignature) super.withoutAnnotation(descriptor);
+    }
+
+    @Override
+    TopLevelClassTypeSignature replacingAnnotationMap(ImmutableMap<ClassTypeDescriptor, Annotation> newMap) {
+        return new TopLevelClassTypeSignature(packageName, getIdentifier(), getTypeArguments(), newMap);
     }
 
     TypeDescriptor makeDescriptor(final ClassContext classContext) {

--- a/compiler/src/main/java/org/qbicc/type/generic/TypeSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/TypeSignature.java
@@ -1,9 +1,16 @@
 package org.qbicc.type.generic;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.impl.block.factory.Functions;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.descriptor.ArrayTypeDescriptor;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
@@ -13,10 +20,73 @@ import org.qbicc.type.descriptor.TypeDescriptor;
  *
  */
 public abstract class TypeSignature extends Signature {
+    private final ImmutableMap<ClassTypeDescriptor, Annotation> annotations;
     private TypeDescriptor descriptor;
 
-    TypeSignature(final int hashCode) {
-        super(hashCode);
+    TypeSignature(final int hashCode, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(annotations.hashCode() * 19 + hashCode);
+        this.annotations = annotations;
+    }
+
+    public Collection<Annotation> getAnnotations() {
+        return annotations.castToMap().values();
+    }
+
+    public boolean hasAnnotation(ClassTypeDescriptor desc) {
+        return annotations.containsKey(desc);
+    }
+
+    public boolean hasAnnotation(Annotation annotation) {
+        return annotation.equals(annotations.get(annotation.getDescriptor()));
+    }
+
+    public Annotation getAnnotation(ClassTypeDescriptor desc) {
+        return annotations.get(desc);
+    }
+
+    public TypeSignature withAnnotation(Annotation annotation) {
+        if (annotation.equals(annotations.get(annotation.getDescriptor()))) {
+            // we have that one
+            return this;
+        } else {
+            // add or replace it
+            return replacingAnnotationMap(annotations.newWithKeyValue(annotation.getDescriptor(), annotation));
+        }
+    }
+
+    abstract TypeSignature replacingAnnotationMap(ImmutableMap<ClassTypeDescriptor, Annotation> newMap);
+
+    public TypeSignature withAnnotations(Set<Annotation> set) {
+        if (annotations.valuesView().containsAll(set)) {
+            return this;
+        } else {
+            return replacingAnnotationMap(annotations.newWithMap(Sets.immutable.ofAll(set).toImmutableMap(Annotation::getDescriptor, Functions.identity()).castToMap()));
+        }
+    }
+
+    public TypeSignature withOnlyAnnotations(Set<Annotation> set) {
+        return replacingAnnotationMap(Sets.immutable.ofAll(set).toImmutableMap(Annotation::getDescriptor, Functions.identity()));
+    }
+
+    public TypeSignature withNoAnnotations() {
+        return annotations.isEmpty() ? this : replacingAnnotationMap(Maps.immutable.empty());
+    }
+
+    public TypeSignature withoutAnnotation(Annotation annotation) {
+        ClassTypeDescriptor descriptor = annotation.getDescriptor();
+        if (annotation.equals(annotations.get(annotation.getDescriptor()))) {
+            return replacingAnnotationMap(annotations.newWithoutKey(descriptor));
+        } else {
+            return this;
+        }
+    }
+
+    public TypeSignature withoutAnnotation(ClassTypeDescriptor descriptor) {
+        if (annotations.containsKey(descriptor)) {
+            return replacingAnnotationMap(annotations.newWithoutKey(descriptor));
+        } else {
+            return this;
+        }
     }
 
     public final boolean equals(final Signature other) {
@@ -24,7 +94,7 @@ public abstract class TypeSignature extends Signature {
     }
 
     public boolean equals(final TypeSignature other) {
-        return super.equals(other);
+        return super.equals(other) && annotations.equals(other.annotations);
     }
 
     public TypeDescriptor asDescriptor(ClassContext classContext) {

--- a/compiler/src/main/java/org/qbicc/type/generic/TypeVariableSignature.java
+++ b/compiler/src/main/java/org/qbicc/type/generic/TypeVariableSignature.java
@@ -2,10 +2,13 @@ package org.qbicc.type.generic;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.Set;
 
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.qbicc.context.ClassContext;
+import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
-import org.qbicc.type.descriptor.TypeDescriptor;
 
 /**
  *
@@ -14,7 +17,11 @@ public final class TypeVariableSignature extends ThrowsSignature {
     private final String identifier;
 
     TypeVariableSignature(final String identifier) {
-        super(Objects.hash(TypeVariableSignature.class, identifier));
+        this(identifier, Maps.immutable.empty());
+    }
+
+    TypeVariableSignature(final String identifier, ImmutableMap<ClassTypeDescriptor, Annotation> annotations) {
+        super(Objects.hash(TypeVariableSignature.class, identifier), annotations);
         this.identifier = identifier;
     }
 
@@ -34,11 +41,46 @@ public final class TypeVariableSignature extends ThrowsSignature {
         return target.append('T').append(identifier).append(';');
     }
 
+    @Override
+    public TypeVariableSignature withAnnotation(Annotation annotation) {
+        return (TypeVariableSignature) super.withAnnotation(annotation);
+    }
+
+    @Override
+    public TypeVariableSignature withAnnotations(Set<Annotation> set) {
+        return (TypeVariableSignature) super.withAnnotations(set);
+    }
+
+    @Override
+    public TypeVariableSignature withOnlyAnnotations(Set<Annotation> set) {
+        return (TypeVariableSignature) super.withOnlyAnnotations(set);
+    }
+
+    @Override
+    public TypeVariableSignature withNoAnnotations() {
+        return (TypeVariableSignature) super.withNoAnnotations();
+    }
+
+    @Override
+    public TypeVariableSignature withoutAnnotation(Annotation annotation) {
+        return (TypeVariableSignature) super.withoutAnnotation(annotation);
+    }
+
+    @Override
+    public TypeVariableSignature withoutAnnotation(ClassTypeDescriptor descriptor) {
+        return (TypeVariableSignature) super.withoutAnnotation(descriptor);
+    }
+
+    @Override
+    TypeVariableSignature replacingAnnotationMap(ImmutableMap<ClassTypeDescriptor, Annotation> newMap) {
+        return new TypeVariableSignature(identifier, newMap);
+    }
+
     public ClassTypeDescriptor asDescriptor(final ClassContext classContext) {
         return (ClassTypeDescriptor) super.asDescriptor(classContext);
     }
 
-    TypeDescriptor makeDescriptor(final ClassContext classContext) {
+    ClassTypeDescriptor makeDescriptor(final ClassContext classContext) {
         return ClassTypeDescriptor.synthesize(classContext, "java/lang/Object");
     }
 

--- a/compiler/src/main/java/org/qbicc/type/util/ResolutionUtil.java
+++ b/compiler/src/main/java/org/qbicc/type/util/ResolutionUtil.java
@@ -9,7 +9,6 @@ import org.qbicc.type.InstanceMethodType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.StaticMethodType;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.descriptor.MethodDescriptor;
 import org.qbicc.type.descriptor.TypeDescriptor;
@@ -91,7 +90,7 @@ public final class ResolutionUtil {
             return enclosingType.load().getType().getReference();
         }
         ClassContext classContext = enclosingType.getContext();
-        ValueType resolvedReturnType = classContext.resolveTypeFromMethodDescriptor(returnType, nestedCtxt, returnTypeSignature, TypeAnnotationList.empty(), TypeAnnotationList.empty());
+        ValueType resolvedReturnType = classContext.resolveTypeFromMethodDescriptor(returnType, nestedCtxt, returnTypeSignature);
         if (resolvedReturnType instanceof ObjectType) {
             resolvedReturnType = ((ObjectType) resolvedReturnType).getReference();
         }

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -31,13 +31,11 @@ import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.ProgramModule;
 import org.qbicc.object.Section;
 import org.qbicc.type.ArrayObjectType;
-import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.InvokableType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.context.ClassContext;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.NativeMethodConfigurator;
@@ -371,11 +369,11 @@ public class TestClassContext implements ClassContext {
         return null;
     }
 
-    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
+    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
         return null;
     }
 
-    public ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visible, final TypeAnnotationList invisible) {
+    public ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
         return null;
     }
 
@@ -391,7 +389,7 @@ public class TestClassContext implements ClassContext {
         return null;
     }
 
-    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
+    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
         return null;
     }
 }

--- a/driver/src/main/java/org/qbicc/driver/BasicDescriptorTypeResolver.java
+++ b/driver/src/main/java/org/qbicc/driver/BasicDescriptorTypeResolver.java
@@ -4,7 +4,6 @@ import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.context.ClassContext;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.DescriptorTypeResolver;
@@ -33,7 +32,7 @@ final class BasicDescriptorTypeResolver implements DescriptorTypeResolver {
         }
     }
 
-    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visible, final TypeAnnotationList invisible) {
+    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
         TypeSystem ts = classContext.getCompilationContext().getTypeSystem();
         if (descriptor instanceof BaseTypeDescriptor) {
             switch (((BaseTypeDescriptor) descriptor).getShortName()) {
@@ -53,12 +52,12 @@ final class BasicDescriptorTypeResolver implements DescriptorTypeResolver {
             return classContext.resolveTypeFromClassName(classTypeDescriptor.getPackageName(), classTypeDescriptor.getClassName());
         } else {
             assert descriptor instanceof ArrayTypeDescriptor;
-            ArrayObjectType arrayObjectType = resolveArrayObjectTypeFromDescriptor(descriptor, paramCtxt, signature, visible, invisible);
+            ArrayObjectType arrayObjectType = resolveArrayObjectTypeFromDescriptor(descriptor, paramCtxt, signature);
             return arrayObjectType;
         }
      }
 
-    public ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visible, final TypeAnnotationList invisible) {
+    public ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
         if (descriptor instanceof BaseTypeDescriptor) {
             throw new ResolutionFailedException("Cannot resolve type as array " + descriptor);
         } else if (descriptor instanceof ClassTypeDescriptor) {
@@ -93,13 +92,13 @@ final class BasicDescriptorTypeResolver implements DescriptorTypeResolver {
                 } else {
                     elemSig = TypeSignature.synthesize(classContext, elemDescriptor);
                 }
-                ArrayObjectType elementArrayObj = resolveArrayObjectTypeFromDescriptor(elemDescriptor, paramCtxt, elemSig, visible, invisible);
+                ArrayObjectType elementArrayObj = resolveArrayObjectTypeFromDescriptor(elemDescriptor, paramCtxt, elemSig);
                 return elementArrayObj.getReferenceArrayObject();
             }
         }
     }
 
-    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
-        return classContext.resolveTypeFromDescriptor(descriptor, paramCtxt, signature, visibleAnnotations, invisibleAnnotations);
+    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
+        return classContext.resolveTypeFromDescriptor(descriptor, paramCtxt, signature);
     }
 }

--- a/driver/src/main/java/org/qbicc/driver/ClassContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/ClassContextImpl.java
@@ -15,7 +15,6 @@ import org.qbicc.interpreter.VmClassLoader;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.type.definition.DefineFailedException;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.DescriptorTypeResolver;
@@ -139,12 +138,12 @@ final class ClassContextImpl implements ClassContext {
         return descriptorTypeResolver.resolveTypeFromClassName(packageName, internalName);
     }
 
-    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
-        return descriptorTypeResolver.resolveTypeFromDescriptor(descriptor, paramCtxt, signature, visibleAnnotations, invisibleAnnotations);
+    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
+        return descriptorTypeResolver.resolveTypeFromDescriptor(descriptor, paramCtxt, signature);
     }
 
-    public ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visible, final TypeAnnotationList invisible) {
-        return descriptorTypeResolver.resolveArrayObjectTypeFromDescriptor(descriptor, paramCtxt, signature, visible, invisible);
+    public ArrayObjectType resolveArrayObjectTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
+        return descriptorTypeResolver.resolveArrayObjectTypeFromDescriptor(descriptor, paramCtxt, signature);
     }
 
     @Override
@@ -156,7 +155,7 @@ final class ClassContextImpl implements ClassContext {
         return builder;
     }
 
-    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
-        return descriptorTypeResolver.resolveTypeFromMethodDescriptor(descriptor, paramCtxt, signature, visibleAnnotations, invisibleAnnotations);
+    public ValueType resolveTypeFromMethodDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
+        return descriptorTypeResolver.resolveTypeFromMethodDescriptor(descriptor, paramCtxt, signature);
     }
 }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ConstTypeResolver.java
@@ -2,7 +2,6 @@ package org.qbicc.plugin.native_;
 
 import org.qbicc.context.CompilationContext;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.context.ClassContext;
 import org.qbicc.type.definition.DescriptorTypeResolver;
 import org.qbicc.type.descriptor.TypeDescriptor;
@@ -27,7 +26,7 @@ public class ConstTypeResolver implements DescriptorTypeResolver.Delegating {
         return delegate;
     }
 
-    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, final TypeAnnotationList visibleAnnotations, final TypeAnnotationList invisibleAnnotations) {
-        return getDelegate().resolveTypeFromDescriptor(descriptor, paramCtxt, signature, visibleAnnotations, invisibleAnnotations);
+    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
+        return getDelegate().resolveTypeFromDescriptor(descriptor, paramCtxt, signature);
     }
 }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/FunctionTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/FunctionTypeResolver.java
@@ -8,7 +8,6 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.context.ClassContext;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.DescriptorTypeResolver;
@@ -41,7 +40,7 @@ public class FunctionTypeResolver implements DescriptorTypeResolver.Delegating {
         return delegate;
     }
 
-    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature, TypeAnnotationList visibleAnnotations, TypeAnnotationList invisibleAnnotations) {
+    public ValueType resolveTypeFromDescriptor(final TypeDescriptor descriptor, TypeParameterContext paramCtxt, final TypeSignature signature) {
         out: if (descriptor instanceof ClassTypeDescriptor) {
             ClassTypeDescriptor ctd = (ClassTypeDescriptor) descriptor;
             if (ctd.getPackageName().equals(Native.NATIVE_PKG)) {
@@ -117,6 +116,6 @@ public class FunctionTypeResolver implements DescriptorTypeResolver.Delegating {
                 break out;
             }
         }
-        return getDelegate().resolveTypeFromDescriptor(descriptor, paramCtxt, signature, visibleAnnotations, invisibleAnnotations);
+        return getDelegate().resolveTypeFromDescriptor(descriptor, paramCtxt, signature);
     }
 }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -21,19 +21,16 @@ import org.qbicc.driver.Driver;
 import org.qbicc.machine.probe.CProbe;
 import org.qbicc.machine.probe.Qualifier;
 import org.qbicc.plugin.core.ConditionEvaluation;
-import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.plugin.linker.Linker;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.annotation.Annotation;
-import org.qbicc.type.annotation.AnnotationValue;
 import org.qbicc.type.annotation.ArrayAnnotationValue;
 import org.qbicc.type.annotation.ClassAnnotationValue;
 import org.qbicc.type.annotation.IntAnnotationValue;
 import org.qbicc.type.annotation.StringAnnotationValue;
 import org.qbicc.type.annotation.type.TypeAnnotation;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.context.ClassContext;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
@@ -191,9 +188,7 @@ final class NativeInfo {
                                             ValueType resolvedType = classContext.resolveTypeFromDescriptor(
                                                 cav.getDescriptor(),
                                                 definedType,
-                                                TypeSignature.synthesize(classContext, definedType.getDescriptor()),
-                                                TypeAnnotationList.empty(),
-                                                TypeAnnotationList.empty()
+                                                TypeSignature.synthesize(classContext, definedType.getDescriptor())
                                             );
                                             annotatedAlign = resolvedType.getAlign();
                                         }
@@ -213,9 +208,7 @@ final class NativeInfo {
                                                             ValueType resolvedType = classContext.resolveTypeFromDescriptor(
                                                                 cav.getDescriptor(),
                                                                 definedType,
-                                                                TypeSignature.synthesize(classContext, definedType.getDescriptor()),
-                                                                TypeAnnotationList.empty(),
-                                                                TypeAnnotationList.empty()
+                                                                TypeSignature.synthesize(classContext, definedType.getDescriptor())
                                                             );
                                                             annotatedAlign = resolvedType.getAlign();
                                                             // stop searching for alignments
@@ -392,7 +385,7 @@ final class NativeInfo {
         }
         ClassContext classContext = definedType.getContext();
         // todo: acquire type annotation list from supertype description
-        ValueType pointeeType = classContext.resolveTypeFromDescriptor(bound.asDescriptor(classContext), definedType, bound, TypeAnnotationList.empty(), TypeAnnotationList.empty());
+        ValueType pointeeType = classContext.resolveTypeFromDescriptor(bound.asDescriptor(classContext), definedType, bound);
         return pointeeType.getPointer();
     }
 

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorTypeBuilder.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/AccessorTypeBuilder.java
@@ -14,7 +14,6 @@ import org.qbicc.type.ValueType;
 import org.qbicc.type.annotation.Annotation;
 import org.qbicc.type.annotation.ArrayAnnotationValue;
 import org.qbicc.type.annotation.ClassAnnotationValue;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.FieldResolver;
 import org.qbicc.type.definition.LoadedTypeDefinition;
@@ -86,7 +85,7 @@ public final class AccessorTypeBuilder implements DefinedTypeDefinition.Builder.
             private VmObject createAccessor(final FieldElement fieldElement, final Annotation annotation) {
                 ClassAnnotationValue value = (ClassAnnotationValue) annotation.getValue("value");
                 TypeDescriptor desc = value.getDescriptor();
-                ValueType valueType = classContext.resolveTypeFromDescriptor(desc, TypeParameterContext.EMPTY, TypeSignature.synthesize(classContext, desc), TypeAnnotationList.empty(), TypeAnnotationList.empty());
+                ValueType valueType = classContext.resolveTypeFromDescriptor(desc, TypeParameterContext.EMPTY, TypeSignature.synthesize(classContext, desc));
                 if (valueType instanceof ClassObjectType cot) {
                     VmThread vmThread = Vm.requireCurrentThread();
                     LoadedTypeDefinition definition = cot.getDefinition().load();

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
@@ -32,7 +32,6 @@ import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
-import org.qbicc.type.annotation.type.TypeAnnotationList;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.FieldElement;
@@ -175,7 +174,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
     public Value checkcast(final Value value, final TypeDescriptor desc) {
         ClassContext cc = getClassContext();
         // it is present else {@link org.qbicc.plugin.verification.ClassLoadingBasicBlockBuilder} would have failed
-        ValueType castType = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc), TypeAnnotationList.empty(), TypeAnnotationList.empty());
+        ValueType castType = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc));
         if (value instanceof ConstantLiteral) {
             // it may be something we can't really cast.
             return ctxt.getLiteralFactory().constantLiteralOfType(castType);
@@ -242,7 +241,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
         ObjectType ot;
         int dimensions = 0;
         if (desc instanceof ArrayTypeDescriptor) {
-            ot = cc.resolveArrayObjectTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc), TypeAnnotationList.empty(), TypeAnnotationList.empty());
+            ot = cc.resolveArrayObjectTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc));
             if (ot instanceof ReferenceArrayObjectType) {
                 dimensions = ((ReferenceArrayObjectType) ot).getDimensionCount();
                 ot = ((ReferenceArrayObjectType) ot).getLeafElementType();
@@ -266,7 +265,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
             // always the current class
             type = enclosingType.load().getType();
         } else {
-            type = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc), TypeAnnotationList.empty(), TypeAnnotationList.empty());
+            type = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc));
         }
         if (type instanceof ClassObjectType cot) {
             Layout layout = Layout.get(ctxt);
@@ -279,7 +278,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
 
     public Value newArray(final ArrayTypeDescriptor desc, final Value size) {
         ClassContext cc = getClassContext();
-        ValueType type = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc), TypeAnnotationList.empty(), TypeAnnotationList.empty());
+        ValueType type = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc));
         if (type instanceof PrimitiveArrayObjectType pat) {
             return super.newArray(pat, size);
         } else if (type instanceof ReferenceArrayObjectType rat) {
@@ -300,7 +299,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
 
     public Value multiNewArray(final ArrayTypeDescriptor desc, final List<Value> dimensions) {
         ClassContext cc = getClassContext();
-        ValueType type = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc), TypeAnnotationList.empty(), TypeAnnotationList.empty());
+        ValueType type = cc.resolveTypeFromDescriptor(desc, TypeParameterContext.of(getCurrentElement()), TypeSignature.synthesize(cc, desc));
         if (type instanceof ArrayObjectType) {
             return super.multiNewArray((ArrayObjectType) type, dimensions);
         }


### PR DESCRIPTION
Start simplifying type resolution, by:

* Removing defunct type annotation support
* Changing `Signature` to also carry annotations (groundwork)