### PR TITLE
WASM: Add Emscripten toolchain support

### DIFF
--- a/machine/file/wasm/src/main/java/org/qbicc/machine/file/wasm/WasmObjectFile.java
+++ b/machine/file/wasm/src/main/java/org/qbicc/machine/file/wasm/WasmObjectFile.java
@@ -60,7 +60,14 @@ public final class WasmObjectFile implements ObjectFile {
                 ArrayList<Webassembly.DataSegmentType> entries = ((Webassembly.DataSection) struct).entries();
                 for (int i = 0; i < entries.size(); i++) {
                     Webassembly.DataSegmentType data = entries.get(i);
-                    sizes.put(indexSymbol.get(i), data.data().get(0));
+                    // data is byte-sized, but the parser uses Integers
+                    ArrayList<Integer> bytes = data.data();
+                    int acc = 0;
+                    for (int j = 0; j < bytes.size(); j++) {
+                        int v = bytes.get(j);
+                        acc |= v << ( j * 8 );
+                    }
+                    sizes.put(indexSymbol.get(i), acc);
                 }
             }
         }

--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/CToolChain.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/CToolChain.java
@@ -42,7 +42,7 @@ public interface CToolChain extends Tool {
                 names.add(cpuName + "-" + osName + "-gnu-gcc");
             }
             // generic compiler names
