### PR TITLE
Drop `llvm.dbg.addr` in favor of `llvm.dbg.value`+`DW_OP_deref`

### DIFF
--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -93,7 +93,7 @@ final class LLVMModuleGenerator {
         }
 
         // declare debug function here
-        org.qbicc.machine.llvm.Function decl = module.declare("llvm.dbg.addr");
+        org.qbicc.machine.llvm.Function decl = module.declare("llvm.dbg.value");
         decl.returns(Types.void_);
         decl.param(Types.metadata).param(Types.metadata).param(Types.metadata);
 

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -109,6 +109,7 @@ import org.qbicc.machine.llvm.Module;
 import org.qbicc.machine.llvm.ParameterAttributes;
 import org.qbicc.machine.llvm.Values;
 import org.qbicc.machine.llvm.debuginfo.DILocalVariable;
+import org.qbicc.machine.llvm.debuginfo.DIOpcode;
 import org.qbicc.machine.llvm.debuginfo.MetadataNode;
 import org.qbicc.machine.llvm.impl.LLVM;
 import org.qbicc.machine.llvm.op.AtomicRmw;
@@ -223,7 +224,6 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         return null;
     }
 
-    private static final LLValue llvm_dbg_addr = Values.global("llvm.dbg.addr");
     private static final LLValue llvm_dbg_value = Values.global("llvm.dbg.value");
     private static final LLValue emptyExpr = diExpression().asValue();
 
@@ -237,10 +237,10 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         ValueType actualType = pointerType.getPointeeType();
         LocalVariableElement variable = node.getVariable();
         MetadataNode metadataNode = getLocalVariableMetadataNode(node, actualType, variable);
-        Call call = builder.call(void_, llvm_dbg_addr);
+        Call call = builder.call(void_, llvm_dbg_value);
         call.arg(metadata(mappedPointerType), mappedAddress)
             .arg(metadata, metadataNode.asRef())
-            .arg(metadata, emptyExpr);
+            .arg(metadata, LLVM.diExpression().arg(DIOpcode.Deref).asValue());
         return call;
     }
 


### PR DESCRIPTION
`llvm.dbg.addr` is likely to be removed; see:

* https://reviews.llvm.org/D100632#inline-948952
* https://discourse.llvm.org/t/what-is-the-status-of-dbg-addr/62898/3