### PR TITLE
recognize clang as installed from llvm.org on Ubuntu

### DIFF
--- a/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangToolProvider.java
+++ b/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangToolProvider.java
@@ -27,7 +27,7 @@ public class ClangToolProvider implements ToolProvider {
         return list;
     }
 
-    static final Pattern VERSION_PATTERN = Pattern.compile("^(?:clang|Apple (?:LLVM|clang)) version (\\S+)");
+    static final Pattern VERSION_PATTERN = Pattern.compile("^(?:clang|Apple (?:LLVM|clang)|Ubuntu (?:LLVM|clang)) version (\\S+)");
 
     private <T extends Tool> void tryOne(final Class<T> type, final Platform platform, final ArrayList<T> list, final Path path) {
         if (path != null && Files.isExecutable(path)) {


### PR DESCRIPTION
Not sure if this is the cleanest fix for this, but it does solve the problem I was having.

Background, I install LLVM 13 in a Docker container with a base image of `eclipse-temurin:17-focal` via: 
`RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13 && rm llvm.sh`

`clang -###` outputs:
```
Ubuntu clang version 13.0.1-++20220120110924+75e33f71c2da-1~exp1~20220120231001.58
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-13/bin
```
The existing regex didn't match, which resulted in this C tool chain not being recognized as valid.
