### PR TITLE
Progress on Mac OS debug info

### DIFF
--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlcInvokerImpl.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlcInvokerImpl.java
@@ -52,5 +52,9 @@ final class LlcInvokerImpl extends AbstractLlvmInvoker implements LlcInvoker {
         cmd.add("--relocation-model=" + relocationModel.value);
         cmd.add("-" + optLevel.name());
         cmd.add("--filetype=" + outputFormat.toOptionString());
+        if (platform.getCpu().getCpuWordSize() == 8) {
+            cmd.add("--dwarf64");
+        }
+        cmd.add("--dwarf-version=4");
     }
 }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -66,7 +66,7 @@ final class LLVMModuleGenerator {
         Path outputFile = context.getOutputFile(def, "ll");
         final Module module = Module.newModule();
         final LLVMModuleNodeVisitor moduleVisitor = new LLVMModuleNodeVisitor(module, context);
-        final LLVMModuleDebugInfo debugInfo = new LLVMModuleDebugInfo(module, context);
+        final LLVMModuleDebugInfo debugInfo = new LLVMModuleDebugInfo(programModule, module, context);
         final LLVMPseudoIntrinsics pseudoIntrinsics = new LLVMPseudoIntrinsics(module);
 
         if (picLevel != 0) {


### PR DESCRIPTION
This at least gets the executable to record the locations of the object files for debug purposes.

After this change:

```text
$ nm -ap grepj |grep OSO
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/lang/module/ModuleDescriptor$$Lambda$219~1.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/jdk/internal/logger/LoggerFinderLoader$$Lambda$156~1.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/security/Policy$1.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/lang/invoke/LambdaForm$DMH~24.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/lang/reflect/ReflectPermission.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/util/regex/CharPredicates$$Lambda$37~1.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/lang/invoke/LambdaForm$DMH~3.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/lang/invoke/LambdaForm$MH~1.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/nio/charset/Charset$2.o
000000006230aaf0 - 03 0001   OSO /Users/david/src/java/grepj/target/native/java/time/chrono/IsoChronology.o
```

which is an improvement. However, `lldb` still finds no debug symbols at run time, and `dsymutil` reports some warnings:

```text
$ dsymutil -o grepj.dwarf grepj
warning: (x86_64)  could not find object file symbol for symbol _exact.java.lang.invoke.LambdaForm$DMH~22.invokeStatic.int.2.ref<java.lang.Object>.ref<java.lang.Object>
warning: (x86_64)  could not find object file symbol for symbol _vtable-java.lang.invoke.LambdaForm$DMH~22
warning: (x86_64)  failed to insert symbol '__LLVM_StackMaps' in the debug map.
warning: (x86_64)  could not find object file symbol for symbol _exact.java.lang.invoke.LambdaForm$DMH~110.newInvokeSpecial.ref<java.lang.Object>.5.ref<java.lang.Object>.int.ref<java.lang.Object>.ref<java.lang.Object>.ref<java.lang.Object>
warning: (x86_64)  could not find object file symbol for symbol _vtable-java.lang.invoke.LambdaForm$DMH~110
warning: (x86_64)  failed to insert symbol '__LLVM_StackMaps' in the debug map.
warning: (x86_64)  could not find object file symbol for symbol _exact.java.lang.invoke.LambdaForm$DMH~91.invokeStatic.void.2.ref<java.lang.Object>.int
warning: (x86_64)  could not find object file symbol for symbol _vtable-java.lang.invoke.LambdaForm$DMH~91
warning: (x86_64)  failed to insert symbol '__LLVM_StackMaps' in the debug map.
warning: (x86_64)  could not find object file symbol for symbol _exact.java.lang.invoke.LambdaForm$DMH~76.newInvokeSpecial.ref<java.lang.Object>.1.ref<java.lang.Object>
warning: (x86_64)  could not find object file symbol for symbol _vtable-java.lang.invoke.LambdaForm$DMH~76
warning: (x86_64)  failed to insert symbol '__LLVM_StackMaps' in the debug map.
```

Note that the symbols which yield the "could not find object file symbol for symbol..." are trivially findable in their corresponding `.o` file.