### PR TITLE
A few workaround for compiling a tiny Quarkus application

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/element/InvokableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/InvokableElement.java
@@ -138,6 +138,9 @@ public abstract class InvokableElement extends AnnotatedElement implements Execu
                         inProgress = true;
                         try {
                             this.methodBody = previousMethodBody = factory.createMethodBody(methodBodyFactoryIndex, this);
+                        } catch (IllegalStateException e) {
+                            getEnclosingType().getContext().getCompilationContext().warning("Failed to create body for "+this+": "+e.getMessage());
+                            return false;
                         } finally {
                             inProgress = false;
                         }

--- a/driver/src/main/java/org/qbicc/driver/BasicDescriptorTypeResolver.java
+++ b/driver/src/main/java/org/qbicc/driver/BasicDescriptorTypeResolver.java
@@ -26,7 +26,7 @@ final class BasicDescriptorTypeResolver implements DescriptorTypeResolver {
     public ValueType resolveTypeFromClassName(final String packageName, final String internalName) {
         DefinedTypeDefinition definedType = classContext.findDefinedType(packageName.isEmpty() ? internalName : packageName + '/' + internalName);
         if (definedType == null) {
-            return null;
+            return classContext.getTypeSystem().getUnresolvedType();
         } else {
             return definedType.load().getObjectType();
         }

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
@@ -119,6 +119,9 @@ public final class Layout {
             if (field.isStatic()) {
                 continue;
             }
+            if (!field.getType().isComplete()) {
+                continue; // skip fields whose type is unresolved
+            }
             if (field.getType().getSize() == 0) {
                 Assert.assertTrue(trailingArray == null); // At most one trailing array per type!
                 trailingArray = field; // defer until all other fields are allocated

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -367,6 +367,10 @@ public class BuildtimeHeap {
 
             CompoundType.Member im = memLayout.getMember(f);
             CompoundType.Member om = objLayout.getMember(f);
+            if (im == null || om == null) {
+                ctxt.warning("Field " + f +" not serialized due to incomplete layout");
+                continue;
+            }
             Literal replacement = f.getReplacementValue(ctxt);
             if (replacement != null) {
                 if (replacement instanceof BooleanLiteral bl) {
@@ -419,7 +423,8 @@ public class BuildtimeHeap {
                     memberMap.put(om, lf.literalOf(pointer));
                 }
             } else {
-                throw new UnsupportedOperationException("Serialization of unsupported member type: " + im.getType());
+                ctxt.warning("Serializing " + f + " as zero literal. Unsupported type");
+                memberMap.put(om, lf.zeroInitializerLiteralOfType(im.getType()));
             }
         }
     }


### PR DESCRIPTION
These fixes are enough to get a trivial app to get through to the LOWER stage (before we quit with an error because we are serializing a java.lang.Thread instance). 