### PR TITLE
Remove deprecated implicit Heap#ctor

### DIFF
--- a/runtime/gc/heap/src/main/java/org/qbicc/runtime/gc/heap/Heap.java
+++ b/runtime/gc/heap/src/main/java/org/qbicc/runtime/gc/heap/Heap.java
@@ -240,14 +240,6 @@ public final class Heap {
             ;
     }
 
-    // Compatibility (temporary until class libs release)
-    @constructor(priority = 0)
-    @export
-    @Deprecated
-    static void ctor(c_int argc, char_ptr_ptr argv) {
-        initHeap(argc.intValue(), argv);
-    }
-
     @export
     public static boolean initHeap(int argc, char_ptr_ptr argv) {
         if (Build.isHost()) {


### PR DESCRIPTION
`Heap#initHeap` is now explicitly invoked in the classlib's CMain. 