### PR TITLE
If CC is set in the environment, don't look for alternative compilers

### DIFF
--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/CToolChain.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/CToolChain.java
@@ -37,12 +37,13 @@ public interface CToolChain extends Tool {
         String cc = System.getenv("CC");
         if (cc != null) {
             names.add(cc);
+        } else {
+            if (os == OS.LINUX && (os != Platform.HOST_PLATFORM.getOs() || cpu != Platform.HOST_PLATFORM.getCpu())) {
+                names.add(cpuName + "-" + osName + "-gnu-gcc");
+            }
+            // generic compiler names
+            names.addAll(List.of("cc", "gcc", "clang"));
         }
-        if (os == OS.LINUX && (os != Platform.HOST_PLATFORM.getOs() || cpu != Platform.HOST_PLATFORM.getCpu())) {
-            names.add(cpuName + "-" + osName + "-gnu-gcc");
-        }
-        // generic compiler names
-        names.addAll(List.of("cc", "gcc", "clang"));
         for (String name : names) {
             Path path = ToolUtil.findExecutable(name);
             if (path != null) {


### PR DESCRIPTION
If the user is telling us to use a specific C compiler, then either it works or qbicc should fail.  Don't silently allow alternative C Tool Chains to also be considered.
