### PR TITLE
Always use EXTERNAL linkage for Globals

### DIFF
--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/Lowering.java
@@ -85,10 +85,8 @@ public class Lowering {
         LiteralFactory lf = ctxt.getLiteralFactory();
         ModuleSection section = ctxt.getOrAddProgramModule(typeDef).getOrAddSection(sectionName);
         Value initialValue;
-        boolean hasValue;
         if (field.getRunTimeInitializer() != null) {
             initialValue = lf.zeroInitializerLiteralOfType(globalType);
-            hasValue = false;
         } else {
             initialValue = field.getReplacementValue(ctxt);
             if (initialValue == null) {
@@ -98,12 +96,7 @@ public class Lowering {
                 initialValue = Constants.get(ctxt).getConstantValue(field);
                 if (initialValue == null) {
                     initialValue = lf.zeroInitializerLiteralOfType(globalType);
-                    hasValue = false;
-                } else {
-                    hasValue = true;
                 }
-            } else {
-                hasValue = true;
             }
         }
         if (initialValue instanceof OffsetOfField oof) {
@@ -132,7 +125,7 @@ public class Lowering {
             initialValue = bth.referToSerializedVmObject(ol.getValue(), ol.getType(), section.getProgramModule());
         }
         final Data data = section.addData(field, globalName, initialValue);
-        data.setLinkage(hasValue ? Linkage.EXTERNAL : Linkage.COMMON);
+        data.setLinkage(Linkage.EXTERNAL);
         data.setDsoLocal();
         return global;
     }

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ExternExportTypeBuilder.java
@@ -150,7 +150,7 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
                     if (resolved.hasAllModifiersOf(ClassFile.I_ACC_THREAD_LOCAL)) {
                         decl.setThreadLocalMode(ThreadLocalMode.GENERAL_DYNAMIC);
                     }
-                    decl.setLinkage(Linkage.COMMON);
+                    decl.setLinkage(Linkage.EXTERNAL);
                     // and register as an external data object
                     addExtern(nativeInfo, resolved, decl);
                 } else if (isExport) {
@@ -164,7 +164,7 @@ public class ExternExportTypeBuilder implements DefinedTypeDefinition.Builder.De
                     if (resolved.hasAllModifiersOf(ClassFile.I_ACC_THREAD_LOCAL)) {
                         data.setThreadLocalMode(ThreadLocalMode.GENERAL_DYNAMIC);
                     }
-                    data.setLinkage(Linkage.COMMON);
+                    data.setLinkage(Linkage.EXTERNAL);
                     // and register it
                     addExport(nativeInfo, resolved, data);
                 }


### PR DESCRIPTION
The Wasm LLVM backend crashes when a `global` variable is declared as `common` https://github.com/llvm/llvm-project/issues/55270

However, a careful re-read of the docs seem to hint that `common` is not a valid modifier for globals *in general*:

> It is illegal for a global variable or function declaration to have any linkage type other than external or extern_weak.

https://llvm.org/docs/LangRef.html#linkage-types

This PR switches `COMMON` linkage for `EXTERNAL` for globals and exported field declarations, which lowers to `external` which seems to work with both backends (an alternative may be `WEAK` which lowers to `extern_weak`)