### PR TITLE
Improve invalid usage detection

### DIFF
--- a/main/src/main/java/org/qbicc/main/QbiccMavenResolver.java
+++ b/main/src/main/java/org/qbicc/main/QbiccMavenResolver.java
@@ -286,6 +286,8 @@ final class QbiccMavenResolver {
                             element.close();
                             throw t;
                         }
+                    } else if (! Files.exists(path)) {
+                        ctxt.warning("Class path entry \"%s\" does not exist", path);
                     }
                 }
             }

--- a/plugins/main/src/main/java/org/qbicc/plugin/main_method/AddMainClassHook.java
+++ b/plugins/main/src/main/java/org/qbicc/plugin/main_method/AddMainClassHook.java
@@ -73,6 +73,8 @@ public class AddMainClassHook implements Consumer<CompilationContext> {
                 } else {
                     runtimeMain.load();
                 }
+            } else {
+                ctxt.error("Main class \"%s\" not found on class path", mainClass);
             }
         }
     }


### PR DESCRIPTION
...by warning when a JAR is missing on the class path and reporting an error when the specified main class is missing. Otherwise, we happily proceed and throw an unsatisfied link error at run time.