### PR TITLE
Add Emscripten support to linker and llvm module. Add branches to Main

### DIFF
--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/CCompilerInvoker.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/CCompilerInvoker.java
@@ -120,6 +120,7 @@ public interface CCompilerInvoker extends MessagingToolInvoker {
     enum SourceLanguage {
         C,
         ASM,
+        LLVM_IR,
         ;
     }
 }

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
@@ -78,18 +78,26 @@ final class EmscriptenLinkerInvokerImpl extends AbstractEmscriptenInvoker implem
         } else {
             cmd.add("-no-pie");
         }
-        cmd.add("-pthread");
+        //  cmd.add("-pthread");
 
         for (Path libraryPath : libraryPaths) {
             cmd.add("-L" + libraryPath.toString());
         }
         for (String library : libraries) {
+            if (
+            library.equals("gcc_s") ||
+            library.equals("unwind")) continue;
             cmd.add("-l" + library);
         }
         for (Path objectFile : objectFiles) {
             cmd.add(objectFile.toString());
         }
-        cmd.add("-o");
-        cmd.add(outputPath.toString());
+
+        cmd.addAll(List.of(
+            "-fwasm-exceptions",
+            "-s", "ALLOW_MEMORY_GROWTH=1",
+            "-fbulk-memory",
+            "-o",
+            outputPath.toString()));
     }
 }

