### PR TITLE
Remove collectedPointers, convert references

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/ReferenceHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/ReferenceHandle.java
@@ -18,7 +18,7 @@ public final class ReferenceHandle extends AbstractValueHandle {
     ReferenceHandle(Node callSite, ExecutableElement element, int line, int bci, Value referenceValue) {
         super(callSite, element, line, bci);
         this.referenceValue = referenceValue;
-        pointerType = ((ReferenceType) referenceValue.getType()).getUpperBound().getPointer().asCollected();
+        pointerType = ((ReferenceType) referenceValue.getType()).getUpperBound().getPointer();
     }
 
     @Override

--- a/compiler/src/main/java/org/qbicc/type/PointerType.java
+++ b/compiler/src/main/java/org/qbicc/type/PointerType.java
@@ -10,7 +10,6 @@ public final class PointerType extends NullableType {
     private final boolean collected;
     private final PointerType asRestrict;
     private final PointerType withConstPointee;
-    private final PointerType asCollected;
     private final int size;
     private final PointerType asWide;
 
@@ -22,7 +21,6 @@ public final class PointerType extends NullableType {
         this.collected = collected;
         this.asRestrict = restrict ? this : new PointerType(typeSystem, pointeeType, true, constPointee, collected, size);
         this.withConstPointee = constPointee ? this : new PointerType(typeSystem, pointeeType, restrict, true, collected, size);
-        this.asCollected = collected ? this : new PointerType(typeSystem, pointeeType, restrict, constPointee, true, size);
         this.asWide = size == 8 ? this : new PointerType(typeSystem, pointeeType, restrict, constPointee, collected, 8);
         this.size = size;
     }
@@ -52,10 +50,6 @@ public final class PointerType extends NullableType {
         return withConstPointee;
     }
 
-    public PointerType asCollected() {
-        return asCollected;
-    }
-
     public PointerType withQualifiersFrom(PointerType otherPointerType) {
         PointerType pointerType = this;
 
@@ -65,10 +59,6 @@ public final class PointerType extends NullableType {
 
         if (otherPointerType.isConstPointee()) {
             pointerType = pointerType.withConstPointee();
-        }
-
-        if (otherPointerType.isCollected()) {
-            pointerType = pointerType.asCollected();
         }
 
         return pointerType;
@@ -150,10 +140,6 @@ public final class PointerType extends NullableType {
 
         if (constPointee) {
             pointerType = pointerType.withConstPointee();
-        }
-
-        if (collected) {
-            pointerType = pointerType.asCollected();
         }
 
         return pointerType;

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -149,7 +149,7 @@ final class CNativeIntrinsics {
         StaticIntrinsic refToPtr = (builder, target, arguments) -> {
             Value value = arguments.get(0);
             if (value.getType() instanceof ReferenceType rt) {
-                return builder.valueConvert(value, rt.getUpperBound().getPointer().asCollected());
+                return builder.valueConvert(value, rt.getUpperBound().getPointer());
             } else {
                 ctxt.error(builder.getLocation(), "Cannot convert non-reference to pointer");
                 return ctxt.getLiteralFactory().nullLiteralOfType(ctxt.getTypeSystem().getVoidType().getPointer());

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
@@ -37,7 +37,7 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder imp
         if (pointerType.getPointeeType() instanceof PhysicalObjectType pot) {
             Layout layout = Layout.get(ctxt);
             LayoutInfo info = layout.getInstanceLayoutInfo(pot.getDefinition());
-            return fb.pointerHandle(fb.valueConvert(pointer, info.getCompoundType().getPointer().asCollected()));
+            return fb.pointerHandle(fb.valueConvert(pointer, info.getCompoundType().getPointer()));
         }
         return getDelegate().pointerHandle(pointer, offsetValue);
     }
@@ -49,7 +49,7 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder imp
                 BasicBlockBuilder fb = getFirstBuilder();
                 Layout layout = Layout.get(ctxt);
                 LayoutInfo info = layout.getInstanceLayoutInfo(pot.getDefinition());
-                PointerType newType = info.getCompoundType().getPointer().asCollected();
+                PointerType newType = info.getCompoundType().getPointer();
                 if (value.getType() instanceof PointerType) {
                     return fb.bitCast(value, newType);
                 } else {
@@ -66,7 +66,7 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder imp
             BasicBlockBuilder fb = getFirstBuilder();
             Layout layout = Layout.get(ctxt);
             LayoutInfo info = layout.getInstanceLayoutInfo(pot.getDefinition());
-            PointerType newType = info.getCompoundType().getPointer().asCollected();
+            PointerType newType = info.getCompoundType().getPointer();
             return fb.stackAllocate(newType, count, align);
         }
         return super.stackAllocate(type, count, align);
@@ -97,7 +97,7 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder imp
         } else {
             info = layout.getInstanceLayoutInfo(upperBound.getDefinition());
         }
-        return fb.pointerHandle(fb.valueConvert(reference, info.getCompoundType().getPointer().asCollected()));
+        return fb.pointerHandle(fb.valueConvert(reference, info.getCompoundType().getPointer()));
     }
 
     @Override

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -127,9 +127,6 @@ final class LLVMModuleGenerator {
                     obj.threadLocal(map(tlm));
                 }
                 obj.asGlobal(item.getName());
-                if (item.getAddrspace() != 0) {
-                    obj.addressSpace(item.getAddrspace());
-                }
             }
         }
         for (ModuleSection section : programModule.sections()) {
@@ -194,9 +191,6 @@ final class LLVMModuleGenerator {
                     }
                     if (! sectionName.equals(CompilationContext.IMPLICIT_SECTION_NAME)) {
                         obj.section(sectionName);
-                    }
-                    if (item.getAddrspace() != 0) {
-                        obj.addressSpace(data.getAddrspace());
                     }
                     MemberElement element = data.getOriginalElement();
                     if (element != null) {


### PR DESCRIPTION
Remove the notion of "collected pointer" and use references instead. Convert instead of casting interned strings and objects of the inital heap.