### PR TITLE
VFS next step: mounting the JDK

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -32,6 +32,11 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-vfs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-metrics</artifactId>
         </dependency>
 

--- a/driver/src/main/java/org/qbicc/driver/ClassPathElement.java
+++ b/driver/src/main/java/org/qbicc/driver/ClassPathElement.java
@@ -12,6 +12,8 @@ import java.nio.file.Path;
 import java.util.jar.JarFile;
 
 import io.smallrye.common.constraint.Assert;
+import org.qbicc.machine.vfs.VirtualFileSystem;
+import org.qbicc.machine.vfs.VirtualPath;
 import org.qbicc.type.definition.ByteBufferInputStream;
 
 /**
@@ -37,6 +39,15 @@ public abstract class ClassPathElement implements Closeable {
      * @throws IOException if reading the resource failed
      */
     public abstract Resource getResource(String name) throws IOException;
+
+    /**
+     * Mount this class path element onto the virtual file system at the given point.
+     * The individual files will be mounted in, replacing any files that exist at the same locations.
+     *
+     * @param vfs the virtual file system (must not be {@code null})
+     * @param mountPoint the mount point (must not be {@code null})
+     */
+    public abstract void mount(VirtualFileSystem vfs, VirtualPath mountPoint) throws IOException;
 
     /**
      * Get a class path element for the given directory path.

--- a/driver/src/main/java/org/qbicc/driver/ClassPathItem.java
+++ b/driver/src/main/java/org/qbicc/driver/ClassPathItem.java
@@ -3,8 +3,11 @@ package org.qbicc.driver;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.ListIterator;
 
 import io.smallrye.common.constraint.Assert;
+import org.qbicc.machine.vfs.VirtualFileSystem;
+import org.qbicc.machine.vfs.VirtualPath;
 
 /**
  * An item on the class path which can be made up of one or more layered resource roots and zero or more layered source file
@@ -19,6 +22,15 @@ public record ClassPathItem(String name, List<ClassPathElement> classRoots, List
         Assert.checkNotNullParam("name", name);
         Assert.checkNotNullParam("classRoots", classRoots);
         Assert.checkNotNullParam("sourceRoots", sourceRoots);
+    }
+
+    public void mount(VirtualFileSystem vfs, VirtualPath mountPoint) throws IOException {
+        // iterate backwards so early items take precedence
+        ListIterator<ClassPathElement> iterator = classRoots.listIterator(classRoots.size());
+        while (iterator.hasPrevious()) {
+            //noinspection resource
+            iterator.previous().mount(vfs, mountPoint);
+        }
     }
 
     /**

--- a/driver/src/main/java/org/qbicc/driver/DirectoryClassPathElement.java
+++ b/driver/src/main/java/org/qbicc/driver/DirectoryClassPathElement.java
@@ -4,12 +4,16 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Set;
 
 import io.smallrye.common.os.OS;
+import org.qbicc.machine.vfs.VirtualFileSystem;
+import org.qbicc.machine.vfs.VirtualPath;
 
 final class DirectoryClassPathElement extends ClassPathElement {
     private final Path baseDir;
@@ -29,6 +33,25 @@ final class DirectoryClassPathElement extends ClassPathElement {
 
     public void close() {
         // no operation
+    }
+
+    public void mount(VirtualFileSystem vfs, VirtualPath mountPoint) throws IOException {
+        mount(vfs, mountPoint, baseDir);
+    }
+
+    private void mount(VirtualFileSystem vfs, VirtualPath mountPoint, Path dirPath) throws IOException {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dirPath)) {
+            for (Path path : stream) {
+                if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                    VirtualPath subDirPath = mountPoint.resolve(path.getFileName().toString());
+                    //noinspection OctalInteger
+                    vfs.mkdir(subDirPath, 0755);
+                    mount(vfs, subDirPath, path);
+                } else {
+                    vfs.bindExternalNode(mountPoint, path, true, false);
+                }
+            }
+        }
     }
 
     static final class Resource extends ClassPathElement.Resource {

--- a/machine/vfs/src/main/java/org/qbicc/machine/vfs/VirtualFileSystem.java
+++ b/machine/vfs/src/main/java/org/qbicc/machine/vfs/VirtualFileSystem.java
@@ -4,11 +4,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -85,10 +84,6 @@ public abstract class VirtualFileSystem implements Closeable {
         getRootNode(vp).openFile(fd, this, getRootNode(vp), vp.relativize(), 0, flags, mode);
     }
 
-    public void createLink(VirtualPath vp, VirtualPath target, final Set<? extends FileAttribute<?>> attrs) throws IOException {
-        throw new IOException("Unimplemented");
-    }
-
     public VirtualPath readLink(final VirtualPath vp) throws IOException {
         return getRootNode(vp).readLink(this, vp, 0);
     }
@@ -120,6 +115,14 @@ public abstract class VirtualFileSystem implements Closeable {
 
     public int getBooleanAttributes(final VirtualPath vp, final boolean followLinks) throws IOException {
         return getRootNode(vp).getBooleanAttributes(vp.relativize(), 0, followLinks);
+    }
+
+    public Collection<String> getDirectoryEntries(final VirtualPath vp, final boolean followLinks) throws IOException {
+        return getRootNode(vp).getEntryNames(vp.relativize(), 0, followLinks);
+    }
+
+    public void link(final VirtualPath toPath, final VirtualPath fromPath, boolean followLinks) throws IOException {
+        getRootNode(fromPath).linkFrom(this, fromPath.relativize(), 0, followLinks, toPath);
     }
 
     @Override

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +50,9 @@ import org.qbicc.machine.arch.Platform;
 import org.qbicc.machine.object.ObjectFileProvider;
 import org.qbicc.machine.probe.CProbe;
 import org.qbicc.machine.tool.CToolChain;
+import org.qbicc.machine.vfs.AbsoluteVirtualPath;
+import org.qbicc.machine.vfs.VFSUtils;
+import org.qbicc.machine.vfs.VirtualFileSystem;
 import org.qbicc.plugin.constants.ConstantBasicBlockBuilder;
 import org.qbicc.plugin.conversion.NumericalConversionBasicBlockBuilder;
 import org.qbicc.plugin.core.CoreAnnotationTypeBuilder;
@@ -404,6 +408,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 });
                                 builder.addPreHook(Phase.ADD, VIO::get);
                                 builder.addPreHook(Phase.ADD, VFS::initialize);
+                                builder.addPreHook(Phase.ADD, Main::mountInitialFileSystem);
                                 builder.addPreHook(Phase.ADD, new AddMainClassHook());
                                 if (nogc) {
                                     builder.addPreHook(Phase.ADD, new NoGcSetupHook());
@@ -600,6 +605,50 @@ public class Main implements Callable<DiagnosticContext> {
                 return list;
             } else {
                 start = idx + 1;
+            }
+        }
+    }
+
+    private static void mountInitialFileSystem(CompilationContext ctxt) {
+        // install all boot classpath items into the VFS
+        VFS vfs = VFS.get(ctxt);
+        Driver driver = Driver.get(ctxt);
+        AbsoluteVirtualPath modulesPath = vfs.getQbiccPath().resolve("modules");
+        Collection<String> bootModuleNames = driver.getBootModuleNames();
+        VirtualFileSystem fileSystem = vfs.getFileSystem();
+        for (String bootModuleName : bootModuleNames) {
+            ClassPathItem bootItem = driver.getBootModuleClassPathItem(bootModuleName);
+            try {
+                bootItem.mount(fileSystem, modulesPath.resolve(bootModuleName));
+            } catch (IOException e) {
+                ctxt.error(e, "Failed to mount %s", bootItem);
+            }
+        }
+        // now look for all META-INF/java.home files and link them into the main system
+        AbsoluteVirtualPath javaHome = vfs.getQbiccPath().resolve("java.home");
+        for (String bootModuleName : bootModuleNames) {
+            AbsoluteVirtualPath moduleJavaHome = modulesPath.resolve(bootModuleName).resolve("META-INF").resolve("java.home");
+            try {
+                int attrs = fileSystem.getBooleanAttributes(moduleJavaHome, false);
+                if ((attrs & VFSUtils.BA_EXISTS) != 0) {
+                    // do it
+                    linkIn(fileSystem, javaHome, moduleJavaHome);
+                }
+            } catch (IOException e) {
+                ctxt.error(e, "Failed to remount %s", moduleJavaHome);
+            }
+        }
+    }
+
+    private static void linkIn(final VirtualFileSystem fileSystem, final AbsoluteVirtualPath toDir, final AbsoluteVirtualPath fromDir) throws IOException {
+        Collection<String> names = fileSystem.getDirectoryEntries(fromDir, false);
+        for (String name : names) {
+            AbsoluteVirtualPath fromPath = fromDir.resolve(name);
+            AbsoluteVirtualPath toPath = toDir.resolve(name);
+            if ((fileSystem.getBooleanAttributes(fromPath, false) & VFSUtils.BA_DIRECTORY) != 0) {
+                linkIn(fileSystem, toPath, fromPath);
+            } else {
+                fileSystem.link(toPath, fromPath, false);
             }
         }
     }

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -403,7 +403,7 @@ public class Main implements Callable<DiagnosticContext> {
                                     vm.doAttached(initThread, vm::initialize);
                                 });
                                 builder.addPreHook(Phase.ADD, VIO::get);
-                                builder.addPreHook(Phase.ADD, VFS::get);
+                                builder.addPreHook(Phase.ADD, VFS::initialize);
                                 builder.addPreHook(Phase.ADD, new AddMainClassHook());
                                 if (nogc) {
                                     builder.addPreHook(Phase.ADD, new NoGcSetupHook());

--- a/plugins/vfs/src/main/java/org/qbicc/plugin/vfs/VFS.java
+++ b/plugins/vfs/src/main/java/org/qbicc/plugin/vfs/VFS.java
@@ -39,24 +39,34 @@ public final class VFS {
         OS os = ctxt.getPlatform().getOs();
         fileSystem = os == OS.WIN32 ? new WindowsVirtualFileSystem(vioSystem) : new PosixVirtualFileSystem(vioSystem, os != OS.DARWIN);
         qbiccPath = fileSystem.getPath("/qbicc").toAbsolutePath();
+    }
+
+    @SuppressWarnings("OctalInteger")
+    public static VFS initialize(CompilationContext ctxt) {
+        VFS attachment = ctxt.getAttachment(KEY);
+        if (attachment != null) {
+            throw new IllegalStateException();
+        }
+        attachment = new VFS(ctxt);
+        VFS appearing = ctxt.putAttachmentIfAbsent(KEY, attachment);
+        if (appearing != null) {
+            throw new IllegalStateException();
+        }
+        // one-time setup
+        attachment.registerInvokables();
         try {
-            //noinspection OctalInteger
-            fileSystem.mkdirs(qbiccPath, 0755);
+            // set up initial filesystem
+            attachment.fileSystem.mkdirs(attachment.qbiccPath, 0755);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
+        return attachment;
     }
 
     public static VFS get(CompilationContext ctxt) {
         VFS attachment = ctxt.getAttachment(KEY);
         if (attachment == null) {
-            attachment = new VFS(ctxt);
-            VFS appearing = ctxt.putAttachmentIfAbsent(KEY, attachment);
-            if (appearing != null) {
-                attachment = appearing;
-            } else {
-                attachment.registerInvokables();
-            }
+            throw new IllegalStateException();
         }
         return attachment;
     }


### PR DESCRIPTION
* Change the setup of the VFS plugin to have a separate initialize vs. get step. In the future, we may set up more directories and structure on the filesystem during this step.
* Also, create a `/qbicc/java.home/` directory which is composed of all of the files under `META-INF/java.home` in all of the boot modules.
