### PR TITLE
Split member classes into static and instance subclasses

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/InstanceFieldOf.java
+++ b/compiler/src/main/java/org/qbicc/graph/InstanceFieldOf.java
@@ -3,7 +3,7 @@ package org.qbicc.graph;
 import org.qbicc.type.PhysicalObjectType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
-import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.InstanceFieldElement;
 
 /**
  * A field handle for an instance field.
@@ -12,7 +12,7 @@ public final class InstanceFieldOf extends Field {
     private final ValueHandle instance;
     private final PhysicalObjectType instanceType;
 
-    InstanceFieldOf(ExecutableElement element, int line, int bci, FieldElement fieldElement, ValueType valueType, ValueHandle instance) {
+    InstanceFieldOf(ExecutableElement element, int line, int bci, InstanceFieldElement fieldElement, ValueType valueType, ValueHandle instance) {
         super(element, line, bci, fieldElement, valueType.getPointer().withQualifiersFrom(instance.getPointerType()));
         instanceType = (PhysicalObjectType) instance.getValueType();
         this.instance = instance;
@@ -26,6 +26,11 @@ public final class InstanceFieldOf extends Field {
     @Override
     public ValueHandle getValueHandle() {
         return instance;
+    }
+
+    @Override
+    public InstanceFieldElement getVariableElement() {
+        return (InstanceFieldElement) super.getVariableElement();
     }
 
     public PhysicalObjectType getInstanceType() {
@@ -42,7 +47,7 @@ public final class InstanceFieldOf extends Field {
     }
 
     public boolean equals(final Object other) {
-        return other instanceof InstanceFieldOf && equals((InstanceFieldOf) other);
+        return other instanceof InstanceFieldOf ifo && equals(ifo);
     }
 
     public boolean equals(final InstanceFieldOf other) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -41,8 +41,10 @@ import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.FunctionElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
 import org.qbicc.type.definition.element.InitializerElement;
+import org.qbicc.type.definition.element.InstanceFieldElement;
 import org.qbicc.type.definition.element.LocalVariableElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.descriptor.ArrayTypeDescriptor;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 import org.qbicc.type.descriptor.MethodDescriptor;
@@ -444,7 +446,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
     }
 
     public ValueHandle instanceFieldOf(ValueHandle instance, FieldElement field) {
-        return new InstanceFieldOf(element, line, bci, field, field.getType(), instance);
+        return new InstanceFieldOf(element, line, bci, (InstanceFieldElement) field, field.getType(), instance);
     }
 
     public ValueHandle instanceFieldOf(ValueHandle instance, TypeDescriptor owner, String name, TypeDescriptor type) {
@@ -452,7 +454,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
     }
 
     public ValueHandle staticField(FieldElement field) {
-        return new StaticField(element, line, bci, field, field.getType());
+        return new StaticField(element, line, bci, (StaticFieldElement) field, field.getType());
     }
 
     public ValueHandle staticField(TypeDescriptor owner, String name, TypeDescriptor type) {

--- a/compiler/src/main/java/org/qbicc/graph/StaticField.java
+++ b/compiler/src/main/java/org/qbicc/graph/StaticField.java
@@ -2,14 +2,14 @@ package org.qbicc.graph;
 
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
-import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 
 /**
  * A field handle for a static field.
  */
 public final class StaticField extends Field {
 
-    StaticField(ExecutableElement element, int line, int bci, FieldElement fieldElement, ValueType valueType) {
+    StaticField(ExecutableElement element, int line, int bci, StaticFieldElement fieldElement, ValueType valueType) {
         super(element, line, bci, fieldElement, valueType.getPointer());
     }
 
@@ -18,8 +18,13 @@ public final class StaticField extends Field {
         return "StaticField";
     }
 
+    @Override
+    public StaticFieldElement getVariableElement() {
+        return (StaticFieldElement) super.getVariableElement();
+    }
+
     public boolean equals(final Object other) {
-        return other instanceof StaticField && equals((StaticField) other);
+        return other instanceof StaticField sf && equals(sf);
     }
 
     public boolean equals(final StaticField other) {

--- a/compiler/src/main/java/org/qbicc/pointer/InstanceFieldPointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/InstanceFieldPointer.java
@@ -1,16 +1,16 @@
 package org.qbicc.pointer;
 
 import org.qbicc.interpreter.Memory;
-import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.InstanceFieldElement;
 
 /**
  *
  */
 public final class InstanceFieldPointer extends Pointer {
     private final Pointer objectPointer;
-    private final FieldElement fieldElement;
+    private final InstanceFieldElement fieldElement;
 
-    public InstanceFieldPointer(Pointer objectPointer, FieldElement fieldElement) {
+    public InstanceFieldPointer(Pointer objectPointer, InstanceFieldElement fieldElement) {
         super(fieldElement.getType().getPointer());
         this.objectPointer = objectPointer;
         this.fieldElement = fieldElement;
@@ -20,7 +20,7 @@ public final class InstanceFieldPointer extends Pointer {
         return objectPointer;
     }
 
-    public FieldElement getFieldElement() {
+    public InstanceFieldElement getInstanceField() {
         return fieldElement;
     }
 

--- a/compiler/src/main/java/org/qbicc/pointer/InstanceMethodPointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/InstanceMethodPointer.java
@@ -1,26 +1,23 @@
 package org.qbicc.pointer;
 
-import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
 
 /**
  * An exact pointer to an instance method.
  */
 public final class InstanceMethodPointer extends RootPointer {
-    private final MethodElement instanceMethod;
+    private final InstanceMethodElement instanceMethod;
 
-    InstanceMethodPointer(MethodElement instanceMethod) {
+    InstanceMethodPointer(InstanceMethodElement instanceMethod) {
         super(instanceMethod.getType().getPointer());
-        if (instanceMethod.isStatic()) {
-            throw new IllegalArgumentException("Method is static");
-        }
         this.instanceMethod = instanceMethod;
     }
 
-    public static InstanceMethodPointer of(final MethodElement methodElement) {
+    public static InstanceMethodPointer of(final InstanceMethodElement methodElement) {
         return methodElement.getOrCreateInstanceMethodPointer(InstanceMethodPointer::new);
     }
 
-    public MethodElement getInstanceMethod() {
+    public InstanceMethodElement getInstanceMethod() {
         return instanceMethod;
     }
 

--- a/compiler/src/main/java/org/qbicc/pointer/Pointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/Pointer.java
@@ -10,6 +10,7 @@ import org.qbicc.type.PointerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.InstanceFieldElement;
 
 /**
  * The base type of a VM pointer value.
@@ -84,10 +85,10 @@ public abstract class Pointer {
             int fieldCount = def.getFieldCount();
             for (int i = 0; i < fieldCount; i ++) {
                 FieldElement field = def.getField(i);
-                if (! field.isStatic()) {
-                    long fieldOffset = field.getOffset();
-                    if (offset >= fieldOffset && offset < field.getType().getSize()) {
-                        return new InstanceFieldPointer(this, field).offsetInBytes(fieldOffset - offset, false);
+                if (field instanceof InstanceFieldElement ife) {
+                    long fieldOffset = ife.getOffset();
+                    if (offset >= fieldOffset && offset < ife.getType().getSize()) {
+                        return new InstanceFieldPointer(this, ife).offsetInBytes(fieldOffset - offset, false);
                     }
                 }
             }

--- a/compiler/src/main/java/org/qbicc/pointer/StaticFieldPointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/StaticFieldPointer.java
@@ -1,26 +1,23 @@
 package org.qbicc.pointer;
 
-import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 
 /**
  * A pointer to a static field.
  */
 public final class StaticFieldPointer extends RootPointer {
-    private final FieldElement staticField;
+    private final StaticFieldElement staticField;
 
-    StaticFieldPointer(FieldElement staticField) {
+    StaticFieldPointer(StaticFieldElement staticField) {
         super(staticField.getType().getPointer());
-        if (! staticField.isStatic()) {
-            throw new IllegalArgumentException("Pointer to non-static field");
-        }
         this.staticField = staticField;
     }
 
-    public static StaticFieldPointer of(final FieldElement fieldElement) {
+    public static StaticFieldPointer of(final StaticFieldElement fieldElement) {
         return fieldElement.getOrCreatePointer(StaticFieldPointer::new);
     }
 
-    public FieldElement getStaticField() {
+    public StaticFieldElement getStaticField() {
         return staticField;
     }
 

--- a/compiler/src/main/java/org/qbicc/pointer/StaticMethodPointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/StaticMethodPointer.java
@@ -1,26 +1,23 @@
 package org.qbicc.pointer;
 
-import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticMethodElement;
 
 /**
  * A pointer to a static method.
  */
 public final class StaticMethodPointer extends RootPointer {
-    private final MethodElement staticMethod;
+    private final StaticMethodElement staticMethod;
 
-    StaticMethodPointer(MethodElement staticMethod) {
+    StaticMethodPointer(StaticMethodElement staticMethod) {
         super(staticMethod.getType().getPointer());
-        if (! staticMethod.isStatic()) {
-            throw new IllegalArgumentException("Method is not static");
-        }
         this.staticMethod = staticMethod;
     }
 
-    public static StaticMethodPointer of(final MethodElement methodElement) {
+    public static StaticMethodPointer of(final StaticMethodElement methodElement) {
         return methodElement.getOrCreateStaticMethodPointer(StaticMethodPointer::new);
     }
 
-    public MethodElement getStaticMethod() {
+    public StaticMethodElement getStaticMethod() {
         return staticMethod;
     }
 

--- a/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/LoadedTypeDefinitionImpl.java
@@ -26,6 +26,7 @@ import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
 import org.qbicc.type.definition.element.ParameterElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.descriptor.MethodDescriptor;
 import org.qbicc.type.descriptor.TypeDescriptor;
@@ -208,7 +209,7 @@ final class LoadedTypeDefinitionImpl extends DelegatingDefinedTypeDefinition imp
     }
 
     public Value getInitialValue(FieldElement field) {
-        return vmClass == null ? field.getInitialValue() : vmClass.getValueForStaticField(field);
+        return vmClass == null ? ((StaticFieldElement)field).getInitialValue() : vmClass.getValueForStaticField(field);
     }
 
     public int getMethodCount() {

--- a/compiler/src/main/java/org/qbicc/type/definition/element/InstanceFieldElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/InstanceFieldElement.java
@@ -1,0 +1,20 @@
+package org.qbicc.type.definition.element;
+
+import org.qbicc.type.definition.classfile.ClassFile;
+
+/**
+ * An instance field element.
+ */
+public final class InstanceFieldElement extends FieldElement {
+    InstanceFieldElement(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public void setModifierFlags(int flags) {
+        if ((flags & ClassFile.ACC_STATIC) != 0) {
+            throw new IllegalArgumentException("Cannot make an instance element into a static element");
+        }
+        super.setModifierFlags(flags);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/type/definition/element/InstanceMethodElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/InstanceMethodElement.java
@@ -1,0 +1,64 @@
+package org.qbicc.type.definition.element;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.function.Function;
+
+import org.qbicc.pointer.InstanceMethodPointer;
+import org.qbicc.type.InstanceMethodType;
+import org.qbicc.type.definition.classfile.ClassFile;
+import org.qbicc.type.util.ResolutionUtil;
+
+/**
+ * An instance method element.
+ */
+public final class InstanceMethodElement extends MethodElement {
+    private static final VarHandle pointerHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "pointer", VarHandle.class, InstanceMethodElement.class, InstanceMethodPointer.class);
+    @SuppressWarnings("unused") // pointerHandle
+    private volatile InstanceMethodPointer pointer;
+
+    InstanceMethodElement(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public InstanceMethodType getType() {
+        return (InstanceMethodType) super.getType();
+    }
+
+    @Override
+    InstanceMethodType computeType() {
+        return ResolutionUtil.resolveInstanceMethodType(getEnclosingType(), this, getDescriptor(), getSignature());
+    }
+
+    @Override
+    public void setModifierFlags(int flags) {
+        if ((flags & ClassFile.ACC_STATIC) != 0) {
+            throw new IllegalArgumentException("Cannot make an instance element into a static element");
+        }
+        super.setModifierFlags(flags);
+    }
+
+    /**
+     * Establish the pointer for this method; intended only for use by {@link InstanceMethodPointer#of}.
+     *
+     * @param factory the factory
+     * @return the pointer
+     * @see InstanceMethodPointer#of
+     */
+    public InstanceMethodPointer getOrCreateInstanceMethodPointer(Function<InstanceMethodElement, InstanceMethodPointer> factory) {
+        InstanceMethodPointer pointer = this.pointer;
+        if (pointer == null) {
+            if (isStatic()) {
+                throw new IllegalArgumentException("Instance pointer for static method");
+            }
+            pointer = factory.apply(this);
+            InstanceMethodPointer appearing = (InstanceMethodPointer) pointerHandle.compareAndExchange(this, null, pointer);
+            if (appearing != null) {
+                pointer = appearing;
+            }
+        }
+        return pointer;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/type/definition/element/StaticFieldElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/StaticFieldElement.java
@@ -1,0 +1,80 @@
+package org.qbicc.type.definition.element;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.function.Function;
+
+import org.qbicc.graph.literal.Literal;
+import org.qbicc.pointer.StaticFieldPointer;
+import org.qbicc.type.definition.classfile.ClassFile;
+
+/**
+ * A static field element.
+ */
+public final class StaticFieldElement extends FieldElement {
+    private static final VarHandle pointerHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "pointer", VarHandle.class, StaticFieldElement.class, StaticFieldPointer.class);
+    private final Literal initialValue;
+    private final InitializerElement runTimeInitializer;
+    @SuppressWarnings("unused") // pointerHandle
+    private volatile StaticFieldPointer pointer;
+
+    StaticFieldElement(BuilderImpl builder) {
+        super(builder);
+        initialValue = builder.initialValue;
+        runTimeInitializer = builder.runTimeInitializer;
+    }
+
+    @Override
+    public boolean isReallyFinal() {
+        return runTimeInitializer == null && super.isReallyFinal();
+    }
+
+    public Literal getInitialValue() {
+        return initialValue;
+    }
+
+    @Override
+    public void clearModifierFlags(int flags) {
+        if ((flags & ClassFile.ACC_STATIC) != 0) {
+            throw new IllegalArgumentException("Cannot make a static element into an instance element");
+        }
+        super.clearModifierFlags(flags);
+    }
+
+    public InitializerElement getRunTimeInitializer() {
+        return runTimeInitializer;
+    }
+
+    /**
+     * Get the pointer to this (static) field.  Convenience method which delegates to {@link StaticFieldPointer#of}.
+     *
+     * @return the pointer
+     * @throws IllegalArgumentException if this field is not static
+     */
+    public StaticFieldPointer getPointer() {
+        return StaticFieldPointer.of(this);
+    }
+
+    /**
+     * Establish the pointer for this field; intended only for use by {@link StaticFieldPointer#of}.
+     *
+     * @param factory the factory
+     * @return the pointer
+     * @see StaticFieldPointer#of
+     */
+    public StaticFieldPointer getOrCreatePointer(Function<StaticFieldElement, StaticFieldPointer> factory) {
+        StaticFieldPointer pointer = this.pointer;
+        if (pointer == null) {
+            if (! isStatic()) {
+                throw new IllegalArgumentException("Static pointer for instance field");
+            }
+            pointer = factory.apply(this);
+            StaticFieldPointer appearing = (StaticFieldPointer) pointerHandle.compareAndExchange(this, null, pointer);
+            if (appearing != null) {
+                pointer = appearing;
+            }
+        }
+        return pointer;
+    }
+}

--- a/compiler/src/main/java/org/qbicc/type/definition/element/StaticMethodElement.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/element/StaticMethodElement.java
@@ -1,0 +1,68 @@
+package org.qbicc.type.definition.element;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.function.Function;
+
+import org.qbicc.pointer.StaticMethodPointer;
+import org.qbicc.type.StaticMethodType;
+import org.qbicc.type.definition.classfile.ClassFile;
+import org.qbicc.type.util.ResolutionUtil;
+
+/**
+ * A static method element.
+ */
+public final class StaticMethodElement extends MethodElement {
+    private static final VarHandle pointerHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "pointer", VarHandle.class, StaticMethodElement.class, StaticMethodPointer.class);
+    @SuppressWarnings("unused") // pointerHandle
+    private volatile StaticMethodPointer pointer;
+
+    StaticMethodElement() {
+        super();
+    }
+
+    StaticMethodElement(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public StaticMethodType getType() {
+        return (StaticMethodType) super.getType();
+    }
+
+    @Override
+    StaticMethodType computeType() {
+        return ResolutionUtil.resolveStaticMethodType(getEnclosingType(), this, getDescriptor(), getSignature());
+    }
+
+    @Override
+    public void clearModifierFlags(int flags) {
+        if ((flags & ClassFile.ACC_STATIC) != 0) {
+            throw new IllegalArgumentException("Cannot make a static element into an instance element");
+        }
+        super.clearModifierFlags(flags);
+    }
+
+    /**
+     * Establish the pointer for this method; intended only for use by {@link StaticMethodPointer#of}.
+     *
+     * @param factory the factory
+     * @return the pointer
+     * @see StaticMethodPointer#of
+     */
+    public StaticMethodPointer getOrCreateStaticMethodPointer(Function<StaticMethodElement, StaticMethodPointer> factory) {
+        StaticMethodPointer pointer = this.pointer;
+        if (pointer == null) {
+            if (! isStatic()) {
+                throw new IllegalArgumentException("Static pointer for instance method");
+            }
+            pointer = factory.apply(this);
+            StaticMethodPointer appearing = (StaticMethodPointer) pointerHandle.compareAndExchange(this, null, pointer);
+            if (appearing != null) {
+                pointer = appearing;
+            }
+        }
+        return pointer;
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -183,7 +183,9 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.InstanceFieldElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.descriptor.MethodDescriptor;
 
 final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVisitor<VmThreadImpl, Object>, TerminatorVisitor<VmThreadImpl, BasicBlock> {
@@ -2369,7 +2371,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
         @Override
         public Memory visit(Frame frame, StaticFieldPointer pointer) {
-            FieldElement variableElement = pointer.getStaticField();
+            StaticFieldElement variableElement = pointer.getStaticField();
             if (variableElement.hasAllModifiersOf(ClassFile.I_ACC_RUN_TIME)) {
                 throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run time field"));
             }
@@ -2398,7 +2400,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
         @Override
         public Memory visit(Frame frame, InstanceFieldOf node) {
-            FieldElement variableElement = node.getVariableElement();
+            InstanceFieldElement variableElement = node.getVariableElement();
             if (variableElement.hasAllModifiersOf(ClassFile.I_ACC_RUN_TIME)) {
                 throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run time field"));
             }
@@ -2417,7 +2419,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
         @Override
         public Memory visit(Frame frame, StaticField node) {
-            FieldElement variableElement = node.getVariableElement();
+            StaticFieldElement variableElement = node.getVariableElement();
             if (variableElement.hasAllModifiersOf(ClassFile.I_ACC_RUN_TIME)) {
                 throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run time field"));
             }
@@ -2538,7 +2540,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         public long visit(Frame frame, InstanceFieldOf node) {
             CompilationContext ctxt = frame.element.getEnclosingType().getContext().getCompilationContext();
             Layout layout = Layout.get(ctxt);
-            FieldElement field = node.getVariableElement();
+            InstanceFieldElement field = node.getVariableElement();
             LayoutInfo layoutInfo = layout.getInstanceLayoutInfo(field.getEnclosingType());
             try {
                 return node.getValueHandle().accept(this, frame) + layoutInfo.getMember(field).getOffset();

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -54,6 +54,7 @@ import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.descriptor.MethodDescriptor;
 import org.qbicc.type.descriptor.TypeDescriptor;
 
@@ -267,8 +268,8 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         int cnt = typeDefinition.getFieldCount();
         for (int i = 0; i < cnt; i ++) {
             FieldElement field = typeDefinition.getField(i);
-            if (field.isStatic()) try {
-                Literal initValue = field.getInitialValue();
+            if (field instanceof StaticFieldElement sfe) try {
+                Literal initValue = sfe.getInitialValue();
                 if (initValue == null || initValue instanceof ZeroInitializerLiteral) {
                     // Nothing to do;  memory starts zeroed.
                     continue;

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -76,6 +76,7 @@ import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.descriptor.ArrayTypeDescriptor;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
@@ -546,11 +547,11 @@ public final class VmImpl implements Vm {
                 VmStringImpl name = (VmStringImpl) fieldObj.getMemory().loadRef(fieldObj.indexOf(fieldDef.findField("name")), SinglePlain);
                 LoadedTypeDefinition clazzDef = clazz.getTypeDefinition();
                 FieldElement field = clazzDef.findField(name.getContent());
-                if (field == null || !field.isStatic()) {
+                if (! (field instanceof StaticFieldElement sfe)) {
                     throw new Thrown(errorClass.newInstance("Invalid argument to objectFieldOffset0"));
                 }
-                field.setModifierFlags(ClassFile.I_ACC_PINNED);
-                return StaticFieldPointer.of(field);
+                sfe.setModifierFlags(ClassFile.I_ACC_PINNED);
+                return StaticFieldPointer.of(sfe);
             });
 
             unsafeClass.registerInvokable("allocateInstance", (thread, target, args) -> {

--- a/plugins/constants/src/main/java/org/qbicc/plugin/constants/ConstantBasicBlockBuilder.java
+++ b/plugins/constants/src/main/java/org/qbicc/plugin/constants/ConstantBasicBlockBuilder.java
@@ -31,8 +31,8 @@ import org.qbicc.type.NullableType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.StaticMethodType;
 import org.qbicc.type.ValueType;
-import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 
 import static org.qbicc.graph.atomic.AccessModes.SinglePlain;
 import static org.qbicc.graph.atomic.AccessModes.SingleUnshared;
@@ -56,8 +56,8 @@ public class ConstantBasicBlockBuilder extends DelegatingBasicBlockBuilder {
 
     @Override
     public Value load(ValueHandle handle, ReadAccessMode accessMode) {
-        if (handle instanceof StaticField) {
-            final FieldElement fieldElement = ((StaticField) handle).getVariableElement();
+        if (handle instanceof StaticField sf) {
+            final StaticFieldElement fieldElement = sf.getVariableElement();
             Value constantValue = Constants.get(ctxt).getConstantValue(fieldElement);
             if (constantValue != null) {
                 return constantValue;

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -13,10 +13,8 @@ import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.BooleanLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.graph.literal.ObjectLiteral;
-import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.graph.literal.ZeroInitializerLiteral;
 import org.qbicc.object.Data;
-import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Linkage;
 import org.qbicc.object.ModuleSection;
 import org.qbicc.plugin.constants.Constants;
@@ -33,6 +31,7 @@ import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
 import org.qbicc.type.definition.element.LocalVariableElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.descriptor.TypeDescriptor;
 import org.qbicc.type.generic.TypeSignature;
 
@@ -50,7 +49,7 @@ public class Lowering {
         return ctxt.computeAttachmentIfAbsent(KEY, Lowering::new);
     }
 
-    public GlobalVariableElement getGlobalForStaticField(FieldElement field) {
+    public GlobalVariableElement getGlobalForStaticField(StaticFieldElement field) {
         GlobalVariableElement global = staticFields.get(field);
         if (global != null) {
             return global;

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
@@ -20,8 +20,9 @@ import org.qbicc.pointer.Pointer;
 import org.qbicc.pointer.ProgramObjectPointer;
 import org.qbicc.pointer.StaticFieldPointer;
 import org.qbicc.pointer.StaticMethodPointer;
-import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.definition.element.InstanceFieldElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.definition.element.StaticMethodElement;
 
 /**
@@ -56,7 +57,7 @@ public final class MemberPointerCopier implements NodeVisitor.Delegating<Node.Co
             DataDeclaration decl = programModule.declareData(function);
             return ProgramObjectPointer.of(decl);
         } else if (pointer instanceof StaticFieldPointer sfp) {
-            FieldElement field = sfp.getStaticField();
+            StaticFieldElement field = sfp.getStaticField();
             GlobalVariableElement global = Lowering.get(ctxt).getGlobalForStaticField(field);
             ProgramModule programModule = ctxt.getOrAddProgramModule(copier.getBlockBuilder().getCurrentElement().getEnclosingType());
             DataDeclaration decl = programModule.declareData(field, global.getName(), global.getType());
@@ -68,7 +69,7 @@ public final class MemberPointerCopier implements NodeVisitor.Delegating<Node.Co
         } else if (pointer instanceof OffsetPointer op) {
             return lowerPointer(copier, op.getBasePointer()).offsetByElements(op.getOffset());
         } else if (pointer instanceof InstanceFieldPointer ifp) {
-            FieldElement field = ifp.getFieldElement();
+            InstanceFieldElement field = ifp.getInstanceField();
             return new MemberPointer(lowerPointer(copier, ifp.getObjectPointer()), Layout.get(ctxt).getInstanceLayoutInfo(field.getEnclosingType()).getMember(field));
         } else if (pointer instanceof MemoryPointer) {
             throw new UnsupportedOperationException("Lowering arbitrary memory is not supported");

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
@@ -22,7 +22,7 @@ import org.qbicc.pointer.StaticFieldPointer;
 import org.qbicc.pointer.StaticMethodPointer;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
-import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticMethodElement;
 
 /**
  *
@@ -50,7 +50,7 @@ public final class MemberPointerCopier implements NodeVisitor.Delegating<Node.Co
 
     private Pointer lowerPointer(Node.Copier copier, Pointer pointer) {
         if (pointer instanceof StaticMethodPointer smp) {
-            MethodElement method = smp.getStaticMethod();
+            StaticMethodElement method = smp.getStaticMethod();
             Function function = ctxt.getExactFunction(method);
             ProgramModule programModule = ctxt.getOrAddProgramModule(copier.getBlockBuilder().getCurrentElement().getEnclosingType());
             DataDeclaration decl = programModule.declareData(function);

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/StaticFieldLoweringBasicBlockBuilder.java
@@ -8,6 +8,7 @@ import org.qbicc.object.ProgramModule;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.GlobalVariableElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 
 /**
  *
@@ -27,7 +28,7 @@ public class StaticFieldLoweringBasicBlockBuilder extends DelegatingBasicBlockBu
         if (! field.isStatic()) {
             throw new IllegalArgumentException();
         }
-        GlobalVariableElement global = Lowering.get(ctxt).getGlobalForStaticField(field);
+        GlobalVariableElement global = Lowering.get(ctxt).getGlobalForStaticField((StaticFieldElement) field);
         DefinedTypeDefinition fieldHolder = field.getEnclosingType();
         if (! fieldHolder.equals(ourHolder)) {
             // we have to declare it in our translation unit

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -26,7 +26,7 @@ import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
-import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 
 /**
  * This class supports reachability analysis by providing the capability of
@@ -49,7 +49,7 @@ class BuildtimeHeapAnalyzer {
      * to identify instantiated types.
      * @param f static field which is the starting point for this trace
      */
-    void traceHeap(CompilationContext ctxt, ReachabilityAnalysis analysis, FieldElement f, ExecutableElement currentElement) {
+    void traceHeap(CompilationContext ctxt, ReachabilityAnalysis analysis, StaticFieldElement f, ExecutableElement currentElement) {
         if (f.isStatic() && f.getType() instanceof ReferenceType && !f.isThreadLocal() && f.getRunTimeInitializer() == null) {
             Value v = f.getEnclosingType().load().getInitialValue(f);
             if (v instanceof ObjectLiteral) {

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
@@ -12,10 +12,10 @@ import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
-import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.InvokableElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 
 /**
  * An implementation of Rapid Type Analysis (RTA).
@@ -121,7 +121,7 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
         }
     }
 
-    public synchronized void processReachableStaticFieldAccess(final FieldElement field, ExecutableElement currentElement) {
+    public synchronized void processReachableStaticFieldAccess(final StaticFieldElement field, ExecutableElement currentElement) {
         if (!info.isAccessedStaticField(field)) {
             processReachableType(field.getEnclosingType().load(), null);
             info.addAccessedStaticField(field);

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -4,10 +4,10 @@ import org.qbicc.graph.literal.ObjectLiteral;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
-import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
 import org.qbicc.type.definition.element.InvokableElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 
 /**
  * A set of hooks that enable the ReachabilityBlockBuilder to inform the underlying
@@ -26,7 +26,7 @@ interface ReachabilityAnalysis {
 
     void processReachableDispatchedInvocation(final MethodElement target, ExecutableElement currentElement);
 
-    void processReachableStaticFieldAccess(final FieldElement field, ExecutableElement currentElement);
+    void processReachableStaticFieldAccess(final StaticFieldElement field, ExecutableElement currentElement);
 
     void processReachableType(final LoadedTypeDefinition ltd, ExecutableElement currentElement);
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -42,7 +42,9 @@ import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.FunctionElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticMethodElement;
 
 /**
  * A block builder stage which traverses the final set of reachable Nodes
@@ -150,7 +152,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
         @Override
         public Void visit(ReachabilityContext reachabilityContext, InstanceMethodPointer pointer) {
-            MethodElement target = pointer.getInstanceMethod();
+            InstanceMethodElement target = pointer.getInstanceMethod();
             reachabilityContext.analysis.processReachableExactInvocation(target, reachabilityContext.currentElement);
             return null;
         }
@@ -170,7 +172,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
         @Override
         public Void visit(ReachabilityContext param, StaticMethodPointer pointer) {
-            MethodElement target = pointer.getStaticMethod();
+            StaticMethodElement target = pointer.getStaticMethod();
             param.analysis.processReachableExactInvocation(target, param.currentElement);
             return null;
         }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -40,10 +40,10 @@ import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
-import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.FunctionElement;
 import org.qbicc.type.definition.element.InstanceMethodElement;
 import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.definition.element.StaticMethodElement;
 
 /**
@@ -165,7 +165,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
         @Override
         public Void visit(ReachabilityContext param, StaticFieldPointer pointer) {
-            FieldElement f = pointer.getStaticField();
+            StaticFieldElement f = pointer.getStaticField();
             param.analysis.processReachableStaticFieldAccess(f, param.currentElement);
             return null;
         }
@@ -260,7 +260,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
         @Override
         public Void visit(ReachabilityContext param, StaticField node) {
             if (visitUnknown(param, (Node)node)) {
-                FieldElement f = node.getVariableElement();
+                StaticFieldElement f = node.getVariableElement();
                 param.analysis.processReachableStaticFieldAccess(f, param.currentElement);
             }
             return null;

--- a/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/Reflection.java
+++ b/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/Reflection.java
@@ -55,6 +55,7 @@ import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
 import org.qbicc.type.definition.element.ParameterElement;
+import org.qbicc.type.definition.element.StaticFieldElement;
 import org.qbicc.type.definition.element.StaticMethodElement;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
@@ -1340,7 +1341,7 @@ public final class Reflection {
             // todo: breakpoint
             idx = 0;
         }
-        FieldElement field = clazz.getTypeDefinition().getField(idx);
+        StaticFieldElement field = (StaticFieldElement) clazz.getTypeDefinition().getField(idx);
         return StaticFieldPointer.of(field);
     }
 

--- a/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/Reflection.java
+++ b/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/Reflection.java
@@ -55,6 +55,7 @@ import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.definition.element.NestedClassElement;
 import org.qbicc.type.definition.element.ParameterElement;
+import org.qbicc.type.definition.element.StaticMethodElement;
 import org.qbicc.type.descriptor.BaseTypeDescriptor;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 import org.qbicc.type.descriptor.MethodDescriptor;
@@ -1063,7 +1064,7 @@ public final class Reflection {
                 return MethodBody.of(entryBlock, schedule, null, paramValues);
             }
         }, 0);
-        MethodElement dispatcher = builder.build();
+        StaticMethodElement dispatcher = (StaticMethodElement) builder.build();
         ctxt.enqueue(dispatcher);
         return StaticMethodPointer.of(dispatcher);
     }
@@ -1131,16 +1132,16 @@ public final class Reflection {
                 return MethodBody.of(entryBlock, schedule, null, paramValues);
             }
         }, 0);
-        MethodElement dispatcher = builder.build();
+        StaticMethodElement dispatcher = (StaticMethodElement) builder.build();
         ctxt.enqueue(dispatcher);
         return StaticMethodPointer.of(dispatcher);
     }
 
     private Pointer generateInvokerDispatcher(final MethodElement element, final MethodHandleKind kind) {
-        if (element.isStatic()) {
+        if (element instanceof StaticMethodElement sme) {
             ctxt.enqueue(element);
             // just dispatch directly to the method itself - nice!
-            return element.getStaticMethodPointer();
+            return StaticMethodPointer.of(sme);
         }
         // generate a static dispatch helper method
         DefinedTypeDefinition enclosingType = element.getEnclosingType();
@@ -1217,7 +1218,7 @@ public final class Reflection {
                 return MethodBody.of(entryBlock, schedule, null, paramValues);
             }
         }, 0);
-        MethodElement dispatcher = builder.build();
+        StaticMethodElement dispatcher = (StaticMethodElement) builder.build();
         ctxt.enqueue(dispatcher);
         return StaticMethodPointer.of(dispatcher);
     }
@@ -1279,7 +1280,7 @@ public final class Reflection {
                 return MethodBody.of(entryBlock, schedule, null, paramValues);
             }
         }, 0);
-        MethodElement dispatcher = builder.build();
+        StaticMethodElement dispatcher = (StaticMethodElement) builder.build();
         ctxt.enqueue(dispatcher);
         return StaticMethodPointer.of(dispatcher);
     }

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -53,7 +53,7 @@ import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.FieldElement;
-import org.qbicc.type.definition.element.MethodElement;
+import org.qbicc.type.definition.element.StaticMethodElement;
 
 import static org.qbicc.graph.atomic.AccessModes.SinglePlain;
 
@@ -414,7 +414,7 @@ public class BuildtimeHeap {
                     memberMap.put(om, lf.nullLiteralOfType(pt));
                 } else if (pointer instanceof StaticMethodPointer smp) {
                     // lower method pointers to their corresponding objects
-                    MethodElement method = smp.getStaticMethod();
+                    StaticMethodElement method = smp.getStaticMethod();
                     ctxt.enqueue(method);
                     Function function = ctxt.getExactFunction(method);
                     FunctionDeclaration decl = into.getProgramModule().declareFunction(function);


### PR DESCRIPTION
Includes the *minimal* necessary cleanup. A fairly large number of non-essential cleanup fixes can be done but can wait for later.