-            names.addAll(List.of("cc", "gcc", "clang"));
+            names.addAll(List.of("cc", "gcc", "clang", "emcc"));
         }
         for (String name : names) {
             Path path = ToolUtil.findExecutable(name);
@@ -55,7 +55,7 @@ public interface CToolChain extends Tool {
         List<CToolChain> working = new ArrayList<>();
         for (CToolChain toolChain : iterable) {
             CCompilerInvoker compilerInvoker = toolChain.newCompilerInvoker();
-            compilerInvoker.setSource(InputSource.from("int main() { return 0; }"));
+            compilerInvoker.setSource(InputSource.from("#include <pthread.h>\nint main() { return 0; }"));
             Path tempFile;
             try {
                 tempFile = Files.createTempFile(null, ".out");

--- a/machine/tool/emscripten/pom.xml
+++ b/machine/tool/emscripten/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.qbicc</groupId>
+        <artifactId>qbicc-machine-tool-parent</artifactId>
+        <version>0.34.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>qbicc-machine-tool-emscripten</artifactId>
+
+    <name>Qbicc Machine: Tooling: Emscripten</name>
+    <description>Support for the emscripten compiler</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-tool-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-version</artifactId>
+        </dependency>
+
+        <!-- Test deps -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-file-wasm</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/AbstractEmscriptenInvoker.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/AbstractEmscriptenInvoker.java
@@ -1,0 +1,108 @@
+package org.qbicc.machine.tool.emscripten;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.qbicc.machine.tool.CompilationFailureException;
+import org.qbicc.machine.tool.MessagingToolInvoker;
+import org.qbicc.machine.tool.ToolMessageHandler;
+import org.qbicc.machine.tool.process.InputSource;
+import org.qbicc.machine.tool.process.OutputDestination;
+import io.smallrye.common.constraint.Assert;
+
+abstract class AbstractEmscriptenInvoker implements MessagingToolInvoker {
+    static final Path TMP = Paths.get(System.getProperty("java.io.tmpdir"));
+
+    private final EmscriptenToolChainImpl tool;
+    private ToolMessageHandler messageHandler = ToolMessageHandler.DISCARDING;
+
+    AbstractEmscriptenInvoker(final EmscriptenToolChainImpl tool) {
+        this.tool = tool;
+    }
+
+    public void setMessageHandler(final ToolMessageHandler messageHandler) {
+        this.messageHandler = Assert.checkNotNullParam("messageHandler", messageHandler);
+    }
+
+    public ToolMessageHandler getMessageHandler() {
+        return messageHandler;
+    }
+
+    public EmscriptenToolChainImpl getTool() {
+        return tool;
+    }
+
+    public Path getPath() {
+        // only one executable for now
+        return tool.getExecutablePath();
+    }
+
+    static final Pattern DIAG_PATTERN = Pattern.compile(
+        "([^ :]+):(?:(\\d+):(?:(\\d+):)?)? (?i:(?<levelStr>error|warning|note): )?(?<msg>.*)(?: \\[-[^]]+])?");
+
+    void collectError(final Reader reader) throws IOException {
+        final ToolMessageHandler handler = getMessageHandler();
+        try (BufferedReader br = new BufferedReader(reader)) {
+            String line;
+            Matcher matcher;
+            while ((line = br.readLine()) != null) {
+                matcher = DIAG_PATTERN.matcher(line.trim());
+                ToolMessageHandler.Level level = ToolMessageHandler.Level.ERROR;
+                String fileOrExecutable = "";
+                String msg = line;
+                int lnum = -1;
+                if (matcher.matches()) {
+                    fileOrExecutable = matcher.group(1);
+                    try {
+                        lnum = Integer.parseInt(matcher.group(2));
+                    } catch (NumberFormatException e) {
+                        // just keep lnum at -1
+                    }
+                    String levelStr = matcher.group("levelStr");
+                    msg = matcher.group("msg");
+                    if (levelStr != null) {
+                        switch (levelStr) {
+                            case "note": level = ToolMessageHandler.Level.INFO; break;
+                            case "warning": level = ToolMessageHandler.Level.WARNING; break;
+                            case "error": level = ToolMessageHandler.Level.ERROR; break;
+                        }
+                    }
+                }
+                // don't log potentially misleading line numbers
+                handler.handleMessage(this, level, fileOrExecutable, lnum, -1, msg);
+            }
+        }
+    }
+
+    void addArguments(List<String> cmd) {}
+
+    InputSource getSource() {
+        return InputSource.empty();
+    }
+
+    public void invoke() throws IOException {
+        OutputDestination errorHandler = OutputDestination.of(AbstractEmscriptenInvoker::collectError, this, StandardCharsets.UTF_8);
+        List<String> cmd = new ArrayList<>();
+        cmd.add(getTool().getExecutablePath().toString());
+        addArguments(cmd);
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.command(cmd);
+        pb.environment().put("LC_ALL", "C");
+        pb.environment().put("LANG", "C");
+        System.out.println(cmd);
+        getSource().transferTo(OutputDestination.of(pb, errorHandler, OutputDestination.discarding(), p -> {
+            int ev = p.exitValue();
+            if (ev != 0) {
+                throw new CompilationFailureException("Compiler terminated with exit code " + ev);
+            }
+        }));
+    }
+}

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/AbstractEmscriptenInvoker.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/AbstractEmscriptenInvoker.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jboss.logging.Logger;
 import org.qbicc.machine.tool.CompilationFailureException;
 import org.qbicc.machine.tool.MessagingToolInvoker;
 import org.qbicc.machine.tool.ToolMessageHandler;
@@ -20,6 +21,8 @@ import io.smallrye.common.constraint.Assert;
 
 abstract class AbstractEmscriptenInvoker implements MessagingToolInvoker {
     static final Path TMP = Paths.get(System.getProperty("java.io.tmpdir"));
+
+    private static final Logger LOGGER = Logger.getLogger("org.qbicc.machine.tool.emscripten");
 
     private final EmscriptenToolChainImpl tool;
     private ToolMessageHandler messageHandler = ToolMessageHandler.DISCARDING;
@@ -97,7 +100,7 @@ abstract class AbstractEmscriptenInvoker implements MessagingToolInvoker {
         pb.command(cmd);
         pb.environment().put("LC_ALL", "C");
         pb.environment().put("LANG", "C");
-        System.out.println(cmd);
+        LOGGER.info(String.join(" ", cmd));
         getSource().transferTo(OutputDestination.of(pb, errorHandler, OutputDestination.discarding(), p -> {
             int ev = p.exitValue();
             if (ev != 0) {

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenCCompilerInvoker.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenCCompilerInvoker.java
@@ -1,0 +1,9 @@
+package org.qbicc.machine.tool.emscripten;
+
+import org.qbicc.machine.tool.CCompilerInvoker;
+
+/**
+ *
+ */
+public interface EmscriptenCCompilerInvoker extends CCompilerInvoker {
+}

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenCCompilerInvokerImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenCCompilerInvokerImpl.java
@@ -1,0 +1,105 @@
+package org.qbicc.machine.tool.emscripten;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.qbicc.machine.arch.Platform;
+import org.qbicc.machine.tool.process.InputSource;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ *
+ */
+final class EmscriptenCCompilerInvokerImpl extends AbstractEmscriptenInvoker implements EmscriptenCCompilerInvoker {
+    private final List<Path> includePaths = new ArrayList<>(1);
+    private final List<String> definedSymbols = new ArrayList<>(2);
+    private InputSource inputSource = InputSource.empty();
+    private Path outputPath = TMP.resolve("qbicc-output." + getTool().getPlatform().getObjectType().objectSuffix());
+    private SourceLanguage sourceLanguage = SourceLanguage.C;
+
+    EmscriptenCCompilerInvokerImpl(final EmscriptenToolChainImpl tool) {
+        super(tool);
+    }
+
+    public void addIncludePath(final Path path) {
+        includePaths.add(Assert.checkNotNullParam("path", path));
+    }
+
+    public int getIncludePathCount() {
+        return includePaths.size();
+    }
+
+    public Path getIncludePath(final int index) throws IndexOutOfBoundsException {
+        return includePaths.get(index);
+    }
+
+    public void addDefinedSymbol(final String name, final String value) {
+        Assert.checkNotNullParam("name", name);
+        Assert.checkNotNullParam("value", value);
+        definedSymbols.add(name);
+        definedSymbols.add(value);
+    }
+
+    public int getDefinedSymbolCount() {
+        return definedSymbols.size() >>> 1;
+    }
+
+    public String getDefinedSymbol(final int index) throws IndexOutOfBoundsException {
+        return definedSymbols.get(index << 1);
+    }
+
+    public String getDefinedSymbolValue(final int index) throws IndexOutOfBoundsException {
+        return definedSymbols.get((index << 1) + 1);
+    }
+
+    public void setSource(final InputSource source) {
+        inputSource = Assert.checkNotNullParam("source", source);
+    }
+
+    public InputSource getSource() {
+        return inputSource;
+    }
+
+    public void setOutputPath(final Path path) {
+        outputPath = Assert.checkNotNullParam("path", path);
+    }
+
+    public SourceLanguage getSourceLanguage() {
+        return sourceLanguage;
+    }
+
+    public void setSourceLanguage(final SourceLanguage sourceLanguage) {
+        this.sourceLanguage = Assert.checkNotNullParam("sourceLanguage", sourceLanguage);
+    }
+
+    public Path getOutputPath() throws IllegalArgumentException {
+        return outputPath;
+    }
+
+    void addArguments(final List<String> cmd) {
+        // ignore target, it is implied
+        Platform platform = getTool().getPlatform();
+        cmd.add("--target="+platform.getCpu().toString() + "-" + platform.getOs().toString() + "-" + platform.getAbi().toString());
+        if (sourceLanguage == SourceLanguage.C) {
+            Collections.addAll(cmd, "-std=gnu11", "-f" + "input-charset=UTF-8");
+            cmd.add("-pthread");
+        }
+        cmd.add("-pipe");
+        for (Path includePath : includePaths) {
+            cmd.add("-I" + includePath.toString());
+        }
+        for (int i = 0; i < definedSymbols.size(); i += 2) {
+            String key = definedSymbols.get(i);
+            String val = definedSymbols.get(i + 1);
+            if (val.equals("1")) {
+                cmd.add("-D" + key);
+            } else {
+                cmd.add("-D" + key + "=" + val);
+            }
+        }
+        Collections.addAll(cmd, "-c", "-x", sourceLanguage == SourceLanguage.ASM ? "assembler" : "c", "-o", getOutputPath().toString(), "-");
+    }
+}
+

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvoker.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvoker.java
@@ -1,0 +1,9 @@
+package org.qbicc.machine.tool.emscripten;
+
+import org.qbicc.machine.tool.LinkerInvoker;
+
+/**
+ *
+ */
+public interface EmscriptenLinkerInvoker extends LinkerInvoker {
+}

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
@@ -1,0 +1,95 @@
+package org.qbicc.machine.tool.emscripten;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.smallrye.common.constraint.Assert;
+
+/**
+ *
+ */
+final class EmscriptenLinkerInvokerImpl extends AbstractEmscriptenInvoker implements EmscriptenLinkerInvoker {
+    private final List<Path> libraryPaths = new ArrayList<>(4);
+    private final List<String> libraries = new ArrayList<>(4);
+    private final List<Path> objectFiles = new ArrayList<>(4);
+    private Path outputPath = TMP.resolve("qbicc-output-image");
+    private boolean isPie = false;
+
+    EmscriptenLinkerInvokerImpl(final EmscriptenToolChainImpl tool) {
+        super(tool);
+    }
+
+    public void addLibraryPath(final Path path) {
+        libraryPaths.add(Assert.checkNotNullParam("path", path));
+    }
+
+    public int getLibraryPathCount() {
+        return libraryPaths.size();
+    }
+
+    public Path getLibraryPath(final int index) throws IndexOutOfBoundsException {
+        return libraryPaths.get(index);
+    }
+
+    public void addLibrary(final String name) {
+        libraries.add(Assert.checkNotNullParam("name", name));
+    }
+
+    public int getLibraryCount() {
+        return libraries.size();
+    }
+
+    public String getLibrary(final int index) throws IndexOutOfBoundsException {
+        return libraries.get(index);
+    }
+
+    public void addObjectFile(final Path path) {
+        objectFiles.add(Assert.checkNotNullParam("path", path));
+    }
+
+    public int getObjectFileCount() {
+        return objectFiles.size();
+    }
+
+    public Path getObjectFile(final int index) throws IndexOutOfBoundsException {
+        return objectFiles.get(index);
+    }
+
+    public void setOutputPath(final Path path) {
+        outputPath = Assert.checkNotNullParam("path", path);
+    }
+
+    public Path getOutputPath() {
+        return outputPath;
+    }
+
+    public void setIsPie(boolean isPie) {
+        this.isPie = isPie;
+    }
+
+    public boolean getIsPie() {
+        return isPie;
+    }
+
+    void addArguments(final List<String> cmd) {
+        if (isPie) {
+            cmd.add("-pie");
+        } else {
+            cmd.add("-no-pie");
+        }
+        cmd.add("-pthread");
+
+        for (Path libraryPath : libraryPaths) {
+            cmd.add("-L" + libraryPath.toString());
+        }
+        for (String library : libraries) {
+            cmd.add("-l" + library);
+        }
+        for (Path objectFile : objectFiles) {
+            cmd.add(objectFile.toString());
+        }
+        cmd.add("-o");
+        cmd.add(outputPath.toString());
+    }
+}

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolChain.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolChain.java
@@ -1,0 +1,9 @@
+package org.qbicc.machine.tool.emscripten;
+
+import org.qbicc.machine.tool.CToolChain;
+
+/**
+ *
+ */
+public interface EmscriptenToolChain extends CToolChain {
+}

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolChainImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolChainImpl.java
@@ -1,0 +1,46 @@
+package org.qbicc.machine.tool.emscripten;
+
+import java.nio.file.Path;
+
+import org.qbicc.machine.arch.Platform;
+import io.smallrye.common.version.VersionScheme;
+
+final class EmscriptenToolChainImpl implements EmscriptenToolChain {
+    private final Path executablePath;
+    private final Platform platform;
+    private final String version;
+
+    EmscriptenToolChainImpl(final Path executablePath, final Platform platform, final String version) {
+        this.executablePath = executablePath;
+        this.platform = platform;
+        this.version = version;
+    }
+
+    public String getImplementationName() {
+        return "LLVM";
+    }
+
+    Path getExecutablePath() {
+        return executablePath;
+    }
+
+    public EmscriptenCCompilerInvoker newCompilerInvoker() {
+        return new EmscriptenCCompilerInvokerImpl(this);
+    }
+
+    public EmscriptenLinkerInvoker newLinkerInvoker() {
+        return new EmscriptenLinkerInvokerImpl(this);
+    }
+
+    public Platform getPlatform() {
+        return platform;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public int compareVersionTo(final String version) {
+        return VersionScheme.BASIC.compare(this.version, version);
+    }
+}

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolChainImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolChainImpl.java
@@ -17,7 +17,7 @@ final class EmscriptenToolChainImpl implements EmscriptenToolChain {
     }
 
     public String getImplementationName() {
-        return "LLVM";
+        return "Emscripten (LLVM)";
     }
 
     Path getExecutablePath() {

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolProvider.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenToolProvider.java
@@ -1,0 +1,65 @@
+package org.qbicc.machine.tool.emscripten;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.qbicc.machine.arch.Platform;
+import org.qbicc.machine.tool.Tool;
+import org.qbicc.machine.tool.ToolProvider;
+import org.qbicc.machine.tool.process.InputSource;
+import org.qbicc.machine.tool.process.OutputDestination;
+
+/**
+ *
+ */
+public class EmscriptenToolProvider implements ToolProvider {
+    public <T extends Tool> Iterable<T> findTools(final Class<T> type, final Platform platform, final Path path) {
+        final ArrayList<T> list = new ArrayList<>();
+        if (type.isAssignableFrom(EmscriptenToolChainImpl.class)) {
+            tryOne(type, platform, list, path);
+        }
+        return list;
+    }
+
+    static final Pattern VERSION_PATTERN = Pattern.compile("^emcc \\(Emscripten .+\\) (.+)$");
+
+    private <T extends Tool> void tryOne(final Class<T> type, final Platform platform, final ArrayList<T> list, final Path path) {
+        if (path != null && Files.isExecutable(path)) {
+            class Result {
+                String version;
+                boolean match;
+            }
+            Result res = new Result();
+            OutputDestination dest = OutputDestination.of(r -> {
+                try (BufferedReader br = new BufferedReader(r)) {
+                    String line;
+                    Matcher matcher;
+                    while ((line = br.readLine()) != null) {
+                        matcher = VERSION_PATTERN.matcher(line);
+                        if (matcher.find()) {
+                            res.version = matcher.group(1);
+                            res.match = true;
+                        }
+                    }
+                }
+            }, StandardCharsets.UTF_8);
+            ProcessBuilder pb = new ProcessBuilder(path.toString(), "-v");
+            try {
+                InputSource.empty().transferTo(OutputDestination.of(pb, dest, OutputDestination.discarding()));
+            } catch (IOException e) {
+                // ignore invalid compiler
+                return;
+            }
+            if (res.match) {
+                final EmscriptenToolChainImpl cc = new EmscriptenToolChainImpl(path, platform, res.version);
+                list.add(type.cast(cc));
+            }
+        }
+    }
+}

--- a/machine/tool/emscripten/src/main/resources/META-INF/services/org.qbicc.machine.tool.ToolProvider
+++ b/machine/tool/emscripten/src/main/resources/META-INF/services/org.qbicc.machine.tool.ToolProvider
@@ -1,0 +1,1 @@
+org.qbicc.machine.tool.emscripten.EmscriptenToolProvider

--- a/machine/tool/emscripten/src/test/java/org/qbicc/machine/tool/emscripten/TestSimpleCompile.java
+++ b/machine/tool/emscripten/src/test/java/org/qbicc/machine/tool/emscripten/TestSimpleCompile.java
@@ -1,0 +1,54 @@
+package org.qbicc.machine.tool.emscripten;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import org.qbicc.machine.arch.Platform;
+import org.qbicc.machine.object.ObjectFile;
+import org.qbicc.machine.object.ObjectFileProvider;
+import org.qbicc.machine.tool.ToolInvoker;
+import org.qbicc.machine.tool.ToolMessageHandler;
+import org.qbicc.machine.tool.ToolProvider;
+import org.qbicc.machine.tool.ToolUtil;
+import org.qbicc.machine.tool.process.InputSource;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class TestSimpleCompile {
+    @Test
+    public void testSimpleCompile() throws Exception {
+        final Path objectFilePath = Files.createTempFile("temp", ".wasm");
+        Platform plaf = Platform.parse("wasm-wasi");
+        Optional<ObjectFileProvider> of = ObjectFileProvider.findProvider(plaf.getObjectType(), getClass().getClassLoader());
+        assumeTrue(of.isPresent());
+        Path clang = ToolUtil.findExecutable("emcc");
+        assumeTrue(clang != null);
+        final Iterable<EmscriptenToolChainImpl> tools = ToolProvider.findAllTools(EmscriptenToolChainImpl.class, plaf, c -> true,
+            TestSimpleCompile.class.getClassLoader(), List.of(clang));
+        final Iterator<EmscriptenToolChainImpl> iterator = tools.iterator();
+        assumeTrue(iterator.hasNext());
+        final EmscriptenToolChainImpl gccCompiler = iterator.next();
+        final EmscriptenCCompilerInvoker ib = gccCompiler.newCompilerInvoker();
+        ib.setOutputPath(objectFilePath);
+        ib.setMessageHandler(new ToolMessageHandler() {
+            public void handleMessage(final ToolInvoker invoker, final Level level, final String file, final int line, final int column, final String message) {
+                if (level == Level.ERROR) {
+                    throw new IllegalStateException("Unexpected error: " + message);
+                }
+            }
+        });
+        ib.setSource(InputSource.from("extern int foo; int foo = 0x12345678;"));
+        ib.invoke();
+        assertNotNull(objectFilePath);
+        ObjectFile objectFile = of.get().openObjectFile(objectFilePath);
+        assertEquals(0x12345678, objectFile.getSymbolValueAsInt("foo"));
+    }
+}

--- a/machine/tool/pom.xml
+++ b/machine/tool/pom.xml
@@ -20,6 +20,7 @@
     <modules>
         <module>api</module>
         <module>clang</module>
+        <module>emscripten</module>
         <module>gnu</module>
         <module>llvm</module>
     </modules>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -199,6 +199,10 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-machine-tool-llvm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-machine-tool-emscripten</artifactId>
+        </dependency>
 
         <!-- External dependencies -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,11 @@
                 <artifactId>qbicc-machine-tool-llvm</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-machine-tool-emscripten</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- test utility -->
 


### PR DESCRIPTION
Relates to #1279 

- add `machine/tool/emscripten`
- fix issue in `WasmObjectFile`: integers weren't correctly decoded
- allow `emcc` as a compiler name

Caveats:

1. I have cloned `tool/emscripten` from `tool/clang`. If we'd rather refactor the shared parts into an abstract class I'll do it.

2. In order to ensure that `emcc` is picked over `clang` I added the `#include <pthread.h>` line to one probe to make it fail on the `WASI` platform

3. The compiler is currently not tested (except for one test case in `machine/tool/emscripten`). It can be enabled by [setting the platform `wasm-wasi`](https://github.com/qbicc/qbicc/commit/7737fe11afdd3e9603a8915cabd5dcd203d33b2f), but currently fails

   (1) it uses the system LLVM toolchain for `llc`, `opt` instead of using Emscripten's, because of the way these are currently looked up
   (2) even with the right LLVM toolchain, `llc` will crash due to other unrelated issues (e.g. `addrspace(1)`)

