### PR TITLE
MethodDataEmitter: Return immediately when stackMapRecords is empty

### DIFF
--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/MethodDataEmitter.java
@@ -128,6 +128,9 @@ public class MethodDataEmitter implements Consumer<CompilationContext> {
     public MethodData createMethodData(CompilationContext ctxt) {
         List<StackMapRecord> stackMapRecords = new StackMapRecordCollector(ctxt).collect();
         CallSiteInfo callSiteInfo = ctxt.getAttachment(CallSiteInfo.KEY);
+        if (stackMapRecords.isEmpty()) {
+            return new MethodData(0);
+        }
         MethodData methodData = new MethodData(stackMapRecords.size());
         Iterator<StackMapRecord> recordIterator = stackMapRecords.iterator();
         final int[] recordIndex = { 0 };


### PR DESCRIPTION
On the Wasm backend, we do not have StackMap information (yet), thus we are generating an invalid `ProgramModule`. We return earlier and avoid scanning through the empty iterator.
