### PR TITLE
Allow operations on values of UnresolvedType

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/ReferenceHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/ReferenceHandle.java
@@ -4,6 +4,7 @@ import org.qbicc.graph.atomic.AccessMode;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
+import org.qbicc.type.UnresolvedType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 import static org.qbicc.graph.atomic.AccessModes.SinglePlain;
@@ -18,10 +19,12 @@ public final class ReferenceHandle extends AbstractValueHandle {
     ReferenceHandle(Node callSite, ExecutableElement element, int line, int bci, Value referenceValue) {
         super(callSite, element, line, bci);
         this.referenceValue = referenceValue;
-        if (referenceValue.getType().isComplete()) {
-            pointerType = ((ReferenceType) referenceValue.getType()).getUpperBound().getPointer();
+        if (referenceValue.getType() instanceof ReferenceType rt) {
+            pointerType = rt.getUpperBound().getPointer();
+        } else if (referenceValue.getType() instanceof UnresolvedType) {
+            pointerType = referenceValue.getType().getPointer();
         } else {
-            pointerType = referenceValue.getType().getTypeSystem().getVoidType().getPointer();
+            throw new IllegalArgumentException("Invalid type for referenceValue: "+referenceValue.getType());
         }
     }
 

--- a/compiler/src/main/java/org/qbicc/type/UnresolvedType.java
+++ b/compiler/src/main/java/org/qbicc/type/UnresolvedType.java
@@ -8,16 +8,12 @@ public final class UnresolvedType extends ValueType {
         super(typeSystem, UnresolvedType.class.hashCode());
     }
 
-    public boolean isComplete() {
-        return false;
-    }
-
     public long getSize() {
-        return 0;
+        return typeSystem.getReferenceSize();
     }
 
     public int getAlign() {
-        return 0;
+        return typeSystem.getReferenceAlignment();
     }
 
     @Override

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/Layout.java
@@ -120,7 +120,7 @@ public final class Layout {
                 continue;
             }
             if (!field.getType().isComplete()) {
-                continue; // skip fields whose type is unresolved
+                continue; // skip fields whose type is incomplete
             }
             if (field.getType().getSize() == 0) {
                 Assert.assertTrue(trailingArray == null); // At most one trailing array per type!

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -58,6 +58,7 @@ import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.Type;
+import org.qbicc.type.UnresolvedType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.VariadicType;
 import org.qbicc.type.VoidType;
@@ -119,7 +120,7 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue>, Pointe
         } else if (type instanceof PointerType) {
             Type pointeeType = ((PointerType) type).getPointeeType();
             res = ptrTo(pointeeType instanceof VoidType ? i8 : map(pointeeType), 0);
-        } else if (type instanceof ReferenceType) {
+        } else if (type instanceof ReferenceType || type instanceof UnresolvedType) {
             // References can be used as different types in the IL without manually casting them, so we need to
             // represent all reference types as being the same LLVM type. We will cast to and from the actual type we
             // use the reference as when needed.


### PR DESCRIPTION
It's quite reasonable to allow programs to be compiled where a runtime
null value is allowed to flow through arguments, fields, and variables
of UnresolvedType.  Change our treatment of UnresolvedType to support
that.