### PR TITLE
improvements in RTA / Reachability Analysis

### DIFF
--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -30,7 +30,7 @@ interface ReachabilityAnalysis {
 
     void processReachableType(final LoadedTypeDefinition ltd, ExecutableElement currentElement);
 
-    void processInstantiatedClass(final LoadedTypeDefinition type, boolean directlyInstantiated, boolean onHeapType, ExecutableElement currentElement);
+    void processInstantiatedClass(final LoadedTypeDefinition type, boolean onHeapType, ExecutableElement currentElement);
 
     void clear();
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -230,7 +230,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, New node) {
             if (visitUnknown(param, (Node)node)) {
                 LoadedTypeDefinition ltd = node.getClassObjectType().getDefinition().load();
-                param.analysis.processInstantiatedClass(ltd, true, false, param.currentElement);
+                param.analysis.processInstantiatedClass(ltd, false, param.currentElement);
             }
             return null;
         }
@@ -278,7 +278,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         public Void visit(ReachabilityContext param, ClassOf node) {
             if (visitUnknown(param, (Node)node)) {
                 MethodElement methodElement = RuntimeMethodFinder.get(param.ctxt).getMethod("getClassFromTypeId");
-                param.ctxt.enqueue(methodElement);
+                param.analysis.processReachableExactInvocation(methodElement, param.currentElement);
                 if (node.getInput() instanceof TypeLiteral tl && tl.getValue() instanceof ClassObjectType cot) {
                     param.analysis.processReachableType(cot.getDefinition().load(), param.currentElement);
                 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/VMHelpers.java
@@ -182,6 +182,14 @@ public final class VMHelpers {
         throw new UnsatisfiedLinkError(target);
     }
 
+    @Hidden
+    @NoReturn
+    @Inline(InlineCondition.NEVER)
+    @AutoQueued
+    static void raiseUnreachableCodeError(String target) {
+        throw new NoSuchMethodError(target);
+    }
+
 
     // Run time class loading
 


### PR DESCRIPTION
+ Fully split the concepts of a dispatchable method and an invokable method
+ Improvements in RTA to only track classes that are actually instantiated
  (stop propagating instantiation up the class hierarchy).
+ Improvements in RTA to consider actual method lookup semantics when
  deciding if a method is reachable (don't force a superclass method
  that is not actually invokable to be invokable just because a subclass
  that also defines an overriding method is instantiated).
+ Reduce vtable size by not allocating slots for private methods;
  they will always be invoked via an invokespecial and therefore
  should not need to be allocated vtable slots.