### PR TITLE
[#1257] Link files in ascending order by type ID

### DIFF
--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompiler.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompiler.java
@@ -15,6 +15,7 @@ import org.qbicc.tool.llvm.OptInvoker;
 import org.qbicc.tool.llvm.OptPass;
 import org.qbicc.tool.llvm.OutputFormat;
 import org.qbicc.tool.llvm.RelocationModel;
+import org.qbicc.type.definition.LoadedTypeDefinition;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,7 +31,7 @@ public class LLVMCompiler {
         ccInvoker = createCCompilerInvoker(context);
     }
 
-    public void compileModule(final CompilationContext context, Path modulePath) {
+    public void compileModule(final CompilationContext context, LoadedTypeDefinition typeDefinition, Path modulePath) {
         CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
 
         String moduleName = modulePath.getFileName().toString();
@@ -79,7 +80,7 @@ public class LLVMCompiler {
                 context.error("Compiler invocation has failed for %s: %s", modulePath, e.toString());
                 return;
             }
-            Linker.get(context).addObjectFilePath(objectPath);
+            Linker.get(context).addObjectFilePath(typeDefinition, objectPath);
         } else {
             context.warning("Ignoring unknown module file name \"%s\"", modulePath);
         }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
@@ -1,6 +1,7 @@
 package org.qbicc.plugin.llvm;
 
 import org.qbicc.context.CompilationContext;
+import org.qbicc.type.definition.DefinedTypeDefinition;
 
 import java.nio.file.Path;
 import java.util.function.Consumer;
@@ -17,10 +18,11 @@ public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContex
     @Override
     public void accept(CompilationContext context) {
         LLVMModuleGenerator generator = new LLVMModuleGenerator(context, isPie ? 2 : 0, isPie ? 2 : 0);
-        Path modulePath = generator.processProgramModule(context.getOrAddProgramModule(context.getDefaultTypeDefinition()));
+        DefinedTypeDefinition defaultTypeDefinition = context.getDefaultTypeDefinition();
+        Path modulePath = generator.processProgramModule(context.getOrAddProgramModule(defaultTypeDefinition));
         if (compileOutput) {
             LLVMCompiler compiler = new LLVMCompiler(context, isPie);
-            compiler.compileModule(context, modulePath);
+            compiler.compileModule(context, defaultTypeDefinition.load(), modulePath);
         }
     }
 }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
@@ -37,7 +37,7 @@ public class LLVMGenerator implements Consumer<CompilationContext>, ValueVisitor
                 }
                 Path outputFile = generator.processProgramModule(programModule);
                 LLVMState llvmState = ctxt.computeAttachmentIfAbsent(LLVMState.KEY, LLVMState::new);
-                llvmState.addModulePath(outputFile);
+                llvmState.addModulePath(programModule.getTypeDefinition().load(), outputFile);
             }
         });
     }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMState.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMState.java
@@ -1,11 +1,12 @@
 package org.qbicc.plugin.llvm;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.qbicc.context.AttachmentKey;
+import org.qbicc.type.definition.LoadedTypeDefinition;
 
 /**
  *
@@ -13,24 +14,15 @@ import org.qbicc.context.AttachmentKey;
 final class LLVMState {
     static final AttachmentKey<LLVMState> KEY = new AttachmentKey<>();
 
-    private final List<Path> modulePaths = Collections.synchronizedList(new ArrayList<>());
-    private Path defaultModulePath;
+    private final Map<LoadedTypeDefinition, Path> pathsByType = new ConcurrentHashMap<>();
 
     LLVMState() {}
 
-    void addModulePath(Path path) {
-        modulePaths.add(path);
+    void addModulePath(LoadedTypeDefinition typeDefinition, Path path) {
+        pathsByType.putIfAbsent(typeDefinition, path);
     }
 
-    void setDefaultModulePath(Path path) { defaultModulePath = path; }
-
-    List<Path> getModulePaths() {
-        synchronized (modulePaths) {
-            return List.copyOf(modulePaths);
-        }
-    }
-
-    Path getDefaultModulePath() {
-        return defaultModulePath;
+    Map<LoadedTypeDefinition, Path> getModulePaths() {
+        return new HashMap<>(pathsByType);
     }
 }

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -377,7 +377,7 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
             Linker linker = Linker.get(context);
             List<StackMapRecord> recordList = new ArrayList<>();
             ObjectFileProvider objFileProvider = context.getAttachment(Driver.OBJ_PROVIDER_TOOL_KEY);
-            Iterator<Path> objFileIterator = linker.getObjectFilePaths().iterator();
+            Iterator<Path> objFileIterator = linker.getObjectFilePathsByType().values().iterator();
             final int[] index = { 0 };
 
             context.runParallelTask(ctxt -> {


### PR DESCRIPTION
Fixes #1257. If two types have the same type ID (for example, -1) then they will have indeterminate order.  I am thinking maybe `LTDI.getTypeId` should throw an exception if the type ID was not set.