### PR TITLE
don't demote integral arguments to invokedynamic's method handle

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -1816,7 +1816,7 @@ final class MethodParser implements BasicBlockBuilder.ExceptionHandlerPolicy {
                         }
                         // todo: promote the method handle directly to a ValueHandle?
                         Value result = gf.call(gf.exactMethodOf(lf.literalOf(methodHandle), descOfMethodHandle, "invokeExact",
-                            desc), List.of(demote(args, desc)));
+                            desc), List.of(args));
                         TypeDescriptor returnType = desc.getReturnType();
                         if (! returnType.isVoid()) {
                             push(promote(result, returnType), returnType.isClass2());


### PR DESCRIPTION
A potential fix for #1356, but I'm not 100% positive it is correct for all possible uses of invokedynamic.

It definitely is the right right thing for the MethodHandle's created to implement lambdas which collapse their parameters  to their basicTypeSignature to minimize the number of unique lambda classes created.  I spent a fair amount of time trying to see if there was a way to inspect the MethodHandle instance returned from `linkCallSite` and determine what descriptor should be used to invoke it, but wasn't convinced I'd found anything general.

FWIW, I believe if this is wrong, then we'll get an error from `llc` because the types of the actual parameters won't match the types of the function argument.  So at some level, if we aren't 100% positive this is right, its probably ok to merge it and wait until we find code that proves it wrong.
