### PR TITLE
Use the actual index of the parameter for debug info

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -162,8 +162,19 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     if (! graphFactory.getCurrentElement().isStatic()) {
                         offset = 1;
                     }
-                    if (slot >= offset && slot < parameters.size() + offset) {
-                        builder.setReflectsParameter(parameters.get(slot - offset));
+                    if (slot >= offset) {
+                        int pos = offset;
+                        for (ParameterElement parameter : parameters) {
+                            if (pos == slot) {
+                                builder.setReflectsParameter(parameter);
+                                break;
+                            }
+                            if (parameter.getTypeDescriptor().isClass2()) {
+                                pos += 2;
+                            } else {
+                                pos++;
+                            }
+                        }
                     }
                 }
                 builder.setBci(startPc);

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -136,6 +136,7 @@ import org.qbicc.type.VoidType;
 import org.qbicc.type.WordType;
 import org.qbicc.type.definition.MethodBody;
 import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.definition.element.InvokableElement;
 import org.qbicc.type.definition.element.LocalVariableElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.ParameterElement;
@@ -268,7 +269,8 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
             ParameterElement param = variable.getReflectsParameter();
             if (param != null) {
                 // debug args are 1-based
-                metadataNode.argument(param.getIndex() + 1);
+                int index = ((InvokableElement) functionObj.getOriginalElement()).getParameters().indexOf(param);
+                metadataNode.argument(index + 1);
             }
             localVariables.put(variable, metadataNode);
         }


### PR DESCRIPTION
The index stored on the original parameter is based on using two slots for `long`/`double` which does not apply to the final image.