### PR TITLE
Phase 2 initialization with module setup

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/Vm.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Vm.java
@@ -37,6 +37,11 @@ public interface Vm {
     void initialize();
 
     /**
+     * Perform second-stage VM initialization in the currently attached thread.
+     */
+    void initialize2();
+
+    /**
      * Create a new thread.
      *
      * @param threadName the thread name

--- a/compiler/src/main/java/org/qbicc/pointer/Pointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/Pointer.java
@@ -62,7 +62,8 @@ public abstract class Pointer {
         long pointeeSize = pointeeType.getSize();
         if (offset < 0 || offset > pointeeSize) {
             if (! array) {
-                throw new IllegalArgumentException("Pointer offset is out of bounds");
+                // invalid pointer/unknown memory location (out of bounds)
+                return null;
             }
             long index = offset / pointeeSize;
             long extra = offset % pointeeSize;
@@ -88,7 +89,8 @@ public abstract class Pointer {
                     return new MemberPointer(this, member).offsetInBytes(offset - memberOffset, false);
                 }
             }
-            throw new IllegalArgumentException("Pointer offset does not correspond to a structure member");
+            // invalid pointer/unknown memory location
+            return null;
         }
         // field?
         if (pointeeType instanceof PhysicalObjectType pot) {
@@ -103,9 +105,11 @@ public abstract class Pointer {
                     }
                 }
             }
-            throw new IllegalArgumentException("Pointer offset does not correspond to a field in the target instance");
+            // invalid pointer/unknown memory location (not within target object)
+            return null;
         }
-        throw new IllegalArgumentException("Cannot determine type of pointer offset");
+        // invalid pointer/unknown memory location (unknown type)
+        return null;
     }
 
     public Pointer offsetByElements(long count) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -340,9 +340,13 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
     @Override
     public Object visit(VmThreadImpl param, AddressOf node) {
-        // Todo: this is temporary until https://github.com/qbicc/qbicc/issues/54 can be resolved.
-        // Sometimes, addr_of gets scheduled before the build-or-run-time-check executes.
-        return null;
+        ValueHandle valueHandle = node.getValueHandle();
+        Memory memory = getMemory(valueHandle);
+        if (memory == null) {
+            return null;
+        }
+        MemoryPointer memoryPointer = new MemoryPointer(node.getType(PointerType.class), memory);
+        return memoryPointer.offsetInBytes(getOffset(valueHandle), false);
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmClassImpl.java
@@ -188,6 +188,16 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         }
     }
 
+    String getPackageInternalName() {
+        String internalName = getTypeDefinition().getInternalName();
+        int idx = internalName.lastIndexOf('/');
+        if (idx == -1) {
+            return "";
+        } else {
+            return internalName.substring(0, idx);
+        }
+    }
+
     @SuppressWarnings("serial")
     static final class BigBitMapException extends RuntimeException {
         private static final StackTraceElement[] EMPTY_STACK = new StackTraceElement[0];
@@ -762,6 +772,11 @@ class VmClassImpl extends VmObjectImpl implements VmClass {
         // this is a `final` field
         CoreClasses coreClasses = CoreClasses.get(vm.getCompilationContext());
         getMemory().storeRef(indexOf(coreClasses.getClassNestHostField()), host, SingleRelease);
+    }
+
+    void setModule(final VmObjectImpl module) {
+        CoreClasses coreClasses = CoreClasses.get(vm.getCompilationContext());
+        getMemory().storeRef(indexOf(coreClasses.getClassModuleField()), module, SingleRelease);
     }
 
     VmClassImpl getNestHost() {

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -455,6 +455,11 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPreHook(Phase.ADD, Main::mountInitialFileSystem);
                                 builder.addPreHook(Phase.ADD, new VMHelpersSetupHook());
                                 builder.addPreHook(Phase.ADD, new InitAppClassLoaderHook());
+                                builder.addPreHook(Phase.ADD, compilationContext -> {
+                                    Vm vm = compilationContext.getVm();
+                                    VmThread initThread = vm.newThread("initialization 2", vm.getMainThreadGroup(), false,  Thread.currentThread().getPriority());
+                                    vm.doAttached(initThread, vm::initialize2);
+                                });
                                 builder.addPreHook(Phase.ADD, new AddMainClassHook());
                                 if (nogc) {
                                     builder.addPreHook(Phase.ADD, new NoGcSetupHook());

--- a/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/CoreClasses.java
+++ b/plugins/core-classes/src/main/java/org/qbicc/plugin/coreclasses/CoreClasses.java
@@ -49,6 +49,7 @@ public final class CoreClasses {
     };
     private static final String OBJECT_INT_NAME = "java/lang/Object";
     private static final String CLASS_INT_NAME = "java/lang/Class";
+    private static final String CLASS_LOADER_INT_NAME = "java/lang/ClassLoader";
     private static final String THREAD_INT_NAME = "java/lang/Thread";
     private static final String THROWABLE_INT_NAME = "java/lang/Throwable";
 
@@ -63,6 +64,8 @@ public final class CoreClasses {
     private final FieldElement classInstanceAlignField;
     private final FieldElement classNestHostField;
     private final FieldElement classNestMembersField;
+    private final FieldElement classModuleField;
+    private final FieldElement classLoaderUnnamedModuleField;
 
     private final FieldElement thrownField;
 
@@ -119,6 +122,9 @@ public final class CoreClasses {
         classInstanceAlignField = jlc.findField("instanceAlign", true);
         classNestHostField = jlc.findField("nestHost", true);
         classNestMembersField = jlc.findField("nestMembers", true);
+        classModuleField = jlc.findField("module", true);
+
+        classLoaderUnnamedModuleField = classContext.findDefinedType(CLASS_LOADER_INT_NAME).load().findField("unnamedModule", true);
 
         thrownField = jlt.findField("thrown", true);
 
@@ -525,6 +531,14 @@ public final class CoreClasses {
 
     public FieldElement getClassNestMembersField() {
         return classNestMembersField;
+    }
+
+    public FieldElement getClassModuleField() {
+        return classModuleField;
+    }
+
+    public FieldElement getClassLoaderUnnamedModuleField() {
+        return classLoaderUnnamedModuleField;
     }
 
     public LoadedTypeDefinition getClassTypeDefinition() {


### PR DESCRIPTION
This progresses initialization a little farther. This change had to deal with two issues.

- Scheduling issue: we're doing pointer arithmetic on nodes which cannot be understood during interpretation. Originally my plan was to rework the scheduler to be smarter about delaying nodes, but this is a can of worms so it must be done incrementally and will take long enough that it's not acceptable for it to be a blocker for this. Instead, arithmetic on invalid pointers in the interpreter always yields a null pointer.
- Now the bad news: some of these invalid pointers are being used during interpretation, which is *not* expected (because memory accesses are ordered nodes and thus should never be moved outside of their conditionals, at least with the current scheduler). Because of this I'm making this a draft PR until I can figure out what's happening.