### PR TITLE
Incremental progress on compiling a Quarkus application

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -157,6 +157,7 @@ public final class VmImpl implements Vm {
 
     final VmThrowableClassImpl incompatibleClassChangeErrorClass;
     final VmThrowableClassImpl noClassDefFoundErrorClass;
+    final VmThrowableClassImpl verifyErrorClass;
 
     final VmThrowableClassImpl noSuchFieldErrorClass;
     final VmThrowableClassImpl noSuchMethodErrorClass;
@@ -315,6 +316,8 @@ public final class VmImpl implements Vm {
         incompatibleClassChangeErrorClass.postConstruct(this);
         noClassDefFoundErrorClass = new VmThrowableClassImpl(this, bcc.findDefinedType("java/lang/NoClassDefFoundError").load());
         noClassDefFoundErrorClass.postConstruct(this);
+        verifyErrorClass = new VmThrowableClassImpl(this, bcc.findDefinedType("java/lang/VerifyError").load());
+        verifyErrorClass.postConstruct(this);
 
         // incompatible class change errors
         noSuchMethodErrorClass = new VmThrowableClassImpl(this, bcc.findDefinedType("java/lang/NoSuchMethodError").load());

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -73,6 +73,10 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-apploader</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-constants</artifactId>
         </dependency>
         <dependency>

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -58,6 +58,7 @@ import org.qbicc.machine.tool.CToolChain;
 import org.qbicc.machine.vfs.AbsoluteVirtualPath;
 import org.qbicc.machine.vfs.VFSUtils;
 import org.qbicc.machine.vfs.VirtualFileSystem;
+import org.qbicc.plugin.apploader.InitAppClassLoaderHook;
 import org.qbicc.plugin.constants.ConstantBasicBlockBuilder;
 import org.qbicc.plugin.conversion.NumericalConversionBasicBlockBuilder;
 import org.qbicc.plugin.core.CoreAnnotationTypeBuilder;
@@ -442,6 +443,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPreHook(Phase.ADD, VFS::initialize);
                                 builder.addPreHook(Phase.ADD, Main::mountInitialFileSystem);
                                 builder.addPreHook(Phase.ADD, new VMHelpersSetupHook());
+                                builder.addPreHook(Phase.ADD, new InitAppClassLoaderHook());
                                 builder.addPreHook(Phase.ADD, new AddMainClassHook());
                                 if (nogc) {
                                     builder.addPreHook(Phase.ADD, new NoGcSetupHook());

--- a/plugins/apploader/pom.xml
+++ b/plugins/apploader/pom.xml
@@ -10,10 +10,10 @@
         <version>0.36.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>qbicc-plugin-reachability</artifactId>
+    <artifactId>qbicc-plugin-apploader</artifactId>
 
-    <name>Qbicc Plugin: Reachability</name>
-    <description>Support for evaluating program reachability</description>
+    <name>Qbicc Plugin: App Class Loader</name>
+    <description>Support for initializing and accessing the AppClassLoader</description>
 
     <dependencies>
         <dependency>
@@ -24,14 +24,5 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-driver</artifactId>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-apploader</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-layout</artifactId>
-        </dependency>
     </dependencies>
-
 </project>

--- a/plugins/apploader/src/main/java/org/qbicc/plugin/apploader/AppClassLoader.java
+++ b/plugins/apploader/src/main/java/org/qbicc/plugin/apploader/AppClassLoader.java
@@ -1,0 +1,28 @@
+package org.qbicc.plugin.apploader;
+
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.interpreter.VmClassLoader;
+
+/**
+ * The AppClassLoader attachment.
+ */
+public final class AppClassLoader {
+    private static final AttachmentKey<AppClassLoader> KEY = new AttachmentKey<>();
+
+    private VmClassLoader appClassLoader;
+
+    private AppClassLoader() {}
+
+    public static AppClassLoader get(CompilationContext ctxt) {
+        return ctxt.computeAttachmentIfAbsent(KEY, AppClassLoader::new);
+    }
+
+    public VmClassLoader getAppClassLoader() {
+        return appClassLoader;
+    }
+
+    public void setAppClassLoader(final VmClassLoader cl) {
+        this.appClassLoader = cl;
+    }
+}

--- a/plugins/apploader/src/main/java/org/qbicc/plugin/apploader/InitAppClassLoaderHook.java
+++ b/plugins/apploader/src/main/java/org/qbicc/plugin/apploader/InitAppClassLoaderHook.java
@@ -1,0 +1,32 @@
+package org.qbicc.plugin.apploader;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.atomic.AccessModes;
+import org.qbicc.interpreter.Vm;
+import org.qbicc.interpreter.VmClass;
+import org.qbicc.interpreter.VmClassLoader;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+
+import java.util.function.Consumer;
+
+public class InitAppClassLoaderHook implements Consumer<CompilationContext> {
+    private static final String CLASS_LOADERS = "jdk/internal/loader/ClassLoaders";
+
+    public InitAppClassLoaderHook() {
+    }
+
+    public void accept(final CompilationContext ctxt) {
+        ClassContext bootstrapClassContext = ctxt.getBootstrapClassContext();
+        LoadedTypeDefinition classLoadersDef = bootstrapClassContext.findDefinedType(CLASS_LOADERS).load();
+        VmClass classLoaders = classLoadersDef.getVmClass();
+        try {
+            Vm.requireCurrent().initialize(classLoaders);
+        } catch (Throwable t) {
+            ctxt.error("Failed to initialize %s: %s", CLASS_LOADERS, t);
+            return;
+        }
+        VmClassLoader appClassLoader = (VmClassLoader) classLoaders.getStaticMemory().loadRef(classLoaders.indexOfStatic(classLoadersDef.findField("APP_LOADER")), AccessModes.SinglePlain);
+        AppClassLoader.get(ctxt).setAppClassLoader(appClassLoader);
+    }
+}

--- a/plugins/main/pom.xml
+++ b/plugins/main/pom.xml
@@ -27,6 +27,10 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-apploader</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-intrinsics</artifactId>
         </dependency>
     </dependencies>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -18,6 +18,7 @@
     <description>Qbicc plugins aggregate POM</description>
 
     <modules>
+        <module>apploader</module>
         <module>constants</module>
         <module>conversion</module>
         <module>core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,12 @@
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-plugin-apploader</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-plugin-constants</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Now producing a 69MB executable with just under 30K reachable functions from the knative-quarkus-bench Sleep benchmark.

```
[D] (org.qbicc.plugin.reachability) ANALYZE: Reachability Statistics
[D] (org.qbicc.plugin.reachability) ANALYZE:   Reachable interfaces:          579
[D] (org.qbicc.plugin.reachability) ANALYZE:   Reachable classes:             4375
[D] (org.qbicc.plugin.reachability) ANALYZE:   Reachable functions:           29611
[D] (org.qbicc.plugin.reachability) ANALYZE:   Dispatchable instance methods: 21760
[D] (org.qbicc.plugin.reachability) ANALYZE:   Invokable instance methods:    19979
[D] (org.qbicc.plugin.reachability) ANALYZE:   Accessed static fields:        342
[D] (org.qbicc.plugin.reachability) ANALYZE:   Reflectively accessed classes: 89
[D] (org.qbicc.plugin.reachability) ANALYZE:   Reflectively accessed methods: 186
[D] (org.qbicc.plugin.reachability) ANALYZE:   Reflectively accessed fields:  14
[D] (org.qbicc.plugin.reachability) ANALYZE:   Instantiated classes:          3456
[D] (org.qbicc.plugin.reachability) ANALYZE:   Deferred dispatchable methods: 1898
[D] (org.qbicc.plugin.reachability) ANALYZE:   Deferred exact methods:        82
```