--- a/plugins/linker/src/main/java/org/qbicc/plugin/linker/EmscriptenLinkStage.java
+++ b/plugins/linker/src/main/java/org/qbicc/plugin/linker/EmscriptenLinkStage.java
@@ -1,0 +1,59 @@
+package org.qbicc.plugin.linker;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.driver.Driver;
+import org.qbicc.machine.tool.CToolChain;
+import org.qbicc.machine.tool.LinkerInvoker;
+import org.qbicc.machine.tool.ToolMessageHandler;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ *
+ */
+public class EmscriptenLinkStage implements Consumer<CompilationContext> {
+    private final String outputName;
+    private final boolean isPie;
+    private final List<Path> librarySearchPaths;
+
+    public EmscriptenLinkStage(String outputName, final boolean isPie, List<Path> librarySearchPaths) {
+        this.outputName = outputName;
+        this.isPie = isPie;
+        this.librarySearchPaths = librarySearchPaths;
+    }
+
+    public void accept(final CompilationContext context) {
+        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
+        if (cToolChain == null) {
+            context.error("No C tool chain is available");
+            return;
+        }
+        LinkerInvoker linkerInvoker = cToolChain.newLinkerInvoker();
+        Linker linker = Linker.get(context);
+        Map<LoadedTypeDefinition, Path> objectFilePathsByType = linker.getObjectFilePathsByType();
+        List<LoadedTypeDefinition> types = new ArrayList<>(objectFilePathsByType.keySet());
+        types.sort(Comparator.comparingInt(LoadedTypeDefinition::getTypeId));
+        List<Path> sortedPaths = new ArrayList<>(types.size());
+        for (LoadedTypeDefinition type : types) {
+            sortedPaths.add(objectFilePathsByType.get(type));
+        }
+        linkerInvoker.addObjectFiles(sortedPaths);
+        linkerInvoker.addLibraries(linker.getLibraries());
+        linkerInvoker.addLibraryPaths(librarySearchPaths);
+        linkerInvoker.setOutputPath(context.getOutputDirectory().resolve(outputName));
+        linkerInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        linkerInvoker.setIsPie(isPie);
+        try {
+            linkerInvoker.invoke();
+        } catch (IOException e) {
+            context.error("Linker invocation failed: %s", e.toString());
+        }
+    }
+}

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompileStage.java
@@ -10,9 +10,11 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 
 public class LLVMCompileStage implements Consumer<CompilationContext> {
     private final boolean isPie;
+    private final LLVMCompiler.Factory llvmCompilerFactory;
 
-    public LLVMCompileStage(final boolean isPie) {
+    public LLVMCompileStage(final boolean isPie, final LLVMCompiler.Factory llvmCompilerFactory) {
         this.isPie = isPie;
+        this.llvmCompilerFactory = llvmCompilerFactory;
     }
 
     public void accept(final CompilationContext context) {
@@ -24,7 +26,7 @@ public class LLVMCompileStage implements Consumer<CompilationContext> {
 
         Iterator<Map.Entry<LoadedTypeDefinition, Path>> iterator = llvmState.getModulePaths().entrySet().iterator();
         context.runParallelTask(ctxt -> {
-            LLVMCompiler compiler = new LLVMCompiler(context, isPie);
+            LLVMCompiler compiler = llvmCompilerFactory.of(context, isPie);
             for (;;) {
                 Map.Entry<LoadedTypeDefinition, Path> entry;
                 synchronized (iterator) {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompiler.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompiler.java
@@ -1,126 +1,13 @@
 package org.qbicc.plugin.llvm;
 
 import org.qbicc.context.CompilationContext;
-import org.qbicc.context.Location;
-import org.qbicc.driver.Driver;
-import org.qbicc.machine.tool.CCompilerInvoker;
-import org.qbicc.machine.tool.CToolChain;
-import org.qbicc.machine.tool.ToolMessageHandler;
-import org.qbicc.machine.tool.process.InputSource;
-import org.qbicc.machine.tool.process.OutputDestination;
-import org.qbicc.plugin.linker.Linker;
-import org.qbicc.tool.llvm.LlcInvoker;
-import org.qbicc.tool.llvm.LlvmToolChain;
-import org.qbicc.tool.llvm.OptInvoker;
-import org.qbicc.tool.llvm.OptPass;
-import org.qbicc.tool.llvm.OutputFormat;
-import org.qbicc.tool.llvm.RelocationModel;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
-public class LLVMCompiler {
-    private final LlcInvoker llcInvoker;
-    private final OptInvoker optInvoker;
-    private final CCompilerInvoker ccInvoker;
-
-    public LLVMCompiler(CompilationContext context, boolean isPie) {
-        llcInvoker = createLlcInvoker(context, isPie);
-        optInvoker = createOptInvoker(context);
-        ccInvoker = createCCompilerInvoker(context);
+public interface LLVMCompiler {
+    interface Factory {
+        LLVMCompiler of(CompilationContext ctx, boolean isPie);
     }
-
-    public void compileModule(final CompilationContext context, LoadedTypeDefinition typeDefinition, Path modulePath) {
-        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
-
-        String moduleName = modulePath.getFileName().toString();
-        if (moduleName.endsWith(".ll")) {
-            String baseName = moduleName.substring(0, moduleName.length() - 3);
-            String optBitCodeName = baseName + "_opt.bc";
-            String assemblyName = baseName + ".s";
-            String objectName = baseName + "." + cToolChain.getPlatform().getObjectType().objectSuffix();
-
-            Path optBitCodePath = modulePath.resolveSibling(optBitCodeName);
-            Path assemblyPath = modulePath.resolveSibling(assemblyName);
-            Path objectPath = modulePath.resolveSibling(objectName);
-
-            optInvoker.setSource(InputSource.from(modulePath));
-            optInvoker.setDestination(OutputDestination.of(optBitCodePath));
-            int errCnt = context.errors();
-            try {
-                optInvoker.invoke();
-            } catch (IOException e) {
-                if (errCnt == context.errors()) {
-                    // whatever the problem was, it wasn't reported, so add an additional error here
-                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`opt` invocation has failed: %s", e.toString());
-                }
-                return;
-            }
-
-            llcInvoker.setSource(InputSource.from(optBitCodePath));
-            llcInvoker.setDestination(OutputDestination.of(assemblyPath));
-            errCnt = context.errors();
-            try {
-                llcInvoker.invoke();
-            } catch (IOException e) {
-                if (errCnt == context.errors()) {
-                    // whatever the problem was, it wasn't reported, so add an additional error here
-                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`llc` invocation has failed: %s", e.toString());
-                }
-                return;
-            }
-
-            // now compile it
-            ccInvoker.setSource(InputSource.from(assemblyPath));
-            ccInvoker.setOutputPath(objectPath);
-            try {
-                ccInvoker.invoke();
-            } catch (IOException e) {
-                context.error("Compiler invocation has failed for %s: %s", modulePath, e.toString());
-                return;
-            }
-            Linker.get(context).addObjectFilePath(typeDefinition, objectPath);
-        } else {
-            context.warning("Ignoring unknown module file name \"%s\"", modulePath);
-        }
-    }
-
-    private static CCompilerInvoker createCCompilerInvoker(CompilationContext context) {
-        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
-        if (cToolChain == null) {
-            context.error("No C tool chain is available");
-            return null;
-        }
-        CCompilerInvoker ccInvoker = cToolChain.newCompilerInvoker();
-        ccInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
-        ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.ASM);
-        return ccInvoker;
-    }
-
-    private static OptInvoker createOptInvoker(CompilationContext context) {
-        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
-        if (llvmToolChain == null) {
-            context.error("No LLVM tool chain is available");
-            return null;
-        }
-        OptInvoker optInvoker = llvmToolChain.newOptInvoker();
-        optInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
-        optInvoker.addOptimizationPass(OptPass.RewriteStatepointsForGc);
-        optInvoker.addOptimizationPass(OptPass.AlwaysInline);
-        return optInvoker;
-    }
-
-    private static LlcInvoker createLlcInvoker(CompilationContext context, boolean isPie) {
-        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
-        if (llvmToolChain == null) {
-            context.error("No LLVM tool chain is available");
-            return null;
-        }
-        LlcInvoker llcInvoker = llvmToolChain.newLlcInvoker();
-        llcInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
-        llcInvoker.setOutputFormat(OutputFormat.ASM);
-        llcInvoker.setRelocationModel(isPie ? RelocationModel.Pic : RelocationModel.Static);
-        return llcInvoker;
-    }
+    void compileModule(CompilationContext context, LoadedTypeDefinition typeDefinition, Path modulePath);
 }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompilerImpl.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompilerImpl.java
@@ -1,0 +1,127 @@
+package org.qbicc.plugin.llvm;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.context.Location;
+import org.qbicc.driver.Driver;
+import org.qbicc.machine.tool.CCompilerInvoker;
+import org.qbicc.machine.tool.CToolChain;
+import org.qbicc.machine.tool.ToolMessageHandler;
+import org.qbicc.machine.tool.process.InputSource;
+import org.qbicc.machine.tool.process.OutputDestination;
+import org.qbicc.plugin.linker.Linker;
+import org.qbicc.tool.llvm.LlcInvoker;
+import org.qbicc.tool.llvm.LlvmToolChain;
+import org.qbicc.tool.llvm.OptInvoker;
+import org.qbicc.tool.llvm.OptPass;
+import org.qbicc.tool.llvm.OutputFormat;
+import org.qbicc.tool.llvm.RelocationModel;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class LLVMCompilerImpl implements LLVMCompiler {
+    private final LlcInvoker llcInvoker;
+    private final OptInvoker optInvoker;
+    private final CCompilerInvoker ccInvoker;
+
+    public LLVMCompilerImpl(CompilationContext context, boolean isPie) {
+        llcInvoker = createLlcInvoker(context, isPie);
+        optInvoker = createOptInvoker(context);
+        ccInvoker = createCCompilerInvoker(context);
+    }
+
+    @Override
+    public void compileModule(final CompilationContext context, LoadedTypeDefinition typeDefinition, Path modulePath) {
+        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
+
+        String moduleName = modulePath.getFileName().toString();
+        if (moduleName.endsWith(".ll")) {
+            String baseName = moduleName.substring(0, moduleName.length() - 3);
+            String optBitCodeName = baseName + "_opt.bc";
+            String assemblyName = baseName + ".s";
+            String objectName = baseName + "." + cToolChain.getPlatform().getObjectType().objectSuffix();
+
+            Path optBitCodePath = modulePath.resolveSibling(optBitCodeName);
+            Path assemblyPath = modulePath.resolveSibling(assemblyName);
+            Path objectPath = modulePath.resolveSibling(objectName);
+
+            optInvoker.setSource(InputSource.from(modulePath));
+            optInvoker.setDestination(OutputDestination.of(optBitCodePath));
+            int errCnt = context.errors();
+            try {
+                optInvoker.invoke();
+            } catch (IOException e) {
+                if (errCnt == context.errors()) {
+                    // whatever the problem was, it wasn't reported, so add an additional error here
+                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`opt` invocation has failed: %s", e.toString());
+                }
+                return;
+            }
+
+            llcInvoker.setSource(InputSource.from(optBitCodePath));
+            llcInvoker.setDestination(OutputDestination.of(assemblyPath));
+            errCnt = context.errors();
+            try {
+                llcInvoker.invoke();
+            } catch (IOException e) {
+                if (errCnt == context.errors()) {
+                    // whatever the problem was, it wasn't reported, so add an additional error here
+                    context.error(Location.builder().setSourceFilePath(modulePath.toString()).build(), "`llc` invocation has failed: %s", e.toString());
+                }
+                return;
+            }
+
+            // now compile it
+            ccInvoker.setSource(InputSource.from(assemblyPath));
+            ccInvoker.setOutputPath(objectPath);
+            try {
+                ccInvoker.invoke();
+            } catch (IOException e) {
+                context.error("Compiler invocation has failed for %s: %s", modulePath, e.toString());
+                return;
+            }
+            Linker.get(context).addObjectFilePath(typeDefinition, objectPath);
+        } else {
+            context.warning("Ignoring unknown module file name \"%s\"", modulePath);
+        }
+    }
+
+    private static CCompilerInvoker createCCompilerInvoker(CompilationContext context) {
+        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
+        if (cToolChain == null) {
+            context.error("No C tool chain is available");
+            return null;
+        }
+        CCompilerInvoker ccInvoker = cToolChain.newCompilerInvoker();
+        ccInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.ASM);
+        return ccInvoker;
+    }
+
+    private static OptInvoker createOptInvoker(CompilationContext context) {
+        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
+        if (llvmToolChain == null) {
+            context.error("No LLVM tool chain is available");
+            return null;
+        }
+        OptInvoker optInvoker = llvmToolChain.newOptInvoker();
+        optInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        optInvoker.addOptimizationPass(OptPass.RewriteStatepointsForGc);
+        optInvoker.addOptimizationPass(OptPass.AlwaysInline);
+        return optInvoker;
+    }
+
+    private static LlcInvoker createLlcInvoker(CompilationContext context, boolean isPie) {
+        LlvmToolChain llvmToolChain = context.getAttachment(Driver.LLVM_TOOL_KEY);
+        if (llvmToolChain == null) {
+            context.error("No LLVM tool chain is available");
+            return null;
+        }
+        LlcInvoker llcInvoker = llvmToolChain.newLlcInvoker();
+        llcInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        llcInvoker.setOutputFormat(OutputFormat.ASM);
+        llcInvoker.setRelocationModel(isPie ? RelocationModel.Pic : RelocationModel.Static);
+        return llcInvoker;
+    }
+}

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
@@ -10,11 +10,13 @@ public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContex
     private final boolean isPie;
     private final boolean compileOutput;
     private final LLVMReferencePointerFactory refFactory;
+    private LLVMCompiler.Factory llvmCompilerFactory;
 
-    public LLVMDefaultModuleCompileStage(boolean isPie, boolean compileOutput, LLVMReferencePointerFactory refFactory) {
+    public LLVMDefaultModuleCompileStage(boolean isPie, boolean compileOutput, LLVMReferencePointerFactory refFactory, LLVMCompiler.Factory llvmCompilerFactory) {
         this.isPie = isPie;
         this.compileOutput = compileOutput;
         this.refFactory = refFactory;
+        this.llvmCompilerFactory = llvmCompilerFactory;
     }
 
     @Override
@@ -23,7 +25,7 @@ public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContex
         DefinedTypeDefinition defaultTypeDefinition = context.getDefaultTypeDefinition();
         Path modulePath = generator.processProgramModule(context.getOrAddProgramModule(defaultTypeDefinition));
         if (compileOutput) {
-            LLVMCompiler compiler = new LLVMCompiler(context, isPie);
+            LLVMCompiler compiler = llvmCompilerFactory.of(context, isPie);
             compiler.compileModule(context, defaultTypeDefinition.load(), modulePath);
         }
     }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMEmscriptenCompiler.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMEmscriptenCompiler.java
@@ -1,0 +1,59 @@
+package org.qbicc.plugin.llvm;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.driver.Driver;
+import org.qbicc.machine.tool.CCompilerInvoker;
+import org.qbicc.machine.tool.CToolChain;
+import org.qbicc.machine.tool.ToolMessageHandler;
+import org.qbicc.machine.tool.process.InputSource;
+import org.qbicc.plugin.linker.Linker;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class LLVMEmscriptenCompiler implements LLVMCompiler {
+    private final CCompilerInvoker ccInvoker;
+
+    public LLVMEmscriptenCompiler(CompilationContext context, boolean isPie) {
+        ccInvoker = createCCompilerInvoker(context);
+    }
+
+    @Override
+    public void compileModule(final CompilationContext context, LoadedTypeDefinition typeDefinition, Path modulePath) {
+        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
+
+        String moduleName = modulePath.getFileName().toString();
+        if (moduleName.endsWith(".ll")) {
+            String baseName = moduleName.substring(0, moduleName.length() - 3);
+            String objectName = baseName + "." + cToolChain.getPlatform().getObjectType().objectSuffix();
+            Path objectPath = modulePath.resolveSibling(objectName);
+
+            ccInvoker.setSource(InputSource.from(modulePath));
+            ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.LLVM_IR);
+            ccInvoker.setOutputPath(objectPath);
+            try {
+                ccInvoker.invoke();
+            } catch (IOException e) {
+                context.error("Compiler invocation has failed for %s: %s", modulePath, e.toString());
+                return;
+            }
+            Linker.get(context).addObjectFilePath(typeDefinition, objectPath);
+        } else {
+            context.warning("Ignoring unknown module file name \"%s\"", modulePath);
+        }
+    }
+
+    private static CCompilerInvoker createCCompilerInvoker(CompilationContext context) {
+        CToolChain cToolChain = context.getAttachment(Driver.C_TOOL_CHAIN_KEY);
+        if (cToolChain == null) {
+            context.error("No C tool chain is available");
+            return null;
+        }
+        CCompilerInvoker ccInvoker = cToolChain.newCompilerInvoker();
+        ccInvoker.setMessageHandler(ToolMessageHandler.reporting(context));
+        ccInvoker.setSourceLanguage(CCompilerInvoker.SourceLanguage.ASM);
+        return ccInvoker;
+    }
+
+}


### PR DESCRIPTION
Attempting to add Emscripten support to the main flow.

if `isWasm`:

- use `SIMPLE` reference pointers #1352 #1355 
- use `LLVMEmscriptenCompiler` instead of `LLVMCompilerImpl` (add LLVMCompiler interface and `LLVMCompiler.Factory`
- use `LLVMEmscriptenLinkStage` (goes through `emcc` instead of `ld`)

A lot of parameters are being hardcoded both in the linker and the compiler for now. Notably:

- `-s USE_ZLIB` so that `#include<zlib.h>` works
- `-pthread` is being ignored
- `libgcc_s` and `libunwind` are being ignored in the linker because support to exceptions has to be further investigated
- compilation still needs `-fwasm-exceptions` to finish

it is possible to run the test cases via node using the following commit https://github.com/evacchi/qbicc/commit/b982156c8715242e8daaf23b3df3266b882db911

still needs to remove the constructor https://github.com/evacchi/qbicc/commit/8629b1a43027aa3811efa29869c4408a75ac0de9

and invoke initHeap() in the class library https://github.com/qbicc/qbicc-class-library/pull/230

other than this, to try it is enough to set the platform to wasm-wasi in the plugin:

                        <configuration>
                            <mainClass>org.qbicc.tests.TestRunner</mainClass>
                            <platform>wasm-wasi</platform>
                        </configuration>
