### PR TITLE
Global variable/method debug improvements

### DIFF
--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/Module.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/Module.java
@@ -10,6 +10,8 @@ import org.qbicc.machine.llvm.debuginfo.DIDerivedType;
 import org.qbicc.machine.llvm.debuginfo.DIEncoding;
 import org.qbicc.machine.llvm.debuginfo.DIExpression;
 import org.qbicc.machine.llvm.debuginfo.DIFile;
+import org.qbicc.machine.llvm.debuginfo.DIGlobalVariable;
+import org.qbicc.machine.llvm.debuginfo.DIGlobalVariableExpression;
 import org.qbicc.machine.llvm.debuginfo.DILocalVariable;
 import org.qbicc.machine.llvm.debuginfo.DILocation;
 import org.qbicc.machine.llvm.debuginfo.DISubprogram;
@@ -51,6 +53,8 @@ public interface Module {
     DISubroutineType diSubroutineType(LLValue types);
     DILocalVariable diLocalVariable(String name, LLValue type, LLValue scope, LLValue file, int line, int align);
     DIExpression diExpression();
+    DIGlobalVariableExpression diGlobalVariableExpression(LLValue var_, LLValue expr);
+    DIGlobalVariable diGlobalVariable(String name, LLValue type, LLValue scope, LLValue file, int line, int align);
 
     void addFlag(ModuleFlagBehavior behavior, String name, LLValue type, LLValue value);
 

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/debuginfo/DIGlobalVariable.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/debuginfo/DIGlobalVariable.java
@@ -1,0 +1,13 @@
+package org.qbicc.machine.llvm.debuginfo;
+
+import java.util.EnumSet;
+
+public interface DIGlobalVariable extends MetadataNode {
+    DIGlobalVariable comment(String comment);
+
+    DIGlobalVariable flags(EnumSet<DIFlags> flags);
+
+    DIGlobalVariable isDefinition();
+
+    DIGlobalVariable isLocal();
+}

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/debuginfo/DIGlobalVariableExpression.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/debuginfo/DIGlobalVariableExpression.java
@@ -1,0 +1,12 @@
+package org.qbicc.machine.llvm.debuginfo;
+
+import org.qbicc.machine.llvm.LLValue;
+
+/**
+ * A debug expression which can be a literal or a declared metadata node.
+ */
+public interface DIGlobalVariableExpression extends MetadataNode {
+    DIGlobalVariableExpression comment(String comment);
+
+    LLValue asValue();
+}

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/DIGlobalVariableExpressionImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/DIGlobalVariableExpressionImpl.java
@@ -1,0 +1,51 @@
+package org.qbicc.machine.llvm.impl;
+
+import java.io.IOException;
+
+import org.qbicc.machine.llvm.LLValue;
+import org.qbicc.machine.llvm.debuginfo.DIGlobalVariableExpression;
+
+final class DIGlobalVariableExpressionImpl extends AbstractMetadataNode implements DIGlobalVariableExpression {
+    final AbstractValue var_;
+    final AbstractValue expr;
+
+    final AsValue value = new AsValue();
+
+    DIGlobalVariableExpressionImpl(int index, AbstractValue var_, AbstractValue expr) {
+        super(index);
+        this.var_ = var_;
+        this.expr = expr;
+    }
+
+    @Override
+    public DIGlobalVariableExpression comment(String comment) {
+        super.comment(comment);
+        return this;
+    }
+
+    @Override
+    public Appendable appendTo(Appendable target) throws IOException {
+        super.appendTo(target);
+        value.appendTo(target);
+        return target;
+    }
+
+    @Override
+    public LLValue asValue() {
+        return value;
+    }
+
+    final class AsValue extends AbstractValue {
+        @Override
+        public Appendable appendTo(Appendable target) throws IOException {
+            target.append("!DIGlobalVariableExpression(");
+            target.append("var: ");
+            var_.appendTo(target);
+            target.append(", expr: ");
+            expr.appendTo(target);
+            target.append(")");
+            return target;
+        }
+    }
+
+}

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/DIGlobalVariableImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/DIGlobalVariableImpl.java
@@ -1,0 +1,99 @@
+package org.qbicc.machine.llvm.impl;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import io.smallrye.common.constraint.Assert;
+import org.qbicc.machine.llvm.debuginfo.DIFlags;
+import org.qbicc.machine.llvm.debuginfo.DIGlobalVariable;
+
+final class DIGlobalVariableImpl extends AbstractMetadataNode implements DIGlobalVariable {
+    private final String name;
+    private final AbstractValue type;
+    private final AbstractValue scope;
+    private final AbstractValue file;
+    private final int line;
+    private final int align;
+    private int argument = -1;
+    private EnumSet<DIFlags> flags = EnumSet.noneOf(DIFlags.class);
+    private boolean isDefinition;
+    private boolean isLocal;
+
+    DIGlobalVariableImpl(int index, String name, AbstractValue type, AbstractValue scope, AbstractValue file, int line, int align) {
+        super(index);
+        this.name = name;
+        this.type = type;
+        this.scope = scope;
+        this.file = file;
+        this.line = line;
+        this.align = align;
+    }
+
+    public Appendable appendTo(final Appendable target) throws IOException {
+        super.appendTo(target);
+
+        target.append("!DIGlobalVariable(name: ");
+        appendEscapedString(target, name);
+
+        target.append(", type: ");
+        type.appendTo(target);
+        target.append(", align: ");
+        appendDecimal(target, align);
+
+        if (scope != null) {
+            target.append(", scope: ");
+            scope.appendTo(target);
+        }
+
+        if (file != null) {
+            target.append(", file: ");
+            file.appendTo(target);
+            target.append(", line: ");
+            appendDecimal(target, line);
+        }
+
+        if (argument != -1) {
+            target.append(", arg: ");
+            appendDecimal(target, argument);
+        }
+
+        if (!flags.isEmpty()) {
+            target.append(", flags: ");
+            appendDiFlags(target, flags);
+        }
+
+        target.append(", isDefinition: ");
+        target.append(Boolean.toString(isDefinition));
+        target.append(", isLocal: ");
+        target.append(Boolean.toString(isLocal));
+
+        target.append(')');
+        return appendTrailer(target);
+    }
+
+    public DIGlobalVariable comment(final String comment) {
+        return (DIGlobalVariable) super.comment(comment);
+    }
+
+    public DIGlobalVariable argument(int index) {
+        argument = index;
+        return this;
+    }
+
+    public DIGlobalVariable flags(EnumSet<DIFlags> flags) {
+        this.flags = Assert.checkNotNullParam("flags", flags);
+        return this;
+    }
+
+    @Override
+    public DIGlobalVariable isDefinition() {
+        this.isDefinition = true;
+        return this;
+    }
+
+    @Override
+    public DIGlobalVariable isLocal() {
+        this.isLocal = true;
+        return null;
+    }
+}

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/GlobalImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/GlobalImpl.java
@@ -173,6 +173,7 @@ final class GlobalImpl extends AbstractYieldingInstruction implements Global {
             target.append(' ');
             target.append(Integer.toString(alignment));
         }
+        appendMeta(target);
         return target;
     }
 }

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/ModuleImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/ModuleImpl.java
@@ -21,6 +21,8 @@ import org.qbicc.machine.llvm.debuginfo.DIDerivedType;
 import org.qbicc.machine.llvm.debuginfo.DIEncoding;
 import org.qbicc.machine.llvm.debuginfo.DIExpression;
 import org.qbicc.machine.llvm.debuginfo.DIFile;
