### PR TITLE
Add AddressSpaceConstants pseudo-enum

### DIFF
--- a/machine/arch/src/main/java/org/qbicc/machine/arch/AddressSpaceConstants.java
+++ b/machine/arch/src/main/java/org/qbicc/machine/arch/AddressSpaceConstants.java
@@ -1,0 +1,6 @@
+package org.qbicc.machine.arch;
+
+public interface AddressSpaceConstants {
+    int DEFAULT = 0;
+    int COLLECTED = 1;
+}

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/AbstractFunction.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/AbstractFunction.java
@@ -13,6 +13,8 @@ import org.qbicc.machine.llvm.LLValue;
 import org.qbicc.machine.llvm.Visibility;
 import io.smallrye.common.constraint.Assert;
 
+import static org.qbicc.machine.arch.AddressSpaceConstants.DEFAULT;
+
 abstract class AbstractFunction extends AbstractMetable implements Function {
     final String name;
     final List<AbstractValue> attributes = new ArrayList<>();
@@ -166,7 +168,7 @@ abstract class AbstractFunction extends AbstractMetable implements Function {
     }
 
     protected final void appendAddressSpace(final Appendable target) throws IOException {
-        if (addressSpace != 0) {
+        if (addressSpace != DEFAULT) {
             target.append(" addrspace(").append(Integer.toString(addressSpace)).append(')');
         }
     }

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/CallImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/CallImpl.java
@@ -13,6 +13,8 @@ import org.qbicc.machine.llvm.Types;
 import org.qbicc.machine.llvm.op.Call;
 import io.smallrye.common.constraint.Assert;
 
+import static org.qbicc.machine.arch.AddressSpaceConstants.DEFAULT;
+
 final class CallImpl extends AbstractYieldingInstruction implements Call {
     final AbstractValue type;
     final AbstractValue function;
@@ -101,7 +103,7 @@ final class CallImpl extends AbstractYieldingInstruction implements Call {
             target.append(cconv.toString()).append(' ');
         }
         returns.appendTo(target);
-        if (addressSpace != 0) {
+        if (addressSpace != DEFAULT) {
             target.append("addrspace").append('(').append(Integer.toString(addressSpace)).append(')').append(' ');
         }
         type.appendTo(target).append(' ');

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/GlobalImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/GlobalImpl.java
@@ -12,6 +12,8 @@ import org.qbicc.machine.llvm.ThreadLocalStorageModel;
 import org.qbicc.machine.llvm.Visibility;
 import io.smallrye.common.constraint.Assert;
 
+import static org.qbicc.machine.arch.AddressSpaceConstants.DEFAULT;
+
 /**
  *
  */
@@ -135,7 +137,7 @@ final class GlobalImpl extends AbstractYieldingInstruction implements Global {
             target.append(' ');
         }
         final int addressSpace = this.addressSpace;
-        if (addressSpace != 0) {
+        if (addressSpace != DEFAULT) {
             target.append("addrspace(");
             target.append(Integer.toString(addressSpace));
             target.append(") ");

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/InvokeImpl.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/InvokeImpl.java
@@ -13,6 +13,8 @@ import org.qbicc.machine.llvm.Types;
 import org.qbicc.machine.llvm.op.Call;
 import io.smallrye.common.constraint.Assert;
 
+import static org.qbicc.machine.arch.AddressSpaceConstants.DEFAULT;
+
 final class InvokeImpl extends AbstractYieldingInstruction implements Call {
     final AbstractValue type;
     final AbstractValue function;
@@ -106,7 +108,7 @@ final class InvokeImpl extends AbstractYieldingInstruction implements Call {
             target.append(cconv.toString()).append(' ');
         }
         // todo ret attrs
-        if (addressSpace != 0) {
+        if (addressSpace != DEFAULT) {
             target.append("addrspace").append('(').append(Integer.toString(addressSpace)).append(')').append(' ');
         }
         returns.appendTo(target);

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/PointerTo.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/PointerTo.java
@@ -1,5 +1,7 @@
 package org.qbicc.machine.llvm.impl;
 
+import static org.qbicc.machine.arch.AddressSpaceConstants.DEFAULT;
+
 import java.io.IOException;
 import java.util.Objects;
 
@@ -14,7 +16,7 @@ final class PointerTo extends AbstractValue {
 
     public Appendable appendTo(final Appendable target) throws IOException {
         type.appendTo(target);
-        if (addrSpace != 0) {
+        if (addrSpace != DEFAULT) {
             target.append(' ').append("addrspace").append('(');
             target.append(Integer.toString(addrSpace));
             target.append(')');

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -25,7 +25,6 @@ import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.GlobalXtor;
 import org.qbicc.object.ModuleSection;
 import org.qbicc.object.ProgramModule;
-import org.qbicc.object.ProgramObject;
 import org.qbicc.object.SectionObject;
 import org.qbicc.object.ThreadLocalMode;
 import org.qbicc.type.ArrayType;
@@ -50,6 +49,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Map;
+
+import static org.qbicc.machine.arch.AddressSpaceConstants.DEFAULT;
 
 final class LLVMModuleGenerator {
     private final CompilationContext context;
@@ -127,7 +128,7 @@ final class LLVMModuleGenerator {
                     obj.threadLocal(map(tlm));
                 }
                 obj.asGlobal(item.getName());
-                if (item.getAddrspace() != 0) {
+                if (item.getAddrspace() != DEFAULT) {
                     obj.addressSpace(item.getAddrspace());
                 }
             }
@@ -195,7 +196,7 @@ final class LLVMModuleGenerator {
                     if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
                         obj.section(sectionName);
                     }
-                    if (item.getAddrspace() != 0) {
+                    if (item.getAddrspace() != DEFAULT) {
                         obj.addressSpace(data.getAddrspace());
                     }
                     MemberElement element = data.getOriginalElement();

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -2,6 +2,8 @@ package org.qbicc.plugin.llvm;
 
 import static org.qbicc.machine.llvm.Types.*;
 import static org.qbicc.machine.llvm.Values.*;
+import static org.qbicc.machine.arch.AddressSpaceConstants.COLLECTED;
+import static org.qbicc.machine.arch.AddressSpaceConstants.DEFAULT;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -119,12 +121,12 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue>, Pointe
         } else if (type instanceof PointerType) {
             Type pointeeType = ((PointerType) type).getPointeeType();
             boolean isCollected = ((PointerType) type).isCollected();
-            res = ptrTo(pointeeType instanceof VoidType ? i8 : map(pointeeType), isCollected ? 1 : 0);
+            res = ptrTo(pointeeType instanceof VoidType ? i8 : map(pointeeType), isCollected ? COLLECTED : DEFAULT);
         } else if (type instanceof ReferenceType) {
             // References can be used as different types in the IL without manually casting them, so we need to
             // represent all reference types as being the same LLVM type. We will cast to and from the actual type we
             // use the reference as when needed.
-            res = ptrTo(i8, 1);
+            res = ptrTo(i8, COLLECTED);
         } else if (type instanceof WordType) {
             // all other words are integers
             // LLVM doesn't really care about signedness

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -56,6 +56,7 @@ import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.MethodElement;
 
 import static org.qbicc.graph.atomic.AccessModes.SinglePlain;
+import static org.qbicc.machine.arch.AddressSpaceConstants.COLLECTED;
 
 public class BuildtimeHeap {
     private static final AttachmentKey<BuildtimeHeap> KEY = new AttachmentKey<>();
@@ -151,7 +152,7 @@ public class BuildtimeHeap {
     void emitRootClassArray() {
         Data d = classSection.addData(null, rootClassesDecl.getName(), ctxt.getLiteralFactory().literalOf((ArrayType) rootClassesDecl.getValueType(), List.of(rootClasses)));
         d.setLinkage(Linkage.EXTERNAL);
-        d.setAddrspace(1);
+        d.setAddrspace(COLLECTED);
     }
 
     void emitRootClassDictionaries(ArrayList<VmClass> rootClasses) {
@@ -189,7 +190,7 @@ public class BuildtimeHeap {
     public ProgramObject getAndRegisterGlobalClassArray(ExecutableElement originalElement) {
         ProgramModule programModule = ctxt.getOrAddProgramModule(originalElement.getEnclosingType());
         DataDeclaration decl = programModule.declareData(rootClassesDecl);
-        decl.setAddrspace(1);
+        decl.setAddrspace(COLLECTED);
         return decl;
     }
 
@@ -201,7 +202,7 @@ public class BuildtimeHeap {
         if (isRootClass(value)) {
             LiteralFactory lf  = ctxt.getLiteralFactory();
             DataDeclaration d = from.declareData(rootClassesDecl);
-            d.setAddrspace(1);
+            d.setAddrspace(COLLECTED);
             int typeId = ((VmClass)value).getTypeDefinition().getTypeId();
             Literal base = lf.bitcastLiteral(lf.literalOf(ProgramObjectPointer.of(rootClassesDecl)), ((ArrayType)rootClassesDecl.getValueType()).getElementType().getPointer().asCollected());
             Literal elem = lf.elementOfLiteral(base, lf.literalOf(typeId));
@@ -213,7 +214,7 @@ public class BuildtimeHeap {
                 return ctxt.getLiteralFactory().zeroInitializerLiteralOfType(desiredType);
             }
             DataDeclaration decl = from.declareData(objDecl);
-            decl.setAddrspace(1);
+            decl.setAddrspace(COLLECTED);
             return ctxt.getLiteralFactory().bitcastLiteral(ctxt.getLiteralFactory().literalOf(decl), desiredType);
         }
     }
@@ -253,7 +254,7 @@ public class BuildtimeHeap {
                 }
                 String name = nextLiteralName(into);
                 DataDeclaration decl = into.getProgramModule().declareData(null, name, objLayout.getCompoundType());
-                decl.setAddrspace(1);
+                decl.setAddrspace(COLLECTED);
                 vmObjects.put(value, decl); // record declaration
                 serializeVmObject(concreteType, objLayout, value, into, -1, decl.getName()); // now serialize and define a Data
             }
@@ -265,7 +266,7 @@ public class BuildtimeHeap {
             int length = memory.load32(info.getMember(coreClasses.getArrayLengthField()).getOffset(), SinglePlain);
             CompoundType literalCT = arrayLiteralType(contentsField, length);
             DataDeclaration decl = into.getProgramModule().declareData(null, nextLiteralName(into), literalCT);
-            decl.setAddrspace(1);
+            decl.setAddrspace(COLLECTED);
             vmObjects.put(value, decl); // record declaration
             serializeRefArray((ReferenceArrayObjectType) ot, literalCT, length, into, decl, (VmArray)value); // now serialize
         } else {
@@ -289,7 +290,7 @@ public class BuildtimeHeap {
     private Data defineData(ModuleSection into, String name, Literal value) {
         Data d = into.addData(null, name, value);
         d.setLinkage(Linkage.EXTERNAL);
-        d.setAddrspace(1);
+        d.setAddrspace(COLLECTED);
         return d;
     }
 
@@ -533,7 +534,7 @@ public class BuildtimeHeap {
 
         Data arrayData = defineData(into, nextLiteralName(into), ctxt.getLiteralFactory().literalOf(literalCT, memberMap));
         DataDeclaration decl = arrayData.getDeclaration();
-        decl.setAddrspace(1);
+        decl.setAddrspace(COLLECTED);
         return decl;
     }
 }


### PR DESCRIPTION
Light abstraction over AddressSpace magic numbers. We add a pseudo-enum with logical names.

```java
package org.qbicc.machine.arch;

public interface AddressSpaceConstants {
     int DEFAULT = 0;
     int COLLECTED = 1;
 }
```

(Using `interface` because fields are already public static final; I can turn it into a class if that's preferred)

This can be further refined with platform-specific constants instead and/or lower it to proper platform-specific constants.