### PR TITLE
Fix checkcast bug with primitive values

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -15,6 +15,7 @@ import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.BlockLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.BooleanType;

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -1854,7 +1854,9 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                     case OP_CHECKCAST: {
                         v1 = pop1();
                         Value narrowed = gf.checkcast(v1, getClassFile().getClassConstantAsDescriptor(buffer.getShort() & 0xffff));
-                        replaceAll(v1, narrowed);
+                        if (narrowed.getType() instanceof ReferenceType) {
+                            replaceAll(v1, narrowed);
+                        }
                         push1(narrowed);
                         break;
                     }


### PR DESCRIPTION
A `checkcast` whose result is primitive (due to native type mapping) would cause all of the live primitive literals with the same value to be replaced with the literal of the new type, breaking compilation of method and function calls which are passed two integers of the same value but different types.