### PR TITLE
Suffix `$INODE64` not required in darwin/aarch64

### DIFF
--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysStat.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysStat.java
@@ -73,12 +73,12 @@ public final class SysStat {
     public static final mode_t S_IWOTH = constant();
     public static final mode_t S_IXOTH = constant();
 
-    @name(value = "stat$INODE64", when = Build.Target.IsMacOs.class)
+    @name(value = "stat$INODE64", when = { Build.Target.IsMacOs.class, Build.Target.IsAmd64.class })
     public static native c_int stat(const_char_ptr pathName, struct_stat_ptr statBuf);
-    @name(value = "fstat$INODE64", when = Build.Target.IsMacOs.class)
+    @name(value = "fstat$INODE64", when = { Build.Target.IsMacOs.class, Build.Target.IsAmd64.class })
     public static native c_int fstat(c_int fd, struct_stat_ptr statBuf);
-    @name(value = "lstat$INODE64", when = Build.Target.IsMacOs.class)
+    @name(value = "lstat$INODE64", when = { Build.Target.IsMacOs.class, Build.Target.IsAmd64.class })
     public static native c_int lstat(const_char_ptr pathName, struct_stat_ptr statBuf);
-    @name(value = "fstatat$INODE64", when = Build.Target.IsMacOs.class)
+    @name(value = "fstatat$INODE64", when = { Build.Target.IsMacOs.class, Build.Target.IsAmd64.class })
     public static native c_int fstatat(c_int dirFd, const_char_ptr pathName, struct_stat_ptr statBuf, c_int flags);
 }


### PR DESCRIPTION
Fixes #1269 

Added `isMacOsAmd64` and `isMacOsArm64` build targets to separate different native registrations depending of env.

This worked locally on M1 machine. Let's see if CI `darwin/amd64` agrees.