### PR TITLE
Add `get*Type(Class<T>)` variants

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/Value.java
+++ b/compiler/src/main/java/org/qbicc/graph/Value.java
@@ -9,6 +9,10 @@ public interface Value extends Node {
 
     ValueType getType();
 
+    default <T extends ValueType> T getType(Class<T> expected) {
+        return expected.cast(getType());
+    }
+
     <T, R> R accept(ValueVisitor<T, R> visitor, T param);
 
     // static

--- a/compiler/src/main/java/org/qbicc/graph/literal/PointerLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/PointerLiteral.java
@@ -37,6 +37,10 @@ public final class PointerLiteral extends Literal {
         return pointer;
     }
 
+    public <P extends Pointer> P getPointer(Class<P> expected) {
+        return expected.cast(getPointer());
+    }
+
     @Override
     public <T, R> R accept(ValueVisitor<T, R> visitor, T param) {
         return visitor.visit(param, this);

--- a/compiler/src/main/java/org/qbicc/graph/literal/PointerLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/PointerLiteral.java
@@ -29,6 +29,10 @@ public final class PointerLiteral extends Literal {
         return getType().getPointeeType();
     }
 
+    public <T extends ValueType> T getValueType(Class<T> expected) {
+        return getType().getPointeeType(expected);
+    }
+
     public Pointer getPointer() {
         return pointer;
     }

--- a/compiler/src/main/java/org/qbicc/graph/literal/ProgramObjectLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ProgramObjectLiteral.java
@@ -29,6 +29,10 @@ public class ProgramObjectLiteral extends Literal {
         return programObject.getValueType();
     }
 
+    public <T extends ValueType> T getValueType(Class<T> expected) {
+        return expected.cast(getValueType());
+    }
+
     public String getName() {
         return programObject.getName();
     }

--- a/compiler/src/main/java/org/qbicc/object/ProgramObject.java
+++ b/compiler/src/main/java/org/qbicc/object/ProgramObject.java
@@ -105,6 +105,10 @@ public abstract class ProgramObject {
         return valueType;
     }
 
+    public <T extends ValueType> T getValueType(Class<T> expected) {
+        return expected.cast(getValueType());
+    }
+
     public Linkage getLinkage() {
         return linkage;
     }

--- a/compiler/src/main/java/org/qbicc/pointer/Pointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/Pointer.java
@@ -29,6 +29,10 @@ public abstract class Pointer {
         return type.getPointeeType();
     }
 
+    public <T extends ValueType> T getPointeeType(Class<T> expected) {
+        return expected.cast(getPointeeType());
+    }
+
     /**
      * Attempt to get a new, correctly-typed pointer which is offset from this one by the given number of bytes.
      * If the byte offset does not correspond to a valid sub-member, an exception is thrown.

--- a/compiler/src/main/java/org/qbicc/type/CompoundType.java
+++ b/compiler/src/main/java/org/qbicc/type/CompoundType.java
@@ -357,6 +357,10 @@ public final class CompoundType extends ValueType {
             return type;
         }
 
+        public <T extends ValueType> T getType(Class<T> expected) {
+            return expected.cast(getType());
+        }
+
         public int getOffset() {
             return offset;
         }

--- a/compiler/src/main/java/org/qbicc/type/PointerType.java
+++ b/compiler/src/main/java/org/qbicc/type/PointerType.java
@@ -36,6 +36,10 @@ public final class PointerType extends NullableType {
         return pointeeType;
     }
 
+    public <T extends ValueType> T getPointeeType(Class<T> expected) {
+        return expected.cast(getPointeeType());
+    }
+
     public int getAlign() {
         return typeSystem.getPointerAlignment();
     }

--- a/compiler/src/main/java/org/qbicc/type/Primitive.java
+++ b/compiler/src/main/java/org/qbicc/type/Primitive.java
@@ -44,6 +44,10 @@ public enum Primitive {
         return this.type;
     }
 
+    public <T extends ValueType> T getType(Class<T> expected) {
+        return expected.cast(getType());
+    }
+
     public void setType(ValueType type) {
         this.type = type;
     }

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinition.java
@@ -29,31 +29,20 @@ public interface LoadedTypeDefinition extends DefinedTypeDefinition {
 
     ValueType getType();
 
+    default <T extends ValueType> T getType(Class<T> expected) {
+        return expected.cast(getType());
+    }
+
     default ObjectType getObjectType() {
-        if (getType() instanceof ObjectType ot) {
-            return ot;
-        } else {
-            // breakpoint
-            throw new ClassCastException("Wrong type");
-        }
+        return getType(ObjectType.class);
     }
 
     default ClassObjectType getClassType() {
-        if (getObjectType() instanceof ClassObjectType cot) {
-            return cot;
-        } else {
-            // breakpoint
-            throw new ClassCastException("Wrong type");
-        }
+        return getType(ClassObjectType.class);
     }
 
     default InterfaceObjectType getInterfaceType() {
-        if (getObjectType() instanceof InterfaceObjectType iot) {
-            return iot;
-        } else {
-            // breakpoint
-            throw new ClassCastException("Wrong type");
-        }
+        return getType(InterfaceObjectType.class);
     }
 
     LoadedTypeDefinition getSuperClass();

--- a/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/ExecutableElement.java
@@ -47,6 +47,10 @@ public interface ExecutableElement extends MemberElement {
 
     InvokableType getType();
 
+    default <T extends InvokableType> T getType(Class<T> expected) {
+        return expected.cast(getType());
+    }
+
     MethodDescriptor getDescriptor();
 
     MethodSignature getSignature();

--- a/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/VariableElement.java
@@ -76,6 +76,10 @@ public abstract class VariableElement extends AnnotatedElement implements NamedE
         return type;
     }
 
+    public <T extends ValueType> T getType(Class<T> expected) {
+        return expected.cast(getType());
+    }
+
     ValueType resolveTypeDescriptor(ClassContext classContext, TypeParameterContext paramCtxt) {
         return classContext.resolveTypeFromDescriptor(
                         getTypeDescriptor(),


### PR DESCRIPTION
This facilitates easier method call chaining without using intermediate local variables or excessive nesting of parentheses