### PR TITLE
Allow `$` in identifiers

### DIFF
--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -531,7 +531,7 @@ final class CompilationContextImpl implements CompilationContext {
                 case '<' -> b.append("_4");
                 case '>' -> b.append("_5");
                 default -> {
-                    if ('A' <= ch && ch <= 'Z' || 'a' <= ch && ch <= 'z' || '0' <= ch && ch <= '9') {
+                    if ('A' <= ch && ch <= 'Z' || 'a' <= ch && ch <= 'z' || '0' <= ch && ch <= '9' || ch == '$') {
                         b.append(ch);
                     } else {
                         appendHex(b.append("_0"), ch);


### PR DESCRIPTION
Most backends seem to allow `$` in identifiers; doing so enhances readability and simplifies debugging.