### PR TITLE
Stack allocate the stack walker

### DIFF
--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackFrameCache.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackFrameCache.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 @SuppressWarnings("unused")
 public class JavaStackFrameCache implements JavaStackFrameVisitor {
-    private final int sourceCodeIndexList[];
+    private final int[] sourceCodeIndexList;
 
     @AutoQueued
     JavaStackFrameCache(final int frameCount) {

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
@@ -2,77 +2,149 @@ package org.qbicc.runtime.stackwalk;
 
 import org.qbicc.runtime.AutoQueued;
 import org.qbicc.runtime.Hidden;
+import org.qbicc.runtime.StackObject;
 
-public class JavaStackWalker implements StackFrameVisitor {
+public final class JavaStackWalker extends StackObject {
     private static final int I_ACC_HIDDEN = 1 << 18;
 
+    private final boolean skipHidden;
+    private int index = -1;
+    private int sourceIndex = -1;
+    private int methodInfoIdx = -1;
 
-    private Throwable exceptionObject;
-    private JavaStackFrameVisitor visitor;
-    private int javaFrameCount;
+    public JavaStackWalker(boolean skipHidden) {
+        this.skipHidden = skipHidden;
+    }
 
-    private JavaStackWalker(Throwable exceptionObject, JavaStackFrameVisitor visitor) {
-        this.exceptionObject = exceptionObject;
-        this.visitor = visitor;
-        this.javaFrameCount = 0;
+    public JavaStackWalker(JavaStackWalker original) {
+        skipHidden = original.skipHidden;
+        index = original.index;
+        sourceIndex = original.sourceIndex;
+        methodInfoIdx = original.methodInfoIdx;
+    }
+
+    public boolean next(StackWalker stackWalker) {
+        for (;;) {
+            for (;;) {
+                if (sourceIndex != -1) {
+                    sourceIndex = MethodData.getInlinedAtIndex(sourceIndex);
+                    break;
+                } else if (!stackWalker.next()) {
+                    methodInfoIdx = -1;
+                    return false;
+                } else {
+                    // TODO: Mark "base" frames with a flag, to jump over natives; then, -1 is an error (corrupt stack)
+                    int ii = MethodData.findInstructionIndex(stackWalker.getIp().longValue());
+                    if (ii != -1) {
+                        sourceIndex = MethodData.getSourceCodeInfoIndex(ii);
+                        break;
+                    }
+                }
+            }
+            if (sourceIndex != -1) {
+                methodInfoIdx = MethodData.getMethodInfoIndex(sourceIndex);
+                if (skipHidden && MethodData.hasAllModifiersOf(methodInfoIdx, I_ACC_HIDDEN)) {
+                    // try again
+                    continue;
+                }
+                index ++;
+                return true;
+            }
+        }
     }
 
     @Hidden
     @AutoQueued
     public static int getFrameCount(Throwable exceptionObject) {
-        JavaStackWalker javaStackWalker = new JavaStackWalker(exceptionObject, new NopVisitor());
-        StackWalker.walkStack(javaStackWalker);
-        return javaStackWalker.javaFrameCount;
+        StackWalker sw = new StackWalker();
+        JavaStackWalker javaStackWalker = new JavaStackWalker(true);
+        int cnt = 0;
+        while (javaStackWalker.next(sw)) {
+            cnt ++;
+        }
+        return cnt;
+    }
+
+    /**
+     * Get the number of Java stack frames in the current stack.
+     *
+     * @param skipRawFrames the number of initial raw (native) frames to skip
+     * @param skipJavaFrames the number of initial Java frames to skip after any skipped raw frames
+     * @param skipHidden {@code true} to skip frames of hidden methods, {@code false} to retain them
+     * @return the number of matching frames
+     */
+    @Hidden
+    public static int getFrameCount(int skipRawFrames, int skipJavaFrames, boolean skipHidden) {
+        StackWalker sw = new StackWalker();
+        for (int i = 0; i < skipRawFrames; i ++) {
+            sw.next();
+        }
+        JavaStackWalker jsw = new JavaStackWalker(skipHidden);
+        for (int i = 0; i < skipJavaFrames; i ++) {
+            jsw.next(sw);
+        }
+        int cnt = 0;
+        while (jsw.next(sw)) {
+            cnt ++;
+        }
+        return cnt;
     }
 
     @Hidden
     @AutoQueued
     public static void walkStack(Throwable exceptionObject, JavaStackFrameVisitor visitor) {
-        StackFrameVisitor javaStackWalker = new JavaStackWalker(exceptionObject, visitor);
-        StackWalker.walkStack(javaStackWalker);
-    }
-
-    private boolean skipFrame(int scIndex, boolean isTopFrame) {
-        int minfoIndex = MethodData.getMethodInfoIndex(scIndex);
-        String methodName = MethodData.getMethodName(minfoIndex);
-        String className = MethodData.getClassName(minfoIndex);
-
-        if (isTopFrame) {
-            // if this is top frame, skip it if it is for excepption constructor or "fillInStackTrace" method
-            if (exceptionObject.getClass().getName().equals(className)) {
-                if (methodName.equals("<init>") || methodName.equals("fillInStackTrace")) {
-                    return true;
-                }
-            }
-        }
-        return MethodData.hasAllModifiersOf(minfoIndex, I_ACC_HIDDEN);
-    }
-
-    public void visitFrame(int frameIndex, long ip, long sp) {
-        int index = MethodData.findInstructionIndex(ip);
-        if (index != -1) {
-            int scIndex = MethodData.getSourceCodeInfoIndex(index);
-            boolean topFrame = (javaFrameCount == 0);
-            if (!skipFrame(scIndex, topFrame)) {
-                visitor.visitFrame(javaFrameCount, scIndex);
-                javaFrameCount += 1;
-            }
-            int inlinedAtIndex = MethodData.getInlinedAtIndex(scIndex);
-            while (inlinedAtIndex != -1) {
-                topFrame = (javaFrameCount == 0);
-                if (!skipFrame(scIndex, topFrame)) {
-                    visitor.visitFrame(javaFrameCount, inlinedAtIndex);
-                    javaFrameCount += 1;
-                }
-                inlinedAtIndex = MethodData.getInlinedAtIndex(inlinedAtIndex);
-            }
-        } else {
-            // skip this frame; probably a native frame
+        StackWalker sw = new StackWalker();
+        JavaStackWalker javaStackWalker = new JavaStackWalker(true);
+        while (javaStackWalker.next(sw)) {
+            visitor.visitFrame(javaStackWalker.index, javaStackWalker.sourceIndex);
         }
     }
 
-    private static class NopVisitor implements JavaStackFrameVisitor {
-        @Override
-        public void visitFrame(int frameIndex, int scIndex) { /* no-op */ }
+    public int getIndex() {
+        return index;
+    }
+
+    public String getFrameSourceFileName() {
+        if (sourceIndex == -1) throw new IllegalStateException();
+        return MethodData.getFileName(methodInfoIdx);
+    }
+
+    public String getFrameMethodName() {
+        if (sourceIndex == -1) throw new IllegalStateException();
+        return MethodData.getMethodName(methodInfoIdx);
+    }
+
+    public String getFrameClassName() {
+        if (sourceIndex == -1) throw new IllegalStateException();
+        return MethodData.getClassName(methodInfoIdx);
+    }
+
+    public Class<?> getFrameClass() {
+        if (sourceIndex == -1) throw new IllegalStateException();
+        return MethodData.getClass(methodInfoIdx);
+    }
+
+    public int getFrameLineNumber() {
+        if (sourceIndex == -1) throw new IllegalStateException();
+        return MethodData.getLineNumber(sourceIndex);
+    }
+
+    public int getFrameBytecodeIndex() {
+        if (sourceIndex == -1) throw new IllegalStateException();
+        return MethodData.getBytecodeIndex(sourceIndex);
+    }
+
+    public int getSourceIndex() {
+        return sourceIndex;
+    }
+
+    public int getMethodInfoIdx() {
+        return methodInfoIdx;
+    }
+
+    public void reset() {
+        methodInfoIdx = -1;
+        sourceIndex = -1;
+        index = -1;
     }
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/MethodData.java
@@ -90,7 +90,15 @@ public final class MethodData {
         int[] sourceCodeIndexList = (int[]) backtrace;
         for (int i = 0; i < depth; i++) {
             //printFrame(sourceCodeIndexList[i]);
-            fillStackTraceElement(steArray[i], sourceCodeIndexList[i]);
+            int sc = sourceCodeIndexList[i];
+            int mi = getMethodInfoIndex(sc);
+            Class<?> clazz = getClass(mi);
+            Module module = clazz.getModule();
+            String modName = module == null ? null : module.getName();
+            String modVer = /* todo: access directly via module */ null;
+            ClassLoader classLoader = clazz.getClassLoader();
+            String classLoaderName = classLoader.getName();
+            steArray[i] = new StackTraceElement(classLoaderName, modName, modVer, clazz.getName(), getMethodName(mi), getFileName(mi), getLineNumber(sc));
         }
     }
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
@@ -1,20 +1,23 @@
 package org.qbicc.runtime.stackwalk;
 
 import org.qbicc.runtime.Build;
-import org.qbicc.runtime.CNative;
+import org.qbicc.runtime.StackObject;
 import org.qbicc.runtime.stdc.Stdint.uint64_t_ptr;
 
 import static org.qbicc.runtime.CNative.*;
 import static org.qbicc.runtime.llvm.LLVM.*;
+
+import static org.qbicc.runtime.stdc.String.*;
 import static org.qbicc.runtime.unwind.LibUnwind.*;
 
-public class StackWalker {
-    public static void walkStack(StackFrameVisitor visitor) {
-        unw_cursor_t_ptr cursor = alloca(CNative.sizeof(unw_cursor_t.class));
-        unw_context_t_ptr uc = alloca(CNative.sizeof(unw_context_t.class));
-        unw_word_t_ptr ip = alloca(CNative.sizeof(unw_word_t.class));
-        unw_word_t_ptr sp = alloca(CNative.sizeof(unw_word_t.class));
+public final class StackWalker extends StackObject {
+    unw_context_t context;
+    unw_cursor_t cursor;
+    int index = -1;
+    boolean ready;
 
+    public StackWalker() {
+        unw_context_t_ptr context_ptr = addr_of(refToPtr(this).sel().context);
         if (Build.Target.isAarch64() && ! Build.Target.isMacOs()) {
             // Expand the inline assembly that `unw_getcontext` corresponds to.
             // The layout of `unw_context_t` for aarch64 has not changed since 2017 when support was first introduced.
@@ -37,18 +40,78 @@ public class StackWalker {
                 str x30, [$0, #240]
                 mov x1, sp
                 stp x1, x30, [$0, #248]
-            """, "={x0},{x0},~{x1},~{memory}", ASM_FLAG_SIDE_EFFECT, uc);
+            """, "={x0},{x0},~{x1},~{memory}", ASM_FLAG_SIDE_EFFECT, context_ptr);
         } else {
-            unw_getcontext(uc);
+            unw_getcontext(context_ptr);
         }
-        unw_init_local(cursor, uc);
-        int index = 0;
-        while (unw_step(cursor).intValue() > 0) {
-            unw_get_reg(cursor, UNW_REG_IP, ip);
-            unw_get_reg(cursor, UNW_REG_SP, sp);
+        unw_init_local(addr_of(refToPtr(this).sel().cursor), context_ptr);
+    }
 
-            visitor.visitFrame(index, ip.loadUnshared().longValue(), sp.loadUnshared().longValue());
-            index += 1;
+    public StackWalker(StackWalker orig) {
+        memcpy(addr_of(refToPtr(this).sel().cursor).cast(), addr_of(refToPtr(orig).sel().cursor).cast(), sizeof(unw_cursor_t.class));
+        index = orig.index;
+        ready = orig.ready;
+    }
+
+    public boolean next() {
+        if (unw_step(addr_of(refToPtr(this).sel().cursor)).isGt(zero())) {
+            index++;
+            return ready = true;
         }
+        return ready = false;
+    }
+
+    public void_ptr getIp() {
+        if (! ready) throw new IllegalStateException();
+        unw_word_t ip = auto();
+        unw_get_reg(addr_of(refToPtr(this).sel().cursor), UNW_REG_IP, addr_of(ip));
+        return ip.cast();
+    }
+
+    public void_ptr getSp() {
+        if (! ready) throw new IllegalStateException();
+        unw_word_t sp = auto();
+        unw_get_reg(addr_of(refToPtr(this).sel().cursor), UNW_REG_SP, addr_of(sp));
+        return sp.cast();
+    }
+
+    /**
+     * Overwrite the current cursor (iteration) position. This allows the stack walker to be rewound or to
+     * skip over frames.
+     *
+     * @param ptr a pointer to the new cursor value (must not be {@code null})
+     */
+    public void setCursor(ptr<@c_const unw_cursor_t> ptr) {
+        memcpy(addr_of(refToPtr(this).sel().cursor).cast(), ptr.cast(), sizeof(unw_cursor_t.class));
+    }
+
+    /**
+     * Get a copy of the current cursor (iteration) position. The value can be later set in {@link #setCursor(ptr)}
+     * to restore the current position.
+     *
+     * @param ptr a pointer to memory into which the copy should be stored (must not be {@code null})
+     */
+    public void getCursor(ptr<unw_cursor_t> ptr) {
+        memcpy(ptr.cast(), addr_of(refToPtr(this).sel().cursor).cast(), sizeof(unw_cursor_t.class));
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void walk(StackFrameVisitor visitor, int limit) {
+        for (int i = 0; i < limit && next(); i ++) {
+            visitor.visitFrame(getIndex(), getIp().longValue(), getSp().longValue());
+        }
+    }
+
+    public void walk(StackFrameVisitor visitor) {
+        while (next()) {
+            visitor.visitFrame(getIndex(), getIp().longValue(), getSp().longValue());
+        }
+    }
+
+    public static void walkStack(StackFrameVisitor visitor) {
+        new StackWalker().walk(visitor);
     }
 }


### PR DESCRIPTION
Because we will use it during GC, and we might not be able to allocate objects at that time.

I've been sitting on this one for a while. There will be a follow-up which updates the class library to contain the implementations of the methods which uses the stack walker API, and then another follow-up to this project to remove the corresponding intrinsics. Because of the interdependency between the projects, these have to be done as the releases are completed.

The last task then is adding `java.lang.StackWalker` support to the class library side.