### PR TITLE
Relate global variable list to GV expr, not GV

### DIFF
--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleDebugInfo.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleDebugInfo.java
@@ -416,8 +416,9 @@ final class LLVMModuleDebugInfo {
         int align = valueType.getAlign();
         LLValue sourceFile = createSourceFile(element);
         LLValue var_ = module.diGlobalVariable(name, type, diCompileUnit, sourceFile, 1, align).isDefinition().asRef();
-        globals.elem(null, var_);
-        return module.diGlobalVariableExpression(var_, Values.diExpression().asValue()).asRef();
+        LLValue expr = module.diGlobalVariableExpression(var_, Values.diExpression().asValue()).asRef();
+        globals.elem(null, expr);
+        return expr;
     }
 
     final static class LocationKey {


### PR DESCRIPTION
Fixes the problem where `opt` emits a warning and then a module gets no debug info.