### PR TITLE
Add support for explicitly `long`-sized pointer types

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -465,7 +465,7 @@ public final class TypeSystem {
     }
 
     PointerType createPointer(ValueType type) {
-        return new PointerType(this, type, false, false, false);
+        return new PointerType(this, type, false, false, false, getPointerSize());
     }
 
     ReferenceType createReference(PhysicalObjectType objectType, Set<InterfaceObjectType> interfaceBounds) {


### PR DESCRIPTION
This will allow us to change the type of certain `long`-typed fields and variables (i.e. ones which may hold a pointer value) to be pointer typed without risking problems on 32-bit targets.