### PR TITLE
Reconfigure sections class hierarchy to track object offsets

### DIFF
--- a/compiler/src/main/java/org/qbicc/object/Data.java
+++ b/compiler/src/main/java/org/qbicc/object/Data.java
@@ -8,18 +8,20 @@ import org.qbicc.type.definition.element.MemberElement;
  * A data object definition.
  */
 public final class Data extends SectionObject {
-    private volatile Value value;
+    private final Value value;
     private volatile DataDeclaration declaration;
     private volatile boolean dsoLocal;
+    private volatile long offset;
 
-    Data(final MemberElement originalElement, final String name, final ValueType valueType, final Value value) {
-        super(originalElement, name, valueType);
+    Data(final MemberElement originalElement, ModuleSection moduleSection, final String name, final ValueType valueType, final Value value) {
+        super(originalElement, name, valueType, moduleSection);
         this.value = value;
+        offset = -1;
     }
 
     @Override
     public MemberElement getOriginalElement() {
-        return (MemberElement) super.getOriginalElement();
+        return super.getOriginalElement();
     }
 
     public String getName() {
@@ -30,8 +32,30 @@ public final class Data extends SectionObject {
         return value;
     }
 
-    public void setValue(final Value value) {
-        this.value = value;
+    /**
+     * Get this object's offset within its enclosing module section.
+     *
+     * @return the relative offset
+     */
+    public long getOffset() {
+        long offset = this.offset;
+        if (offset == -1) {
+            throw new IllegalArgumentException("Offset unknown");
+        }
+        return offset;
+    }
+
+    void initOffset(long offset) {
+        this.offset = offset;
+    }
+
+    /**
+     * Get this object's actual size.
+     *
+     * @return the object's actual size
+     */
+    public long getSize() {
+        return value.getType().getSize();
     }
 
     public DataDeclaration getDeclaration() {

--- a/compiler/src/main/java/org/qbicc/object/DataDeclaration.java
+++ b/compiler/src/main/java/org/qbicc/object/DataDeclaration.java
@@ -6,17 +6,14 @@ import org.qbicc.type.definition.element.MemberElement;
 /**
  * A declaration of some global data item.
  */
-public class DataDeclaration extends SectionObject {
-    DataDeclaration(final MemberElement originalElement, final String name, final ValueType valueType) {
-        super(originalElement, name, valueType);
+public class DataDeclaration extends Declaration {
+
+    DataDeclaration(final MemberElement originalElement, ProgramModule programModule, final String name, final ValueType valueType) {
+        super(originalElement, programModule, name, valueType);
     }
 
     DataDeclaration(final Data original) {
         super(original);
-    }
-
-    public MemberElement getOriginalElement() {
-        return (MemberElement) super.getOriginalElement();
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/object/Declaration.java
+++ b/compiler/src/main/java/org/qbicc/object/Declaration.java
@@ -1,0 +1,39 @@
+package org.qbicc.object;
+
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.element.MemberElement;
+
+/**
+ *
+ */
+public abstract class Declaration extends ProgramObject {
+    protected final MemberElement originalElement;
+    private final ProgramModule programModule;
+
+    Declaration(final Declaration original) {
+        super(original);
+        this.originalElement = original.getOriginalElement();
+        this.programModule = original.programModule;
+    }
+
+    Declaration(final SectionObject original) {
+        super(original);
+        this.originalElement = original.getOriginalElement();
+        this.programModule = original.getProgramModule();
+    }
+
+    Declaration(final MemberElement originalElement, ProgramModule programModule, final String name, final ValueType valueType) {
+        super(name, valueType);
+        this.originalElement = originalElement;
+        this.programModule = programModule;
+    }
+
+    public MemberElement getOriginalElement() {
+        return originalElement;
+    }
+
+    @Override
+    public ProgramModule getProgramModule() {
+        return programModule;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/object/Function.java
+++ b/compiler/src/main/java/org/qbicc/object/Function.java
@@ -16,8 +16,8 @@ public final class Function extends SectionObject {
     private volatile MethodBody body;
     private volatile FunctionDeclaration declaration;
 
-    Function(final ExecutableElement originalElement, final String name, final FunctionType functionType, int fnFlags) {
-        super(originalElement, name, functionType);
+    Function(final ExecutableElement originalElement, ModuleSection moduleSection, final String name, final FunctionType functionType, int fnFlags) {
+        super(originalElement, name, functionType, moduleSection);
         this.fnFlags = fnFlags;
     }
 

--- a/compiler/src/main/java/org/qbicc/object/FunctionDeclaration.java
+++ b/compiler/src/main/java/org/qbicc/object/FunctionDeclaration.java
@@ -4,19 +4,16 @@ import org.qbicc.type.FunctionType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
- * A function definition.
+ * A function declaration.
  */
-public final class FunctionDeclaration extends SectionObject {
-    FunctionDeclaration(final ExecutableElement originalElement, final String name, final FunctionType functionType) {
-        super(originalElement, name, functionType);
+public final class FunctionDeclaration extends Declaration {
+
+    FunctionDeclaration(final ExecutableElement originalElement, ProgramModule programModule, final String name, final FunctionType functionType) {
+        super(originalElement, programModule, name, functionType);
     }
 
     FunctionDeclaration(final Function original) {
         super(original);
-    }
-
-    public ExecutableElement getOriginalElement() {
-        return (ExecutableElement) super.getOriginalElement();
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/object/ModuleSection.java
+++ b/compiler/src/main/java/org/qbicc/object/ModuleSection.java
@@ -1,0 +1,170 @@
+package org.qbicc.object;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.smallrye.common.constraint.Assert;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.Value;
+import org.qbicc.type.FunctionType;
+import org.qbicc.type.TypeUtil;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.MemberElement;
+
+/**
+ * A section in a program module.
+ * <p>
+ * A section has a <em>simple name</em>, which is translated into a target-specific form. For example, some
+ * targets might requires sections to begin with a leading period ({@code .}) character.
+ * <p>
+ * Sections are loaded into {@linkplain Segment segments}. Segments are predefined program areas that the
+ * linker handles in a specific manner.
+ */
+public final class ModuleSection extends ProgramObject implements Comparable<ModuleSection> {
+    final ProgramModule programModule;
+    final Section section;
+    // the list of section objects, unindexed (see ProgramModule#moduleObjects), in order
+    // protected by programModule
+    final List<SectionObject> objects = new ArrayList<>();
+    // protected by programModule
+    long offset;
+
+    ModuleSection(final Section section, final ValueType valueType, final ProgramModule programModule) {
+        super(section.getName(), valueType);
+        this.section = section;
+        this.programModule = programModule;
+        if (section.isDataOnly()) {
+            offset = 0;
+        } else {
+            offset = -1;
+        }
+    }
+
+    public Data addData(MemberElement originalElement, String name, Value value) {
+        Data obj = new Data(originalElement,
+            this, Assert.checkNotNullParam("name", name),
+            Assert.checkNotNullParam("value", value).getType(),
+            value
+        );
+        Map<String, ProgramObject> definedObjects = programModule.moduleObjects;
+        synchronized (programModule) {
+            ProgramObject existing = definedObjects.get(name);
+            long offset = TypeUtil.alignUp(this.offset, obj.getValueType().getAlign());
+            if (existing == null) {
+                if (offset != -1) {
+                    // todo: max(obj align, type align)
+                    obj.initOffset(offset);
+                    this.offset = offset + obj.getSize();
+                }
+                objects.add(obj);
+                definedObjects.put(name, obj);
+            } else {
+                if (existing instanceof DataDeclaration decl) {
+                    if (! decl.getValueType().equals(obj.getValueType())) {
+                        programModule.clash(originalElement, name);
+                    } else {
+                        obj.initDeclaration(decl);
+                        if (offset != -1) {
+                            // todo: max(obj align, type align)
+                            obj.initOffset(offset);
+                            this.offset = offset + obj.getSize();
+                        }
+                        objects.add(obj);
+                        definedObjects.replace(name, decl, obj);
+                    }
+                } else {
+                    twice(originalElement, name);
+                }
+            }
+        }
+        return obj;
+    }
+
+    /**
+     * Get the current data offset of this module section.
+     * Each new data object will increase this offset based on its size and alignment.
+     *
+     * @return the current offset
+     * @throws IllegalArgumentException if the section is not data-only
+     */
+    public long getCurrentOffset() {
+        long offset;
+        synchronized (programModule) {
+            offset = this.offset;
+        }
+        if (offset == -1) {
+            throw new IllegalArgumentException("Not a data-only section");
+        }
+        return offset;
+    }
+
+    private void twice(MemberElement originalElement, final String name) {
+        CompilationContext ctxt = programModule.getTypeDefinition().getContext().getCompilationContext();
+        if (originalElement != null) {
+            ctxt.error(originalElement, "Object '%s' defined twice", name);
+        } else {
+            ctxt.error("Synthetic object '%s' defined twice", name);
+        }
+    }
+
+    public Function addFunction(ExecutableElement originalElement, String name, FunctionType type) {
+        if (section.isDataOnly()) {
+            throw dataOnlyException();
+        }
+        Function obj = new Function(originalElement,
+            this, Assert.checkNotNullParam("name", name),
+            Assert.checkNotNullParam("type", type),
+            Function.getFunctionFlags(originalElement)
+        );
+        Map<String, ProgramObject> definedObjects = programModule.moduleObjects;
+        synchronized (programModule) {
+            ProgramObject existing = definedObjects.get(name);
+            if (existing == null) {
+                objects.add(obj);
+                definedObjects.put(name, obj);
+            } else {
+                if (existing instanceof FunctionDeclaration decl) {
+                    if (! decl.getSymbolType().equals(obj.getSymbolType())) {
+                        programModule.clash(originalElement, name);
+                    } else {
+                        obj.initDeclaration(decl);
+                        objects.add(obj);
+                        definedObjects.replace(name, existing, obj);
+                    }
+                } else if (existing instanceof Function) {
+                    twice(originalElement, name);
+                } else {
+                    programModule.clash(originalElement, name);
+                }
+            }
+        }
+        return obj;
+    }
+
+    public Iterable<SectionObject> contents() {
+        synchronized (programModule) {
+            return List.copyOf(objects);
+        }
+    }
+
+    @Override
+    public ProgramModule getProgramModule() {
+        return programModule;
+    }
+
+    @Override
+    public DataDeclaration getDeclaration() {
+        return section.getSegmentStartDeclaration(programModule);
+    }
+
+    @Override
+    public int compareTo(ModuleSection o) {
+        return section.compareTo(o.section);
+    }
+
+    private static IllegalArgumentException dataOnlyException() {
+        return new IllegalArgumentException("Cannot add function to data-only section");
+    }
+}

--- a/compiler/src/main/java/org/qbicc/object/ProgramModule.java
+++ b/compiler/src/main/java/org/qbicc/object/ProgramModule.java
@@ -2,15 +2,23 @@ package org.qbicc.object;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.smallrye.common.constraint.Assert;
 import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.type.FunctionType;
 import org.qbicc.type.TypeSystem;
+import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.element.ExecutableElement;
+import org.qbicc.type.definition.element.MemberElement;
 
 /**
  *
@@ -19,12 +27,18 @@ public final class ProgramModule {
     final DefinedTypeDefinition typeDefinition;
     final TypeSystem typeSystem;
     final LiteralFactory literalFactory;
-    final Map<String, Section> sections = new ConcurrentHashMap<>();
+    // All module objects by name, in no particular order
+    // protected by this
+    final Map<String, ProgramObject> moduleObjects = new HashMap<>();
+    // concurrent
+    final Map<Section, ModuleSection> sections = new ConcurrentHashMap<>();
+    // protected by ctors
     final List<GlobalXtor> ctors = new ArrayList<>();
+    // protected by dtors
     final List<GlobalXtor> dtors = new ArrayList<>();
 
     public ProgramModule(final DefinedTypeDefinition typeDefinition, final TypeSystem typeSystem, final LiteralFactory literalFactory) {
-        this.typeDefinition = typeDefinition;
+        this.typeDefinition = Assert.checkNotNullParam("typeDefinition", typeDefinition);
         this.typeSystem = Assert.checkNotNullParam("typeSystem", typeSystem);
         this.literalFactory = Assert.checkNotNullParam("literalFactory", literalFactory);
     }
@@ -33,16 +47,17 @@ public final class ProgramModule {
         return typeDefinition;
     }
 
-    public Section getSectionIfExists(String name) {
-        return sections.get(name);
+    @Deprecated
+    public ModuleSection getOrAddSection(String name) {
+        Section section = typeDefinition.getContext().getCompilationContext().getSection(name);
+        if (section == null) {
+            throw new IllegalArgumentException("Section " + name + " is not known");
+        }
+        return inSection(section);
     }
 
-    public Section getOrAddSection(String name) {
-        return sections.computeIfAbsent(name, n -> new Section(n, typeSystem.getVoidType(), this));
-    }
-
-    public Iterable<Section> sections() {
-        Section[] array = this.sections.values().toArray(Section[]::new);
+    public Collection<ModuleSection> sections() {
+        ModuleSection[] array = this.sections.values().toArray(ModuleSection[]::new);
         Arrays.sort(array, Comparator.comparing(ProgramObject::getName));
         return List.of(array);
     }
@@ -77,5 +92,291 @@ public final class ProgramModule {
             dtors.add(xtor);
         }
         return xtor;
+    }
+
+    public ModuleSection inSection(final Section section) {
+        return sections.computeIfAbsent(Assert.checkNotNullParam("section", section), this::registerSection);
+    }
+
+    /**
+     * Convenience method to produce a function declaration in this module for the given original program object, which
+     * must be a function definition or a function declaration.
+     *
+     * @param original the original item (must not be {@code null})
+     * @return the function declaration (not {@code null})
+     */
+    public FunctionDeclaration declareFunction(ProgramObject original) {
+        if (original instanceof Function fn) {
+            return declareFunction(fn);
+        } else if (original instanceof FunctionDeclaration decl) {
+            return declareFunction(decl);
+        } else {
+            throw new IllegalArgumentException("Invalid input type");
+        }
+    }
+
+    /**
+     * Convenience method to produce a function declaration in this module for the given original function.
+     *
+     * @param originalFunction the original function (must not be {@code null})
+     * @return the function declaration (not {@code null})
+     */
+    public FunctionDeclaration declareFunction(Function originalFunction) {
+        Assert.checkNotNullParam("originalFunction", originalFunction);
+        String name = originalFunction.getName();
+        Map<String, ProgramObject> definedObjects = this.moduleObjects;
+        synchronized (this) {
+            ProgramObject existing = definedObjects.get(name);
+            FunctionDeclaration origDecl = originalFunction.getDeclaration();
+            if (existing == null) {
+                definedObjects.put(name, origDecl);
+                return origDecl;
+            } else {
+                if (existing == origDecl) {
+                    // fast/common path
+                    return origDecl;
+                } else if (existing instanceof FunctionDeclaration decl) {
+                    if (! originalFunction.getSymbolType().equals(decl.getSymbolType())) {
+                        clash(originalFunction.getOriginalElement(), name);
+                        return origDecl;
+                    }
+                    return decl;
+                } else if (existing instanceof Function fn) {
+                    if (! originalFunction.getSymbolType().equals(fn.getSymbolType())) {
+                        clash(originalFunction.getOriginalElement(), name);
+                        return origDecl;
+                    }
+                    return fn.getDeclaration();
+                } else {
+                    clash(originalFunction.getOriginalElement(), name);
+                    return origDecl;
+                }
+            }
+        }
+    }
+
+    /**
+     * Convenience method to produce a function declaration in this module for the given original function declaration.
+     *
+     * @param originalDecl the original function declaration (must not be {@code null})
+     * @return the function declaration (not {@code null})
+     */
+    public FunctionDeclaration declareFunction(FunctionDeclaration originalDecl) {
+        Assert.checkNotNullParam("originalDecl", originalDecl);
+        String name = originalDecl.getName();
+        Map<String, ProgramObject> definedObjects = this.moduleObjects;
+        synchronized (this) {
+            ProgramObject existing = definedObjects.get(name);
+            if (existing == null) {
+                definedObjects.put(name, originalDecl);
+                return originalDecl;
+            } else {
+                if (existing == originalDecl) {
+                    // fast/common path
+                    return originalDecl;
+                } else if (existing instanceof FunctionDeclaration decl) {
+                    if (! originalDecl.getSymbolType().equals(decl.getSymbolType())) {
+                        clash(originalDecl.getOriginalElement(), name);
+                        return originalDecl;
+                    }
+                    return decl;
+                } else if (existing instanceof Function fn) {
+                    if (! originalDecl.getSymbolType().equals(fn.getSymbolType())) {
+                        clash(originalDecl.getOriginalElement(), name);
+                        return originalDecl.getDeclaration();
+                    }
+                    return fn.getDeclaration();
+                } else {
+                    clash(originalDecl.getOriginalElement(), name);
+                    return originalDecl;
+                }
+            }
+        }
+    }
+
+    public FunctionDeclaration declareFunction(ExecutableElement originalElement, String name, FunctionType type) {
+        Assert.checkNotNullParam("name", name);
+        Map<String, ProgramObject> definedObjects = this.moduleObjects;
+        synchronized (this) {
+            ProgramObject existing = definedObjects.get(name);
+            if (existing == null) {
+                FunctionDeclaration decl = new FunctionDeclaration(originalElement, this, name, type);
+                definedObjects.put(name, decl);
+                return decl;
+            } else {
+                if (existing instanceof FunctionDeclaration decl) {
+                    if (! type.equals(decl.getValueType())) {
+                        clash(originalElement, name);
+                        return new FunctionDeclaration(originalElement, this, name, type);
+                    }
+                    return decl;
+                } else if (existing instanceof Function fn) {
+                    if (! type.equals(fn.getValueType())) {
+                        clash(originalElement, name);
+                        return new FunctionDeclaration(originalElement, this, name, type);
+                    }
+                    return fn.getDeclaration();
+                } else {
+                    clash(originalElement, name);
+                    return new FunctionDeclaration(originalElement, this, name, type);
+                }
+            }
+        }
+    }
+
+    /**
+     * Convenience method to produce a data declaration in this module for the given original program object, which
+     * must be a data definition or a data declaration.
+     *
+     * @param original the original item (must not be {@code null})
+     * @return the data declaration (not {@code null})
+     */
+    public DataDeclaration declareData(ProgramObject original) {
+        if (original instanceof Data data) {
+            return declareData(data);
+        } else if (original instanceof DataDeclaration decl) {
+            return declareData(decl);
+        } else {
+            throw new IllegalArgumentException("Invalid input type");
+        }
+    }
+
+    /**
+     * Convenience method to produce a data declaration in this module for the given original data definition.
+     *
+     * @param originalData the original data definition (must not be {@code null})
+     * @return the data declaration (not {@code null})
+     */
+    public DataDeclaration declareData(Data originalData) {
+        Assert.checkNotNullParam("originalData", originalData);
+        String name = originalData.getName();
+        Map<String, ProgramObject> definedObjects = this.moduleObjects;
+        synchronized (this) {
+            ProgramObject existing = definedObjects.get(name);
+            DataDeclaration origDecl = originalData.getDeclaration();
+            if (existing == null) {
+                definedObjects.put(name, origDecl);
+                return origDecl;
+            } else {
+                if (existing == origDecl) {
+                    // fast/common path
+                    return origDecl;
+                } else if (existing instanceof DataDeclaration decl) {
+                    if (! originalData.getSymbolType().equals(decl.getSymbolType())) {
+                        clash(originalData.getOriginalElement(), name);
+                        return origDecl;
+                    }
+                    return decl;
+                } else if (existing instanceof Data data) {
+                    if (! originalData.getSymbolType().equals(data.getSymbolType())) {
+                        clash(originalData.getOriginalElement(), name);
+                        return origDecl;
+                    }
+                    return data.getDeclaration();
+                } else {
+                    clash(originalData.getOriginalElement(), name);
+                    return origDecl;
+                }
+            }
+        }
+    }
+
+    /**
+     * Convenience method to produce a data declaration in this module for the given original data declaration.
+     *
+     * @param originalDecl the original data declaration (must not be {@code null})
+     * @return the data declaration (not {@code null})
+     */
+    public DataDeclaration declareData(DataDeclaration originalDecl) {
+        Assert.checkNotNullParam("originalDecl", originalDecl);
+        String name = originalDecl.getName();
+        Map<String, ProgramObject> definedObjects = this.moduleObjects;
+        synchronized (this) {
+            ProgramObject existing = definedObjects.get(name);
+            if (existing == null) {
+                // reuse original decl
+                definedObjects.put(name, originalDecl);
+                return originalDecl;
+            } else {
+                if (existing == originalDecl) {
+                    // fast/common path
+                    return originalDecl;
+                } else if (existing instanceof DataDeclaration decl) {
+                    if (! originalDecl.getSymbolType().equals(decl.getSymbolType())) {
+                        clash(originalDecl.getOriginalElement(), name);
+                        return originalDecl;
+                    }
+                    return decl;
+                } else if (existing instanceof Data data) {
+                    if (! originalDecl.getSymbolType().equals(data.getSymbolType())) {
+                        clash(originalDecl.getOriginalElement(), name);
+                        return originalDecl;
+                    }
+                    return data.getDeclaration();
+                } else {
+                    clash(originalDecl.getOriginalElement(), name);
+                    return originalDecl;
+                }
+            }
+        }
+    }
+
+    public DataDeclaration declareData(MemberElement originalElement, String name, ValueType type) {
+        Assert.checkNotNullParam("name", name);
+        Map<String, ProgramObject> definedObjects = this.moduleObjects;
+        synchronized (this) {
+            ProgramObject existing = definedObjects.get(name);
+            if (existing == null) {
+                DataDeclaration decl = new DataDeclaration(originalElement, this, name, type);
+                definedObjects.put(name, decl);
+                return decl;
+            } else {
+                if (existing instanceof DataDeclaration decl) {
+                    if (! type.equals(decl.getValueType())) {
+                        clash(originalElement, name);
+                    }
+                    return decl;
+                } else if (existing instanceof Data data) {
+                    if (! type.equals(data.getValueType())) {
+                        clash(originalElement, name);
+                    }
+                    return data.getDeclaration();
+                } else {
+                    clash(originalElement, name);
+                    return new DataDeclaration(originalElement, this, name, type);
+                }
+            }
+        }
+    }
+
+    void clash(final MemberElement originalElement, final String name) {
+        if (originalElement != null) {
+            originalElement.getEnclosingType().getContext().getCompilationContext().error(originalElement, "Object '%s' redeclared with different type", name);
+        } else {
+            getTypeDefinition().getContext().getCompilationContext().error("Synthetic object '%s' redeclared with different type", name);
+        }
+    }
+
+    private ModuleSection registerSection(final Section section) {
+        return new ModuleSection(section, typeSystem.getVoidType(), this);
+    }
+
+    public Iterable<Declaration> declarations() {
+        return new Iterable<Declaration>() {
+            @Override
+            public Iterator<Declaration> iterator() {
+                List<Declaration> decls;
+                synchronized (ProgramModule.this) {
+                    decls = new ArrayList<>(moduleObjects.size());
+                    for (ProgramObject programObject : moduleObjects.values()) {
+                        if (programObject instanceof Declaration decl) {
+                            decls.add(decl);
+                        }
+                    }
+                }
+                decls.sort(Comparator.comparing(ProgramObject::getName));
+                return decls.iterator();
+            }
+        };
     }
 }

--- a/compiler/src/main/java/org/qbicc/object/ProgramObject.java
+++ b/compiler/src/main/java/org/qbicc/object/ProgramObject.java
@@ -40,6 +40,8 @@ public abstract class ProgramObject {
         this.threadLocalMode = original.getThreadLocalMode();
     }
 
+    public abstract ProgramModule getProgramModule();
+
     public String getName() {
         return name;
     }
@@ -91,7 +93,7 @@ public abstract class ProgramObject {
         return pointer;
     }
 
-    public abstract ProgramObject getDeclaration();
+    public abstract Declaration getDeclaration();
 
     /**
      * Get the type of the value contained in this object.  This is the pointee of the symbol type,

--- a/compiler/src/main/java/org/qbicc/object/SectionObject.java
+++ b/compiler/src/main/java/org/qbicc/object/SectionObject.java
@@ -1,35 +1,46 @@
 package org.qbicc.object;
 
 import org.qbicc.type.ValueType;
-import org.qbicc.type.definition.element.Element;
+import org.qbicc.type.definition.element.MemberElement;
 
 /**
  * An object which is part of a section.
  */
 public abstract class SectionObject extends ProgramObject {
-    final Element originalElement;
+    final MemberElement originalElement;
+    final ModuleSection moduleSection;
 
-    SectionObject(final Element originalElement, final String name, final ValueType valueType) {
+    SectionObject(final MemberElement originalElement, final String name, final ValueType valueType, ModuleSection moduleSection) {
         super(name, valueType);
         this.originalElement = originalElement;
-    }
-
-    SectionObject(final SectionObject original) {
-        super(original);
-        this.originalElement = original.getOriginalElement();
+        this.moduleSection = moduleSection;
     }
 
     /**
      * The program-level element that caused this SectionObject to be generated.
      * If the SectionObject is synthetic (injected by/for the qbicc runtime) originalElement will be null
      */
-    public Element getOriginalElement() {
+    public MemberElement getOriginalElement() {
         return originalElement;
     }
 
-    public abstract SectionObject getDeclaration();
+    @Override
+    public ProgramModule getProgramModule() {
+        return moduleSection.getProgramModule();
+    }
+
+    public abstract Declaration getDeclaration();
 
     public String toString() {
         return getName();
+    }
+
+    /**
+     * Get the module section that this object belongs to.
+     *
+     * @return the module section (not {@code null})
+     */
+    public ModuleSection getModuleSection() {
+        return moduleSection;
     }
 }

--- a/compiler/src/main/java/org/qbicc/object/Segment.java
+++ b/compiler/src/main/java/org/qbicc/object/Segment.java
@@ -1,0 +1,27 @@
+package org.qbicc.object;
+
+/**
+ * A segment into which sections may be defined.
+ */
+public enum Segment {
+    /**
+     * The so-called "text" segment, where read-only program information is loaded.
+     */
+    TEXT("text"),
+    /**
+     * The so-called "data" segment, where read-write program information is loaded.
+     */
+    DATA("data"),
+    ;
+
+    private final String str;
+
+    Segment(final String str) {
+        this.str = str;
+    }
+
+    @Override
+    public String toString() {
+        return str;
+    }
+}

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -29,7 +29,9 @@ import org.qbicc.machine.arch.Platform;
 import org.qbicc.object.Function;
 import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.ProgramModule;
+import org.qbicc.object.ModuleSection;
 import org.qbicc.object.Section;
+import org.qbicc.object.Segment;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.InvokableType;
@@ -120,10 +122,6 @@ public class TestClassContext implements ClassContext {
             return null;
         }
 
-        public ProgramModule getProgramModule(final DefinedTypeDefinition type) {
-            return null;
-        }
-
         public ProgramModule getOrAddProgramModule(final DefinedTypeDefinition type) {
             return null;
         }
@@ -136,12 +134,24 @@ public class TestClassContext implements ClassContext {
             return null;
         }
 
-        public Section getImplicitSection(ExecutableElement element) {
+        public ModuleSection getImplicitSection(ExecutableElement element) {
             return null;  // TODO: Customise this generated block
         }
         
-        public Section getImplicitSection(DefinedTypeDefinition typeDefinition) {
+        public ModuleSection getImplicitSection(DefinedTypeDefinition typeDefinition) {
             return null;  // TODO: Customise this generated block
+        }
+
+        public Section getSection(String name) {
+            return null;
+        }
+
+        public Section addSection(String name, int index, Segment segment, Section.Attribute... attributes) {
+            return null;
+        }
+
+        public Section getImplicitSection() {
+            return null;
         }
 
         public Function getExactFunction(final ExecutableElement element) {

--- a/machine/arch/src/main/java/org/qbicc/machine/arch/ObjectType.java
+++ b/machine/arch/src/main/java/org/qbicc/machine/arch/ObjectType.java
@@ -31,4 +31,64 @@ public final class ObjectType extends PlatformComponent {
     public static Set<String> getNames() {
         return index.keySet();
     }
+
+    /**
+     * Format a section name according to the rules of this object file format.
+     *
+     * @param segmentName the segment name (must not be {@code null})
+     * @param simpleName the simple name (must not be {@code null})
+     * @return the object-specific section name (not {@code null})
+     */
+    public String formatSectionName(final String segmentName, final String simpleName) {
+        if (this == MACH_O) {
+            return formatSegmentName(segmentName) + ",__" + simpleName;
+        } else {
+            return "." + simpleName;
+        }
+    }
+
+    /**
+     * Format a segment name according to the rules of this object file format.
+     *
+     * @param name the segment name (must not be {@code null})
+     * @return the object-specific segment name (not {@code null})
+     */
+    public String formatSegmentName(final String name) {
+        if (this == MACH_O) {
+            return "__" + name.toUpperCase(Locale.ROOT);
+        } else {
+            return name + "-segment";
+        }
+    }
+
+    /**
+     * Format the start-of-segment name according to the rules of this object file format.
+     *
+     * @param segmentName the segment name (must not be {@code null})
+     * @param simpleName  the section's simple name (must not be {@code null})
+     * @return the object-specific symbol (not {@code null})
+     */
+    public String formatStartOfSectionSymbolName(final String segmentName, final String simpleName) {
+        // todo: COFF: https://stackoverflow.com/questions/3808053/how-to-get-a-pointer-to-a-binary-section-in-msvc?noredirect=1&lq=1
+        if (this == MACH_O) {
+            return "section$start$" + formatSegmentName(segmentName) + "$__" + simpleName;
+        } else {
+            return "__start_" + simpleName;
+        }
+    }
+
+    /**
+     * Format the end-of-segment name according to the rules of this object file format.
+     *
+     * @param segmentName the segment name (must not be {@code null})
+     * @param simpleName  the section's simple name (must not be {@code null})
+     * @return the object-specific symbol (not {@code null})
+     */
+    public String formatEndOfSectionSymbolName(final String segmentName, final String simpleName) {
+        if (this == MACH_O) {
+            return "section$end$" + formatSegmentName(segmentName) + "$__" + simpleName;
+        } else {
+            return "__stop_" + simpleName;
+        }
+    }
 }

--- a/machine/arch/src/main/java/org/qbicc/machine/arch/Platform.java
+++ b/machine/arch/src/main/java/org/qbicc/machine/arch/Platform.java
@@ -53,6 +53,25 @@ public final class Platform {
         return cpu.getSimpleName() + '-' + os + '-' + abi + '-' + objectType;
     }
 
+    /**
+     * Format a section name according to the rules of this platform.
+     *
+     * @param segmentName the simple segment name (must not be {@code null})
+     * @param simpleName the simple section name (must not be {@code null})
+     * @return the platform-specific section name (not {@code null})
+     */
+    public String formatSectionName(String segmentName, String simpleName) {
+        return objectType.formatSectionName(segmentName, simpleName);
+    }
+
+    public String formatStartOfSectionSymbolName(String segmentName, String simpleName) {
+        return objectType.formatStartOfSectionSymbolName(segmentName, simpleName);
+    }
+
+    public String formatEndOfSectionSymbolName(String segmentName, String simpleName) {
+        return objectType.formatEndOfSectionSymbolName(segmentName, simpleName);
+    }
+
     public boolean isSupersetOf(Platform other) {
         return cpu.incorporates(other.cpu) && os.equals(other.os) && abi.equals(other.abi);
     }

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotGenerator.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/DotGenerator.java
@@ -25,7 +25,8 @@ import org.qbicc.graph.NodeVisitor;
 import org.qbicc.object.Function;
 import org.qbicc.object.ProgramModule;
 import org.qbicc.object.ProgramObject;
-import org.qbicc.object.Section;
+import org.qbicc.object.ModuleSection;
+import org.qbicc.object.SectionObject;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.MethodBody;
 import org.qbicc.type.definition.classfile.ClassFile;
@@ -66,8 +67,8 @@ public class DotGenerator implements ElementVisitor<CompilationContext, Void>, C
 
     static final class Producer {
         private final Iterator<ProgramModule> pmIter;
-        private Iterator<Section> sectionIter;
-        private Iterator<ProgramObject> fnIter;
+        private Iterator<ModuleSection> sectionIter;
+        private Iterator<SectionObject> fnIter;
 
         Producer(CompilationContext ctxt) {
             pmIter = ctxt.getAllProgramModules().iterator();
@@ -75,7 +76,7 @@ public class DotGenerator implements ElementVisitor<CompilationContext, Void>, C
 
         Function next() {
             synchronized (this) {
-                ProgramObject item;
+                SectionObject item;
                 do {
                     while (fnIter == null || ! fnIter.hasNext()) {
                         while (sectionIter == null || ! sectionIter.hasNext()) {

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -12,7 +12,8 @@ import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
-import org.qbicc.object.Section;
+import org.qbicc.object.ModuleSection;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayTables.IdAndRange.Factory;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.type.ArrayType;
@@ -459,7 +460,7 @@ public class SupersDisplayTables {
         Literal typeIdsValue = ctxt.getLiteralFactory().literalOf((ArrayType)typeIdArrayGlobal.getType(), List.of(typeIdTable));
         
         /* Write the data into Object's section */
-        Section section = ctxt.getImplicitSection(jlo);
+        ModuleSection section = ctxt.getImplicitSection(jlo);
         section.addData(null, GLOBAL_TYPEID_ARRAY, typeIdsValue);
     }
 
@@ -475,8 +476,8 @@ public class SupersDisplayTables {
     public GlobalVariableElement getAndRegisterGlobalTypeIdArray(ExecutableElement originalElement) {
         Assert.assertNotNull(typeIdArrayGlobal);
         if (!typeIdArrayGlobal.getEnclosingType().equals(originalElement.getEnclosingType())) {
-            Section section = ctxt.getImplicitSection(originalElement.getEnclosingType());
-            section.declareData(null, typeIdArrayGlobal.getName(), typeIdArrayGlobal.getType());
+            ProgramModule programModule = ctxt.getOrAddProgramModule(originalElement.getEnclosingType());
+            programModule.declareData(null, typeIdArrayGlobal.getName(), typeIdArrayGlobal.getType());
         }
         return typeIdArrayGlobal;
     }

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -35,7 +35,7 @@ import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.graph.literal.UndefinedLiteral;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.object.Data;
-import org.qbicc.object.Section;
+import org.qbicc.object.ModuleSection;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.intrinsics.InstanceIntrinsic;
 import org.qbicc.plugin.intrinsics.Intrinsics;
@@ -344,11 +344,11 @@ final class CNativeIntrinsics {
             Literal literal = lf.literalOf(ts.getArrayType(ts.getUnsignedInteger8Type(), bytes.length), bytes);
             Data data = utf8zCache.computeIfAbsent(literal, bal -> {
                 ExecutableElement currentElement = builder.getCurrentElement();
-                Section section = ctxt.getImplicitSection(currentElement);
+                ModuleSection section = ctxt.getImplicitSection(currentElement);
                 return section.addData(null, "utf8z_" + cnt.incrementAndGet(), bal);
             });
             final IntegerLiteral z = lf.literalOf(0);
-            final ProgramObjectLiteral global = lf.literalOf(ctxt.getImplicitSection(builder.getCurrentElement()).declareData(data));
+            final ProgramObjectLiteral global = lf.literalOf(ctxt.getOrAddProgramModule(builder.getCurrentElement().getEnclosingType()).declareData(data));
             // get the zeroth array element of the zeroth pointer element of the global
             return builder.addressOf(builder.elementOf(builder.pointerHandle(global), z));
         };

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -35,7 +35,7 @@ import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.machine.probe.CProbe;
-import org.qbicc.object.Section;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.coreclasses.RuntimeMethodFinder;
 import org.qbicc.plugin.dispatch.DispatchTables;
@@ -968,8 +968,8 @@ public final class CoreIntrinsics {
         StaticIntrinsic callRuntimeInitializer = (builder, target, arguments) -> {
             Value index = arguments.get(0);
             GlobalVariableElement rtinitTable = DispatchTables.get(ctxt).getRTInitsGlobal();
-            Section section = ctxt.getImplicitSection(builder.getCurrentElement().getEnclosingType());
-            section.declareData(null, rtinitTable.getName(), rtinitTable.getType());
+            ProgramModule programModule = ctxt.getOrAddProgramModule(builder.getCurrentElement().getEnclosingType());
+            programModule.declareData(null, rtinitTable.getName(), rtinitTable.getType());
             Value initFunc = builder.load(builder.elementOf(builder.globalVariable(rtinitTable), index));
             return builder.call(builder.pointerHandle(initFunc), List.of(builder.load(builder.currentThread(), SingleUnshared)));
         };

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -103,7 +103,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
     private Value minMaxIntrinsic(String funcName, NumericType numericType, Value v1, Value v2) {
         TypeSystem tps = ctxt.getTypeSystem();
         FunctionType functionType = tps.getFunctionType(numericType, numericType, numericType);
-        FunctionDeclaration declaration = ctxt.getImplicitSection(getRootElement()).declareFunction(null, funcName, functionType);
+        FunctionDeclaration declaration = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(null, funcName, functionType);
         final LiteralFactory lf = ctxt.getLiteralFactory();
         return getFirstBuilder().callNoSideEffects(pointerHandle(lf.literalOf(declaration)), List.of(v1, v2));
     }
@@ -118,7 +118,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
             throw new IllegalArgumentException("Invalid integer type " + inputType + " for byte swap (must be a multiple of 16 bits)");
         }
         String functionName = "llvm.bswap.i" + minBits;
-        FunctionDeclaration declaration = ctxt.getImplicitSection(getRootElement()).declareFunction(null, functionName, functionType);
+        FunctionDeclaration declaration = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(null, functionName, functionType);
         final LiteralFactory lf = ctxt.getLiteralFactory();
         return getFirstBuilder().callNoSideEffects(pointerHandle(lf.literalOf(declaration)), List.of(v));
     }
@@ -130,7 +130,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         FunctionType functionType = tps.getFunctionType(inputType, inputType);
         int minBits = inputType.getMinBits();
         String functionName = "llvm.bitreverse.i" + minBits;
-        FunctionDeclaration declaration = ctxt.getImplicitSection(getRootElement()).declareFunction(null, functionName, functionType);
+        FunctionDeclaration declaration = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(null, functionName, functionType);
         final LiteralFactory lf = ctxt.getLiteralFactory();
         return getFirstBuilder().callNoSideEffects(pointerHandle(lf.literalOf(declaration)), List.of(v));
     }
@@ -142,7 +142,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         FunctionType functionType = tps.getFunctionType(inputType.asUnsigned(), inputType, tps.getBooleanType());
         int minBits = inputType.getMinBits();
         String functionName = "llvm.ctlz.i" + minBits;
-        FunctionDeclaration declaration = ctxt.getImplicitSection(getRootElement()).declareFunction(null, functionName, functionType);
+        FunctionDeclaration declaration = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(null, functionName, functionType);
         LiteralFactory lf = ctxt.getLiteralFactory();
         Value result = getFirstBuilder().callNoSideEffects(pointerHandle(lf.literalOf(declaration)), List.of(v, lf.literalOf(false)));
         // LLVM always returns the same type as the input
@@ -165,7 +165,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         FunctionType functionType = tps.getFunctionType(inputType.asUnsigned(), inputType, tps.getBooleanType());
         int minBits = inputType.getMinBits();
         String functionName = "llvm.cttz.i" + minBits;
-        FunctionDeclaration declaration = ctxt.getImplicitSection(getRootElement()).declareFunction(null, functionName, functionType);
+        FunctionDeclaration declaration = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(null, functionName, functionType);
         LiteralFactory lf = ctxt.getLiteralFactory();
         Value result = getFirstBuilder().callNoSideEffects(pointerHandle(lf.literalOf(declaration)), List.of(v, lf.literalOf(false)));
         // LLVM always returns the same type as the input
@@ -188,7 +188,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         FunctionType functionType = tps.getFunctionType(inputType.asUnsigned(), inputType);
         int minBits = inputType.getMinBits();
         String functionName = "llvm.ctpop.i" + minBits;
-        FunctionDeclaration declaration = ctxt.getImplicitSection(getRootElement()).declareFunction(null, functionName, functionType);
+        FunctionDeclaration declaration = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(null, functionName, functionType);
         final LiteralFactory lf = ctxt.getLiteralFactory();
         Value result = getFirstBuilder().callNoSideEffects(pointerHandle(lf.literalOf(declaration)), List.of(v));
         // LLVM always returns the same type as the input
@@ -283,7 +283,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
     @Override
     public BasicBlock unreachable() {
         TypeSystem ts = ctxt.getTypeSystem();
-        FunctionDeclaration decl = ctxt.getImplicitSection(getRootElement()).declareFunction(null, "llvm.trap", ts.getFunctionType(ts.getVoidType()));
+        FunctionDeclaration decl = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(null, "llvm.trap", ts.getFunctionType(ts.getVoidType()));
         return callNoReturn(pointerHandle(ctxt.getLiteralFactory().literalOf(decl)), List.of());
     }
 
@@ -658,7 +658,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         // declare personality function
         MethodElement personalityMethod = UnwindHelper.get(ctxt).getPersonalityMethod();
         Function function = ctxt.getExactFunction(personalityMethod);
-        ctxt.getImplicitSection(getRootElement()).declareFunction(function);
+        ctxt.getOrAddProgramModule(getRootElement()).declareFunction(function);
         return super.invokeNoReturn(target, arguments, catchLabel);
     }
 
@@ -667,7 +667,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         // declare personality function
         MethodElement personalityMethod = UnwindHelper.get(ctxt).getPersonalityMethod();
         Function function = ctxt.getExactFunction(personalityMethod);
-        ctxt.getImplicitSection(getRootElement()).declareFunction(function);
+        ctxt.getOrAddProgramModule(getRootElement()).declareFunction(function);
         return super.invoke(target, arguments, catchLabel, resumeLabel);
     }
 
@@ -676,7 +676,7 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
         // declare personality function
         MethodElement personalityMethod = UnwindHelper.get(ctxt).getPersonalityMethod();
         Function function = ctxt.getExactFunction(personalityMethod);
-        ctxt.getImplicitSection(getRootElement()).declareFunction(function);
+        ctxt.getOrAddProgramModule(getRootElement()).declareFunction(function);
         if (isTailCallSafe()) {
             return super.tailInvoke(target, arguments, catchLabel);
         }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
@@ -17,7 +17,7 @@ public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContex
     @Override
     public void accept(CompilationContext context) {
         LLVMModuleGenerator generator = new LLVMModuleGenerator(context, isPie ? 2 : 0, isPie ? 2 : 0);
-        Path modulePath = generator.processProgramModule(context.getProgramModule(context.getDefaultTypeDefinition()));
+        Path modulePath = generator.processProgramModule(context.getOrAddProgramModule(context.getDefaultTypeDefinition()));
         if (compileOutput) {
             LLVMCompiler compiler = new LLVMCompiler(context, isPie);
             compiler.compileModule(context, modulePath);

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
@@ -1,45 +1,14 @@
 package org.qbicc.plugin.llvm;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 
 import org.qbicc.context.CompilationContext;
-import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.ValueVisitor;
-import org.qbicc.graph.literal.Literal;
-import org.qbicc.graph.schedule.Schedule;
-import org.qbicc.machine.llvm.FunctionAttributes;
-import org.qbicc.machine.llvm.FunctionDefinition;
-import org.qbicc.machine.llvm.Global;
 import org.qbicc.machine.llvm.LLValue;
-import org.qbicc.machine.llvm.Linkage;
-import org.qbicc.machine.llvm.Module;
-import org.qbicc.machine.llvm.ModuleFlagBehavior;
-import org.qbicc.machine.llvm.RuntimePreemption;
-import org.qbicc.machine.llvm.ThreadLocalStorageModel;
-import org.qbicc.machine.llvm.Types;
-import org.qbicc.machine.llvm.Values;
-import org.qbicc.object.Data;
-import org.qbicc.object.DataDeclaration;
-import org.qbicc.object.Function;
-import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.ProgramModule;
-import org.qbicc.object.ProgramObject;
-import org.qbicc.object.Section;
-import org.qbicc.object.ThreadLocalMode;
-import org.qbicc.type.FunctionType;
-import org.qbicc.type.ValueType;
-import org.qbicc.type.VariadicType;
-import org.qbicc.type.definition.DefinedTypeDefinition;
-import org.qbicc.type.definition.MethodBody;
-import org.qbicc.type.definition.element.ExecutableElement;
-import io.smallrye.common.constraint.Assert;
 
 /**
  *

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMIntrinsics.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMIntrinsics.java
@@ -11,18 +11,15 @@ import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.BlockEarlyTermination;
 import org.qbicc.graph.ClassOf;
 import org.qbicc.graph.Load;
-import org.qbicc.graph.NewArray;
 import org.qbicc.graph.StaticMethodElementHandle;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
-import org.qbicc.graph.literal.ArrayLiteral;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
-import org.qbicc.graph.literal.ZeroInitializerLiteral;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.plugin.intrinsics.Intrinsics;
@@ -31,7 +28,6 @@ import org.qbicc.type.ArrayType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.VariadicType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.descriptor.ArrayTypeDescriptor;
@@ -174,7 +170,7 @@ public final class LLVMIntrinsics {
             TypeSystem ts = ctxt.getTypeSystem();
             LiteralFactory lf = ctxt.getLiteralFactory();
             FunctionType fnType = ts.getFunctionType(ts.getSignedInteger32Type(), ts.getFloat32Type());
-            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i32.f32", fnType);
+            FunctionDeclaration decl = ctxt.getOrAddProgramModule(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i32.f32", fnType);
             return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
         };
 
@@ -184,7 +180,7 @@ public final class LLVMIntrinsics {
             TypeSystem ts = ctxt.getTypeSystem();
             LiteralFactory lf = ctxt.getLiteralFactory();
             FunctionType fnType = ts.getFunctionType(ts.getSignedInteger64Type(), ts.getFloat32Type());
-            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i64.f32", fnType);
+            FunctionDeclaration decl = ctxt.getOrAddProgramModule(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i64.f32", fnType);
             return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
         };
 
@@ -194,7 +190,7 @@ public final class LLVMIntrinsics {
             TypeSystem ts = ctxt.getTypeSystem();
             LiteralFactory lf = ctxt.getLiteralFactory();
             FunctionType fnType = ts.getFunctionType(ts.getSignedInteger32Type(), ts.getFloat64Type());
-            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i32.f64", fnType);
+            FunctionDeclaration decl = ctxt.getOrAddProgramModule(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i32.f64", fnType);
             return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
         };
 
@@ -204,7 +200,7 @@ public final class LLVMIntrinsics {
             TypeSystem ts = ctxt.getTypeSystem();
             LiteralFactory lf = ctxt.getLiteralFactory();
             FunctionType fnType = ts.getFunctionType(ts.getSignedInteger64Type(), ts.getFloat64Type());
-            FunctionDeclaration decl = ctxt.getImplicitSection(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i64.f64", fnType);
+            FunctionDeclaration decl = ctxt.getOrAddProgramModule(builder.getRootElement()).declareFunction(null, "llvm.fptosi.sat.i64.f64", fnType);
             return builder.getFirstBuilder().callNoSideEffects(builder.pointerHandle(lf.literalOf(decl)), arguments);
         };
 

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -18,7 +18,7 @@ import org.qbicc.graph.literal.ZeroInitializerLiteral;
 import org.qbicc.object.Data;
 import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Linkage;
-import org.qbicc.object.Section;
+import org.qbicc.object.ModuleSection;
 import org.qbicc.plugin.constants.Constants;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
@@ -80,7 +80,7 @@ public class Lowering {
         }
         // we added it, so we must add the definition as well
         LiteralFactory lf = ctxt.getLiteralFactory();
-        Section section = ctxt.getOrAddProgramModule(typeDef).getOrAddSection(sectionName);
+        ModuleSection section = ctxt.getOrAddProgramModule(typeDef).getOrAddSection(sectionName);
         Value initialValue;
         boolean hasValue;
         if (field.getRunTimeInitializer() != null) {
@@ -125,7 +125,7 @@ public class Lowering {
         }
         if (initialValue instanceof ObjectLiteral ol) {
             ProgramObjectLiteral objLit = BuildtimeHeap.get(ctxt).serializeVmObject(ol.getValue());
-            DataDeclaration decl = section.declareData(objLit.getProgramObject());
+            DataDeclaration decl = section.getProgramModule().declareData(objLit.getProgramObject());
             decl.setAddrspace(1);
             ProgramObjectLiteral refToLiteral = lf.literalOf(decl);
             initialValue = lf.valueConvertLiteral(refToLiteral, ol.getType());

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
@@ -9,7 +9,7 @@ import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.literal.PointerLiteral;
 import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Function;
-import org.qbicc.object.Section;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.pointer.ElementPointer;
 import org.qbicc.pointer.InstanceFieldPointer;
@@ -52,14 +52,14 @@ public final class MemberPointerCopier implements NodeVisitor.Delegating<Node.Co
         if (pointer instanceof StaticMethodPointer smp) {
             MethodElement method = smp.getStaticMethod();
             Function function = ctxt.getExactFunction(method);
-            Section section = ctxt.getImplicitSection(copier.getBlockBuilder().getCurrentElement());
-            DataDeclaration decl = section.declareData(function);
+            ProgramModule programModule = ctxt.getOrAddProgramModule(copier.getBlockBuilder().getCurrentElement().getEnclosingType());
+            DataDeclaration decl = programModule.declareData(function);
             return ProgramObjectPointer.of(decl);
         } else if (pointer instanceof StaticFieldPointer sfp) {
             FieldElement field = sfp.getStaticField();
             GlobalVariableElement global = Lowering.get(ctxt).getGlobalForStaticField(field);
-            Section section = ctxt.getImplicitSection(copier.getBlockBuilder().getCurrentElement());
-            DataDeclaration decl = section.declareData(field, global.getName(), global.getType());
+            ProgramModule programModule = ctxt.getOrAddProgramModule(copier.getBlockBuilder().getCurrentElement().getEnclosingType());
+            DataDeclaration decl = programModule.declareData(field, global.getName(), global.getType());
             return ProgramObjectPointer.of(decl);
         } else if (pointer instanceof ElementPointer ep) {
             return new ElementPointer(lowerPointer(copier, ep.getArrayPointer()), ep.getIndex());

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
@@ -4,7 +4,7 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.ValueHandle;
-import org.qbicc.object.Section;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
@@ -31,8 +31,8 @@ public class StaticFieldLoweringBasicBlockBuilder extends DelegatingBasicBlockBu
         DefinedTypeDefinition fieldHolder = field.getEnclosingType();
         if (! fieldHolder.equals(ourHolder)) {
             // we have to declare it in our translation unit
-            Section section = ctxt.getOrAddProgramModule(ourHolder).getOrAddSection(global.getSection());
-            section.declareData(field, global.getName(), global.getType());
+            ProgramModule programModule = ctxt.getOrAddProgramModule(ourHolder);
+            programModule.declareData(field, global.getName(), global.getType());
         }
         return globalVariable(global);
     }

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/ThrowLoweringBasicBlockBuilder.java
@@ -35,7 +35,7 @@ public class ThrowLoweringBasicBlockBuilder extends DelegatingBasicBlockBuilder 
         String functionName = "_Unwind_RaiseException";
         MethodType origType = teh.getRaiseExceptionMethod().getType();
         FunctionType functionType = ts.getFunctionType(origType.getReturnType(), origType.getParameterTypes());
-        FunctionDeclaration decl = ctxt.getImplicitSection(getRootElement()).declareFunction(teh.getRaiseExceptionMethod(), functionName, functionType);
+        FunctionDeclaration decl = ctxt.getOrAddProgramModule(getRootElement()).declareFunction(teh.getRaiseExceptionMethod(), functionName, functionType);
         return callNoReturn(pointerHandle(ctxt.getLiteralFactory().literalOf(decl)), List.of(ptr));
     }
 }

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataTypes.java
@@ -3,7 +3,7 @@ package org.qbicc.plugin.methodinfo;
 import io.smallrye.common.constraint.Assert;
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
-import org.qbicc.object.Section;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
@@ -90,8 +90,8 @@ public class MethodDataTypes {
     public GlobalVariableElement getAndRegisterGlobalMethodData(ExecutableElement originalElement) {
         Assert.assertNotNull(globalMethodData);
         if (originalElement != null && !globalMethodData.getEnclosingType().equals(originalElement.getEnclosingType())) {
-            Section section = ctxt.getImplicitSection(originalElement.getEnclosingType());
-            section.declareData(null, globalMethodData.getName(), globalMethodData.getType());
+            ProgramModule programModule = ctxt.getOrAddProgramModule(originalElement.getEnclosingType());
+            programModule.declareData(null, globalMethodData.getName(), globalMethodData.getType());
         }
         return globalMethodData;
     }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
@@ -11,7 +11,8 @@ import org.qbicc.machine.probe.CProbe;
 import org.qbicc.object.Data;
 import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Linkage;
-import org.qbicc.object.Section;
+import org.qbicc.object.ModuleSection;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.object.ThreadLocalMode;
 import org.qbicc.plugin.core.ConditionEvaluation;
 import org.qbicc.type.FunctionType;
@@ -20,7 +21,6 @@ import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.annotation.Annotation;
-import org.qbicc.type.annotation.AnnotationValue;
 import org.qbicc.type.annotation.ArrayAnnotationValue;
 import org.qbicc.type.annotation.IntAnnotationValue;
 import org.qbicc.type.annotation.StringAnnotationValue;
@@ -144,9 +144,9 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
                         ctxt.error(resolved, "External (imported) fields must be `static`");
                     }
                     // declare it
-                    Section section = ctxt.getOrAddProgramModule(enclosing).getOrAddSection(CompilationContext.IMPLICIT_SECTION_NAME);
+                    ProgramModule programModule = ctxt.getOrAddProgramModule(enclosing);
                     ValueType fieldType = resolved.getType();
-                    DataDeclaration decl = section.declareData(resolved, name, fieldType);
+                    DataDeclaration decl = programModule.declareData(resolved, name, fieldType);
                     if (resolved.hasAllModifiersOf(ClassFile.I_ACC_THREAD_LOCAL)) {
                         decl.setThreadLocalMode(ThreadLocalMode.GENERAL_DYNAMIC);
                     }
@@ -158,7 +158,7 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
                         ctxt.error(resolved, "Exported fields must be `static`");
                     }
                     // define it
-                    Section section = ctxt.getOrAddProgramModule(enclosing).getOrAddSection(CompilationContext.IMPLICIT_SECTION_NAME);
+                    ModuleSection section = ctxt.getOrAddProgramModule(enclosing).getOrAddSection(CompilationContext.IMPLICIT_SECTION_NAME);
                     ValueType fieldType = resolved.getType();
                     Data data = section.addData(resolved, name, ctxt.getLiteralFactory().zeroInitializerLiteralOfType(fieldType));
                     if (resolved.hasAllModifiersOf(ClassFile.I_ACC_THREAD_LOCAL)) {

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeBasicBlockBuilder.java
@@ -14,7 +14,6 @@ import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.ProgramObjectLiteral;
-import org.qbicc.object.Section;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.ValueType;
@@ -148,7 +147,7 @@ public class NativeBasicBlockBuilder extends DelegatingBasicBlockBuilder {
                 }
             }
             // declare it
-            return pointerHandle(ctxt.getLiteralFactory().literalOf(ctxt.getImplicitSection(getRootElement())
+            return pointerHandle(ctxt.getLiteralFactory().literalOf(ctxt.getOrAddProgramModule(getRootElement())
                 .declareFunction(null, functionInfo.getName(), functionInfo.getType())));
         }
         return super.staticMethod(owner, name, deNative(descriptor));
@@ -230,8 +229,7 @@ public class NativeBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         ProgramObjectLiteral sym = fieldInfo.symbolLiteral;
         DefinedTypeDefinition ourType = getRootElement().getEnclosingType();
         // declare it
-        Section section = ctxt.getImplicitSection(ourType);
-        return ctxt.getLiteralFactory().literalOf(section.declareData(sym.getProgramObject()));
+        return ctxt.getLiteralFactory().literalOf(ctxt.getOrAddProgramModule(ourType).declareData(sym.getProgramObject()));
     }
 
 }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeXtorLoweringHook.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeXtorLoweringHook.java
@@ -36,7 +36,7 @@ public final class NativeXtorLoweringHook {
                 ctxt.error(functionElement, "No lowered function for entry point element");
                 continue;
             }
-            ProgramModule programModule = ctxt.getProgramModule(enclosingType);
+            ProgramModule programModule = ctxt.getOrAddProgramModule(enclosingType);
             if (programModule == null) {
                 ctxt.error(functionElement, "No program module for reachable element");
                 continue;

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/InliningBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/InliningBasicBlockBuilder.java
@@ -56,10 +56,11 @@ import org.qbicc.graph.ValueHandleVisitor;
 import org.qbicc.graph.ValueReturn;
 import org.qbicc.graph.Xor;
 import org.qbicc.object.DataDeclaration;
+import org.qbicc.object.Declaration;
 import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.ProgramModule;
 import org.qbicc.object.ProgramObject;
-import org.qbicc.object.Section;
+import org.qbicc.object.ModuleSection;
 import org.qbicc.type.definition.MethodBody;
 import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -263,13 +264,11 @@ public class  InliningBasicBlockBuilder extends DelegatingBasicBlockBuilder impl
     private void copyDeclarations(final ExecutableElement target) {
         ProgramModule ourModule = ctxt.getOrAddProgramModule(getRootElement().getEnclosingType());
         ProgramModule module = ctxt.getOrAddProgramModule(target.getEnclosingType());
-        for (Section section : module.sections()) {
-            for (ProgramObject object : section.contents()) {
-                if (object instanceof FunctionDeclaration declaration) {
-                    ourModule.getOrAddSection(section.getName()).declareFunction(declaration);
-                } else if (object instanceof DataDeclaration declaration) {
-                    ourModule.getOrAddSection(section.getName()).declareData(declaration);
-                }
+        for (Declaration decl : module.declarations()) {
+            if (decl instanceof FunctionDeclaration declaration) {
+                ourModule.declareFunction(declaration);
+            } else if (decl instanceof DataDeclaration declaration) {
+                ourModule.declareData(declaration);
             }
         }
     }

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
@@ -8,7 +8,8 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.object.DataDeclaration;
-import org.qbicc.object.Section;
+import org.qbicc.object.ModuleSection;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayTables;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.type.ArrayType;
@@ -29,7 +30,8 @@ public class ClassObjectSerializer implements Consumer<CompilationContext> {
         SupersDisplayTables tables = SupersDisplayTables.get(ctxt);
         ReachabilityInfo reachabilityInfo = ReachabilityInfo.get(ctxt);
         LoadedTypeDefinition jlc = ctxt.getBootstrapClassContext().findDefinedType("java/lang/Class").load();
-        Section section = ctxt.getImplicitSection(jlc);
+        ModuleSection section = ctxt.getImplicitSection(jlc);
+        ProgramModule programModule = section.getProgramModule();
         ReferenceType jlcRef = jlc.getType().getReference();
         ArrayType rootArrayType = ctxt.getTypeSystem().getArrayType(jlcRef, tables.get_number_of_typeids());
 
@@ -47,7 +49,7 @@ public class ClassObjectSerializer implements Consumer<CompilationContext> {
         Arrays.fill(rootTable, ctxt.getLiteralFactory().zeroInitializerLiteralOfType(jlcRef));
         reachabilityInfo.visitReachableTypes(ltd -> {
             ProgramObjectLiteral cls = bth.serializeClassObject(ltd);
-            DataDeclaration decl = section.declareData(cls.getProgramObject());
+            DataDeclaration decl = programModule.declareData(cls.getProgramObject());
             decl.setAddrspace(1);
             ProgramObjectLiteral refToClass = ctxt.getLiteralFactory().literalOf(decl);
             rootTable[ltd.getTypeId()] = ctxt.getLiteralFactory().bitcastLiteral(refToClass, jlcRef);
@@ -56,7 +58,7 @@ public class ClassObjectSerializer implements Consumer<CompilationContext> {
         Primitive.forEach(type -> {
             ProgramObjectLiteral cls = bth.serializeClassObject(type);
             if (cls != null) {
-                DataDeclaration decl = section.declareData(cls.getProgramObject());
+                DataDeclaration decl = programModule.declareData(cls.getProgramObject());
                 decl.setAddrspace(1);
                 ProgramObjectLiteral refToClass = ctxt.getLiteralFactory().literalOf(decl);
                 rootTable[type.getTypeId()] = ctxt.getLiteralFactory().bitcastLiteral(refToClass, jlcRef);

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
@@ -32,13 +32,13 @@ public class ObjectLiteralSerializingVisitor implements NodeVisitor.Delegating<N
     public Value visit(final Node.Copier param, final StringLiteral node) {
         VmString vString = ctxt.getVm().intern(node.getValue());
         ProgramObjectLiteral literal = BuildtimeHeap.get(ctxt).serializeVmObject(vString);
-        ctxt.getImplicitSection(param.getBlockBuilder().getRootElement()).declareData(literal.getProgramObject());
+        ctxt.getOrAddProgramModule(param.getBlockBuilder().getRootElement()).declareData(literal.getProgramObject());
         return param.getBlockBuilder().notNull(ctxt.getLiteralFactory().bitcastLiteral(literal, node.getType()));
     }
 
     public Value visit(final Node.Copier param, final ObjectLiteral node) {
         ProgramObjectLiteral literal = BuildtimeHeap.get(ctxt).serializeVmObject(node.getValue());
-        ctxt.getImplicitSection(param.getBlockBuilder().getRootElement()).declareData(literal.getProgramObject());
+        ctxt.getOrAddProgramModule(param.getBlockBuilder().getRootElement()).declareData(literal.getProgramObject());
         return param.getBlockBuilder().notNull(ctxt.getLiteralFactory().bitcastLiteral(literal, node.getType()));
     }
 }


### PR DESCRIPTION
Rework the API for sections, program modules, and program objects:

* Removes section from declarations; they're always in the implicit section.
* Sort declarations in order by name.
* Create concept of "data-only" section, with known offset tracking for data objects.
* Introduce separate `Section` and `ModuleSection` concepts: `Section` defines the properties of the section for the entire image, vs `ModuleSection` which contains all of the object definitions in a particular section in a particular program module.
* Create an initial `Segment` concept, and utility methods to format section and segment names based on the target platform.
* Introduce `Declaration` intermediate abstract class for declaration types, which connects to a `ProgramModule`, as the complement for `SectionObject` which connects to a `ModuleSection`.

Resolves #1249.