### PR TITLE
put interned strings into their own .ll file

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/Vm.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Vm.java
@@ -238,6 +238,11 @@ public interface Vm {
     VmString intern(String string);
 
     /**
+     * Is the given VmObject and interned VmString?
+     */
+    boolean isInternedString(VmObject val);
+
+    /**
      * Iterate over all interned VmStrings
      * @param thunk the function to apply to each VmString
      */

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -1558,6 +1558,14 @@ public final class VmImpl implements Vm {
         return vmString;
     }
 
+    public boolean isInternedString(VmObject val) {
+        if (val instanceof VmStringImpl vs) {
+            return interned.containsKey(vs.getContent());
+        } else {
+            return false;
+        }
+    }
+
     public void forEachInternedString(Consumer<VmString> thunk) {
         interned.forEach((s, vs) -> thunk.accept(vs));
     }

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
@@ -287,7 +287,7 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
         // Perform the transformation done by ObjectLiteralSerializingVisitor.visit(StringLiteral) because this BBB runs during LOWER
         VmString vString = ctxt.getVm().intern(target.getEnclosingType().getInternalName().replace("/", ".")+"."+target.getName());
         BuildtimeHeap bth = BuildtimeHeap.get(ctxt);
-        bth.serializeVmObject(vString);
+        bth.serializeVmObject(vString, true);
         Literal arg = bth.referToSerializedVmObject(vString,
             ctxt.getBootstrapClassContext().findDefinedType("java/lang/String").load().getObjectType().getReference(),
             ctxt.getOrAddProgramModule(originalElement));

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -129,7 +129,7 @@ public class Lowering {
         }
         if (initialValue instanceof ObjectLiteral ol) {
             BuildtimeHeap bth = BuildtimeHeap.get(ctxt);
-            bth.serializeVmObject(ol.getValue());
+            bth.serializeVmObject(ol.getValue(), false);
             initialValue = bth.referToSerializedVmObject(ol.getValue(), ol.getType(), section.getProgramModule());
         }
         final Data data = section.addData(field, globalName, initialValue);

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ClassObjectSerializer.java
@@ -32,11 +32,11 @@ public class ClassObjectSerializer implements Consumer<CompilationContext> {
         // Serialize all the root Class instances
         ReachabilityInfo.get(ctxt).visitReachableTypes(ltd -> {
             VmClass vmClass = ltd.getVmClass();
-            bth.serializeVmObject(vmClass);
+            bth.serializeVmObject(vmClass, false);
         });
         Primitive.forEach(type -> {
             VmClass vmClass = ctxt.getVm().getPrimitiveClass(type);
-            bth.serializeVmObject(vmClass);
+            bth.serializeVmObject(vmClass, false);
         });
 
         bth.emitRootClassArray();

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/MethodDataStringsSerializer.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/MethodDataStringsSerializer.java
@@ -50,11 +50,11 @@ public final class MethodDataStringsSerializer extends DelegatingBasicBlockBuild
 
         // the ProgramObjects being created here will be looked up by MethodDateEmitter later.
         if (fileName != null) {
-            heap.serializeVmObject(vm.intern(fileName));
+            heap.serializeVmObject(vm.intern(fileName), true);
         }
-        heap.serializeVmObject(vm.intern(className));
-        heap.serializeVmObject(vm.intern(methodName));
-        heap.serializeVmObject(vm.intern(methodDesc));
+        heap.serializeVmObject(vm.intern(className), true);
+        heap.serializeVmObject(vm.intern(methodName), true);
+        heap.serializeVmObject(vm.intern(methodDesc), true);
     }
 
     public Value call(ValueHandle target, List<Value> arguments) {

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/ObjectLiteralSerializingVisitor.java
@@ -33,14 +33,14 @@ public class ObjectLiteralSerializingVisitor implements NodeVisitor.Delegating<N
     public Value visit(final Node.Copier param, final StringLiteral node) {
         BuildtimeHeap bth = BuildtimeHeap.get(ctxt);
         VmString vString = ctxt.getVm().intern(node.getValue());
-        bth.serializeVmObject(vString);
+        bth.serializeVmObject(vString, true);
         Literal literal = bth.referToSerializedVmObject(vString, node.getType(), ctxt.getOrAddProgramModule(param.getBlockBuilder().getRootElement()));
         return param.getBlockBuilder().notNull(literal);
     }
 
     public Value visit(final Node.Copier param, final ObjectLiteral node) {
         BuildtimeHeap bth = BuildtimeHeap.get(ctxt);
-        bth.serializeVmObject(node.getValue());
+        bth.serializeVmObject(node.getValue(), false);
         Literal literal = bth.referToSerializedVmObject(node.getValue(), node.getType(), ctxt.getOrAddProgramModule(param.getBlockBuilder().getRootElement()));
         return param.getBlockBuilder().notNull(literal);
     }

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/StringInternTableEmitter.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/StringInternTableEmitter.java
@@ -33,7 +33,7 @@ public class StringInternTableEmitter implements Consumer<CompilationContext> {
         // Construct and serialize the VmReferenceArray of interned VmStrings
         VmClass jls = ctxt.getBootstrapClassContext().findDefinedType("java/lang/String").load().getVmClass();
         VmReferenceArray internedStrings = ctxt.getVm().newArrayOf(jls, used.toArray(new VmObject[used.size()]));
-        bth.serializeVmObject(internedStrings);
+        bth.serializeVmObject(internedStrings, true);
 
         // Initialize InitialHeap.internedStrings to refer to it
         LoadedTypeDefinition ih = ctxt.getBootstrapClassContext().findDefinedType("org/qbicc/runtime/main/InitialHeap").load();

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/InitialHeap.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/InitialHeap.java
@@ -2,11 +2,12 @@ package org.qbicc.runtime.main;
 
 @SuppressWarnings("unused")
 public class InitialHeap {
-    // All of the interned String carried over from build time.
-    // After the runtime String intern table is initialized, this field will
-    // be set to null to allow the String[] object to be garbage collected.
+    // All of the interned String objects carried over from build time.
+    // The array is sorted in "natural order" to enable Arrays.binarySearch
+    // to be used at runtime by String.intern() for efficient lookup.
     public static String[] internedStrings;
 
     static class ClassSection {}
+    static class InternedStringSection {}
     static class ObjectSection {}
 }


### PR DESCRIPTION
Organize heap to get interned strings into their own .ll file.

This almost does what we want, except for a single byte[] that "leaked" from its containing String object into a java.nio.fs.UnixPath object due to the use of JavaLangAccess.getBytesNoRepl.  When serializing the heap, we found the byte[] from the UnixPath object "first" and as a result there is a single pointer from the internedString section of the heap "out" to the main heap.

It would be easy to identify when this happens and generate a root table for GC scanning (which would be tiny) when we actually get to worrying about scanning the heap roots.
