### PR TITLE
Revert "Bump svm from 21.3.0 to 22.1.0.1"

### DIFF
--- a/plugins/graalvm-nativeimage-emulation/pom.xml
+++ b/plugins/graalvm-nativeimage-emulation/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
-            <version>22.1.0.1</version>
+            <version>21.3.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Reverts qbicc/qbicc#1351

changes internal APIs.  Need to keep matching the version used by Quarkus for its AutoFeature.