+import org.qbicc.machine.llvm.debuginfo.DIGlobalVariable;
+import org.qbicc.machine.llvm.debuginfo.DIGlobalVariableExpression;
 import org.qbicc.machine.llvm.debuginfo.DILocalVariable;
 import org.qbicc.machine.llvm.debuginfo.DILocation;
 import org.qbicc.machine.llvm.debuginfo.DISubprogram;
@@ -156,6 +158,21 @@ final class ModuleImpl implements Module {
 
     public DIExpression diExpression() {
         return add(meta, new DIExpressionImpl(nextMetadataNodeId()));
+    }
+
+    public DIGlobalVariableExpression diGlobalVariableExpression(LLValue var_, LLValue expr) {
+        Assert.checkNotNullParam("var_", var_);
+        Assert.checkNotNullParam("expr", expr);
+        return add(meta, new DIGlobalVariableExpressionImpl(nextMetadataNodeId(), (AbstractValue) var_, (AbstractValue) expr));
+    }
+
+    @Override
+    public DIGlobalVariable diGlobalVariable(String name, LLValue type, LLValue scope, LLValue file, int line, int align) {
+        Assert.checkNotNullParam("name", name);
+        Assert.checkNotNullParam("type", type);
+        Assert.checkNotNullParam("scope", scope);
+        Assert.checkNotNullParam("file", file);
+        return add(meta, new DIGlobalVariableImpl(nextMetadataNodeId(), name, (AbstractValue) type, (AbstractValue) scope, (AbstractValue) file, line, align));
     }
 
     int nextGlobalId() {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -40,6 +40,7 @@ import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.MethodBody;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.MemberElement;
 import org.qbicc.type.definition.element.MethodElement;
 
 import java.io.BufferedWriter;
@@ -180,6 +181,10 @@ final class LLVMModuleGenerator {
                     }
                     if (item.getAddrspace() != 0) {
                         obj.addressSpace(data.getAddrspace());
+                    }
+                    MemberElement element = data.getOriginalElement();
+                    if (element != null) {
+                        obj.meta("dbg", debugInfo.getDebugInfoForGlobal(data, element));
                     }
                     obj.asGlobal(data.getName());
                 } else {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -1,6 +1,5 @@
 package org.qbicc.plugin.lowering;
 
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -12,7 +11,6 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.OffsetOfField;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.BooleanLiteral;
-import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.graph.literal.ProgramObjectLiteral;
@@ -25,26 +23,25 @@ import org.qbicc.plugin.constants.Constants;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.plugin.serialization.BuildtimeHeap;
+import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
-import org.qbicc.type.CompoundType;
 import org.qbicc.type.IntegerType;
-import org.qbicc.type.annotation.Annotation;
-import org.qbicc.type.annotation.LongAnnotationValue;
+import org.qbicc.type.TypeSystem;
+import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
-import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
 import org.qbicc.type.definition.element.LocalVariableElement;
-import org.qbicc.type.descriptor.BaseTypeDescriptor;
-import org.qbicc.type.generic.BaseTypeSignature;
+import org.qbicc.type.descriptor.TypeDescriptor;
+import org.qbicc.type.generic.TypeSignature;
 
 public class Lowering {
     public static final String GLOBAL_REFERENCES = "QBICC_GLOBALS";
 
     private static final AttachmentKey<Lowering> KEY = new AttachmentKey<>();
 
-    private final Map<LoadedTypeDefinition, GlobalVariableElement> globals = new ConcurrentHashMap<>();
+    private final Map<FieldElement, GlobalVariableElement> staticFields = new ConcurrentHashMap<>();
     private final Map<ExecutableElement, LinkedHashSet<LocalVariableElement>> usedVariables = new ConcurrentHashMap<>();
 
     private Lowering() {}
@@ -53,95 +50,106 @@ public class Lowering {
         return ctxt.computeAttachmentIfAbsent(KEY, Lowering::new);
     }
 
-    public GlobalVariableElement getStaticsGlobalForType(LoadedTypeDefinition typeDef) {
-        GlobalVariableElement global = globals.get(typeDef);
+    public GlobalVariableElement getGlobalForStaticField(FieldElement field) {
+        GlobalVariableElement global = staticFields.get(field);
         if (global != null) {
             return global;
         }
+        DefinedTypeDefinition typeDef = field.getEnclosingType();
         ClassContext classContext = typeDef.getContext();
         CompilationContext ctxt = classContext.getCompilationContext();
-        String itemName = "statics-" + typeDef.getInternalName().replace('/', '.');
-        LayoutInfo layoutInfo = Layout.get(ctxt).getStaticLayoutInfo(typeDef);
-        final GlobalVariableElement.Builder builder = GlobalVariableElement.builder(itemName, BaseTypeDescriptor.V);
-        CompoundType staticsType = layoutInfo.getCompoundType();
-        builder.setType(staticsType);
-        builder.setSignature(BaseTypeSignature.V);
-        builder.setModifiers(typeDef.getModifiers());
+        StringBuilder b = new StringBuilder(64);
+        // todo: consider class loader
+        b.append(typeDef.getInternalName().replace('/', '.'));
+        b.append('.');
+        b.append(field.getName());
+        TypeDescriptor fieldDesc = field.getTypeDescriptor();
+        String globalName = b.toString();
+        final GlobalVariableElement.Builder builder = GlobalVariableElement.builder(globalName, fieldDesc);
+        ValueType globalType = widenBoolean(field.getType());
+        builder.setType(globalType);
+        builder.setSignature(TypeSignature.synthesize(classContext, fieldDesc));
+        builder.setModifiers(field.getModifiers());
         builder.setEnclosingType(typeDef);
-        final String sectionName = CompilationContext.IMPLICIT_SECTION_NAME;
+        String sectionName = CompilationContext.IMPLICIT_SECTION_NAME;
         builder.setSection(sectionName);
         global = builder.build();
-        GlobalVariableElement appearing = globals.putIfAbsent(typeDef, global);
+        GlobalVariableElement appearing = staticFields.putIfAbsent(field, global);
         if (appearing != null) {
             return appearing;
         }
-
-        Section section = ctxt.getOrAddProgramModule(typeDef).getOrAddSection(sectionName);
-        // initialize values for all fields
-        int cnt = typeDef.getFieldCount();
+        // we added it, so we must add the definition as well
         LiteralFactory lf = ctxt.getLiteralFactory();
-        boolean hasValue = false;
-        Map<CompoundType.Member, Literal> valueMap = new HashMap<>(cnt);
-        for (int i = 0; i < cnt; i ++) {
-            FieldElement field = typeDef.getField(i);
-            if (field.isStatic()) {
-                Value initialValue;
-                if (field.getRunTimeInitializer() != null) {
-                    initialValue = lf.zeroInitializerLiteralOfType(field.getType());
+        Section section = ctxt.getOrAddProgramModule(typeDef).getOrAddSection(sectionName);
+        Value initialValue;
+        boolean hasValue;
+        if (field.getRunTimeInitializer() != null) {
+            initialValue = lf.zeroInitializerLiteralOfType(globalType);
+            hasValue = false;
+        } else {
+            initialValue = field.getReplacementValue(ctxt);
+            if (initialValue == null) {
+                initialValue = typeDef.load().getInitialValue(field);
+            }
+            if (initialValue == null) {
+                initialValue = Constants.get(ctxt).getConstantValue(field);
+                if (initialValue == null) {
+                    initialValue = lf.zeroInitializerLiteralOfType(globalType);
+                    hasValue = false;
                 } else {
-                    initialValue = field.getReplacementValue(ctxt);
-                    if (initialValue == null) {
-                        initialValue = ((DefinedTypeDefinition) typeDef).load().getInitialValue(field);
-                    }
-                    if (initialValue == null) {
-                        initialValue = Constants.get(ctxt).getConstantValue(field);
-                        if (initialValue == null) {
-                            initialValue = lf.zeroInitializerLiteralOfType(field.getType());
-                        } else {
-                            hasValue = true;
-                        }
-                    } else {
-                        hasValue = true;
-                    }
+                    hasValue = true;
                 }
-                CompoundType.Member member = layoutInfo.getMember(field);
-                if (initialValue instanceof OffsetOfField) {
-                    // special case: the field holds an offset which is really an integer
-                    FieldElement offsetField = ((OffsetOfField) initialValue).getFieldElement();
-                    LayoutInfo instanceLayout = Layout.get(ctxt).getInstanceLayoutInfo(offsetField.getEnclosingType());
-                    if (offsetField.isStatic()) {
-                        initialValue = lf.literalOf(-1);
-                    } else {
-                        initialValue = lf.literalOf(instanceLayout.getMember(offsetField).getOffset());
-                    }
-                }
-                if (initialValue.getType() instanceof BooleanType && member.getType() instanceof IntegerType it) {
-                    // widen the initial value
-                    if (initialValue instanceof BooleanLiteral) {
-                        initialValue = lf.literalOf(it, ((BooleanLiteral) initialValue).booleanValue() ? 1 : 0);
-                    } else if (initialValue instanceof ZeroInitializerLiteral) {
-                        initialValue = lf.literalOf(it, 0);
-                    } else {
-                        throw new IllegalArgumentException("Cannot initialize boolean field");
-                    }
-                }
-                if (initialValue instanceof ObjectLiteral ol) {
-                    ProgramObjectLiteral objLit = BuildtimeHeap.get(ctxt).serializeVmObject(ol.getValue());
-                    DataDeclaration decl = section.declareData(objLit.getProgramObject());
-                    decl.setAddrspace(1);
-                    ProgramObjectLiteral refToLiteral = lf.literalOf(decl);
-                    initialValue = lf.valueConvertLiteral(refToLiteral, ol.getType());
-                }
-                valueMap.put(member, (Literal) initialValue);
+            } else {
+                hasValue = true;
             }
         }
-
-        final Data data = section.addData(null, itemName, hasValue ? lf.literalOf(staticsType, valueMap) : lf.zeroInitializerLiteralOfType(staticsType));
+        if (initialValue instanceof OffsetOfField oof) {
+            // special case: the field holds an offset which is really an integer
+            FieldElement offsetField = oof.getFieldElement();
+            LayoutInfo instanceLayout = Layout.get(ctxt).getInstanceLayoutInfo(offsetField.getEnclosingType());
+            if (offsetField.isStatic()) {
+                initialValue = lf.literalOf(0);
+            } else {
+                initialValue = lf.literalOf(instanceLayout.getMember(offsetField).getOffset());
+            }
+        }
+        if (initialValue.getType() instanceof BooleanType && globalType instanceof IntegerType it) {
+            // widen the initial value
+            if (initialValue instanceof BooleanLiteral) {
+                initialValue = lf.literalOf(it, ((BooleanLiteral) initialValue).booleanValue() ? 1 : 0);
+            } else if (initialValue instanceof ZeroInitializerLiteral) {
+                initialValue = lf.literalOf(it, 0);
+            } else {
+                throw new IllegalArgumentException("Cannot initialize boolean field");
+            }
+        }
+        if (initialValue instanceof ObjectLiteral ol) {
+            ProgramObjectLiteral objLit = BuildtimeHeap.get(ctxt).serializeVmObject(ol.getValue());
+            DataDeclaration decl = section.declareData(objLit.getProgramObject());
+            decl.setAddrspace(1);
+            ProgramObjectLiteral refToLiteral = lf.literalOf(decl);
+            initialValue = lf.valueConvertLiteral(refToLiteral, ol.getType());
+        }
+        final Data data = section.addData(field, globalName, initialValue);
         data.setLinkage(hasValue ? Linkage.EXTERNAL : Linkage.COMMON);
         data.setDsoLocal();
         return global;
     }
 
+    private ValueType widenBoolean(ValueType type) {
+        // todo: n-bit booleans
+        if (type instanceof BooleanType) {
+            TypeSystem ts = type.getTypeSystem();
+            return ts.getUnsignedInteger8Type();
+        } else if (type instanceof ArrayType arrayType) {
+            TypeSystem ts = type.getTypeSystem();
+            ValueType elementType = arrayType.getElementType();
+            ValueType widened = widenBoolean(elementType);
+            return elementType == widened ? type : ts.getArrayType(widened, arrayType.getElementCount());
+        } else {
+            return type;
+        }
+    }
 
     LinkedHashSet<LocalVariableElement> createUsedVariableSet(ExecutableElement element) {
         final LinkedHashSet<LocalVariableElement> set = new LinkedHashSet<>();

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
@@ -11,7 +11,6 @@ import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Function;
 import org.qbicc.object.Section;
 import org.qbicc.plugin.layout.Layout;
-import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.pointer.ElementPointer;
 import org.qbicc.pointer.InstanceFieldPointer;
 import org.qbicc.pointer.MemberPointer;
@@ -21,7 +20,6 @@ import org.qbicc.pointer.Pointer;
 import org.qbicc.pointer.ProgramObjectPointer;
 import org.qbicc.pointer.StaticFieldPointer;
 import org.qbicc.pointer.StaticMethodPointer;
-import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
 import org.qbicc.type.definition.element.MethodElement;
@@ -59,13 +57,10 @@ public final class MemberPointerCopier implements NodeVisitor.Delegating<Node.Co
             return ProgramObjectPointer.of(decl);
         } else if (pointer instanceof StaticFieldPointer sfp) {
             FieldElement field = sfp.getStaticField();
-            GlobalVariableElement global = Lowering.get(ctxt).getStaticsGlobalForType(field.getEnclosingType().load());
-            DefinedTypeDefinition fieldHolder = field.getEnclosingType();
+            GlobalVariableElement global = Lowering.get(ctxt).getGlobalForStaticField(field);
             Section section = ctxt.getImplicitSection(copier.getBlockBuilder().getCurrentElement());
             DataDeclaration decl = section.declareData(field, global.getName(), global.getType());
-            LayoutInfo layoutInfo = Layout.get(ctxt).getStaticLayoutInfo(fieldHolder);
-            assert layoutInfo != null; // field exists so layout is non empty
-            return new MemberPointer(ProgramObjectPointer.of(decl), layoutInfo.getMember(field));
+            return ProgramObjectPointer.of(decl);
         } else if (pointer instanceof ElementPointer ep) {
             return new ElementPointer(lowerPointer(copier, ep.getArrayPointer()), ep.getIndex());
         } else if (pointer instanceof MemberPointer mp) {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
@@ -5,8 +5,6 @@ import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.object.Section;
-import org.qbicc.plugin.layout.Layout;
-import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
@@ -29,14 +27,13 @@ public class StaticFieldLoweringBasicBlockBuilder extends DelegatingBasicBlockBu
         if (! field.isStatic()) {
             throw new IllegalArgumentException();
         }
-        GlobalVariableElement global = Lowering.get(ctxt).getStaticsGlobalForType(field.getEnclosingType().load());
+        GlobalVariableElement global = Lowering.get(ctxt).getGlobalForStaticField(field);
         DefinedTypeDefinition fieldHolder = field.getEnclosingType();
         if (! fieldHolder.equals(ourHolder)) {
             // we have to declare it in our translation unit
             Section section = ctxt.getOrAddProgramModule(ourHolder).getOrAddSection(global.getSection());
             section.declareData(field, global.getName(), global.getType());
         }
-        LayoutInfo layoutInfo = Layout.get(ctxt).getStaticLayoutInfo(fieldHolder);
-        return memberOf(globalVariable(global), layoutInfo.getMember(field));
+        return globalVariable(global);
     }
 }


### PR DESCRIPTION
This changes the nice-name of global variables and of methods so that they match Java syntax, to an extent anyway.

With this change Mac debug works as far as it can... however, when entering a Java frame with `lldb` you are hit with this message:

```text
This version of LLDB has no plugin for the language "java". Inspection of frame variables will be limited.
```

But it really means that inspection of *any* variables is essentially nonexistent.  So going forward, we have to decide whether to rewrite the debug info to seem like C++ or some other language, or else commit to getting support for Java debug info upstream to `lldb`.