### PR TITLE
Add `auto(init)` variants

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -315,8 +315,16 @@ final class CNativeIntrinsics {
 
         intrinsics.registerIntrinsic(cNativeDesc, "zero", MethodDescriptor.synthesize(classContext, nObjDesc, List.of()), zero);
 
-        // todo: implement an "uninitialized" constant similar to zero
         intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, nObjDesc, List.of()), zero);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, nObjDesc, List.of(nObjDesc)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.B, List.of(BaseTypeDescriptor.B)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.C, List.of(BaseTypeDescriptor.C)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.D, List.of(BaseTypeDescriptor.D)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.F, List.of(BaseTypeDescriptor.F)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.I, List.of(BaseTypeDescriptor.I)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.J, List.of(BaseTypeDescriptor.J)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.S, List.of(BaseTypeDescriptor.S)), identityStatic);
+        intrinsics.registerIntrinsic(cNativeDesc, "auto", MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of(BaseTypeDescriptor.Z)), identityStatic);
 
         StaticIntrinsic constant = (builder, target, arguments) ->
             ctxt.getLiteralFactory().constantLiteralOfType(ctxt.getTypeSystem().getPoisonType());

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -270,6 +270,16 @@ public final class CNative {
      */
     public static native <T extends object> T auto();
 
+    public static native <T extends object> T auto(T initial);
+    public static native byte auto(byte initial);
+    public static native char auto(char initial);
+    public static native double auto(double initial);
+    public static native float auto(float initial);
+    public static native int auto(int initial);
+    public static native long auto(long initial);
+    public static native short auto(short initial);
+    public static native boolean auto(boolean initial);
+
     /**
      * Make a word type instance directly out of the given value. If the word type is integral and signed,
      * the given value is sign-extended. If the word type is integral and unsigned, or is not integral, then


### PR DESCRIPTION
This allows explicit stack allocation with an initial value rather than having to store the initial value in a separate step, which IDEs might complain about ("Redundant assignment" or similar).