### PR TITLE
Eliminate one major source of "Unsupported type" errors

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -1417,7 +1417,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
     @Override
     public Object visit(VmThreadImpl thread, ZeroInitializerLiteral node) {
-        throw unsupportedType();
+        return VmImpl.require().allocate(node.getType(), 1);
     }
 
     ///////////////////////////


### PR DESCRIPTION
I should have done this easy fix a long time ago.