### PR TITLE
WASM: Configure `emcc` compilation+linking flags

### DIFF
--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenCCompilerInvokerImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenCCompilerInvokerImpl.java
@@ -95,14 +95,23 @@ final class EmscriptenCCompilerInvokerImpl extends AbstractEmscriptenInvoker imp
                 cmd.add("-D" + key + "=" + val);
             }
         }
+
+        appendEmscriptenPorts(cmd);
+        enableExceptions(cmd);
+
         Collections.addAll(cmd,
-            "-s", "USE_ZLIB",
             "-Wno-override-module",
             "-mbulk-memory",
-            "-s", "ALLOW_MEMORY_GROWTH=1",
-            "-s", "EXIT_RUNTIME=1",
+            "-g",
+            "-c", "-x", sourceLanguageArg(), "-o", getOutputPath().toString(), "-");
+    }
 
-        "-c", "-x", sourceLanguageArg(), "-o", getOutputPath().toString(), "-");
+    private void appendEmscriptenPorts(List<String> cmd) {
+        Collections.addAll(cmd, "-sUSE_ZLIB");
+    }
+
+    private void enableExceptions(final List<String> cmd) {
+        Collections.addAll(cmd, "-fexceptions");
     }
 
     private String sourceLanguageArg() {

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
@@ -2,6 +2,7 @@ package org.qbicc.machine.tool.emscripten;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import io.smallrye.common.constraint.Assert;
@@ -78,26 +79,37 @@ final class EmscriptenLinkerInvokerImpl extends AbstractEmscriptenInvoker implem
         } else {
             cmd.add("-no-pie");
         }
-        //  cmd.add("-pthread");
+        // cmd.add("-pthread");
 
         for (Path libraryPath : libraryPaths) {
             cmd.add("-L" + libraryPath.toString());
         }
         for (String library : libraries) {
-            if (
-            library.equals("gcc_s") ||
-            library.equals("unwind")) continue;
             cmd.add("-l" + library);
         }
         for (Path objectFile : objectFiles) {
             cmd.add(objectFile.toString());
         }
 
-        cmd.addAll(List.of(
-            "-fwasm-exceptions",
-            "-s", "ALLOW_MEMORY_GROWTH=1",
+        enableExceptions(cmd);
+        appendLinkingOptions(cmd);
+
+        Collections.addAll(cmd,
+            "-g",
             "-fbulk-memory",
             "-o",
-            outputPath.toString()));
+            outputPath.toString());
+    }
+
+    private void enableExceptions(final List<String> cmd) {
+        Collections.addAll(cmd, "-fexceptions");
+    }
+
+    private void appendLinkingOptions(final List<String> cmd) {
+        Collections.addAll(cmd,
+            "-sALLOW_MEMORY_GROWTH=1",
+            "-sEXIT_RUNTIME=1",
+            "-sERROR_ON_UNDEFINED_SYMBOLS=0",
+            "-sLLD_REPORT_UNDEFINED");
     }
 }

--- a/plugins/core/src/main/java/org/qbicc/plugin/core/ConditionEvaluation.java
+++ b/plugins/core/src/main/java/org/qbicc/plugin/core/ConditionEvaluation.java
@@ -52,7 +52,8 @@ public final class ConditionEvaluation {
 
             // CPU architectures
             Map.entry("org/qbicc/runtime/Build$Target$IsAmd64", Boolean.valueOf(platform.getCpu() == Cpu.X86_64)),
-            Map.entry("org/qbicc/runtime/Build$Target$IsArm", Boolean.valueOf(platform.getCpu() == Cpu.ARM))
+            Map.entry("org/qbicc/runtime/Build$Target$IsArm", Boolean.valueOf(platform.getCpu() == Cpu.ARM)),
+            Map.entry("org/qbicc/runtime/Build$Target$IsWasm", Boolean.valueOf(platform.getCpu() == Cpu.WASM32))
         );
     }
 

--- a/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/LibUnwind.java
+++ b/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/LibUnwind.java
@@ -9,7 +9,7 @@ import static org.qbicc.runtime.CNative.*;
  */
 @define("UNW_LOCAL_ONLY")
 @include("<libunwind.h>")
-@lib(value = "unwind", unless = Build.Target.IsMacOs.class)
+@lib(value = "unwind", unless = { Build.Target.IsMacOs.class, Build.Target.IsWasm.class } )
 public final class LibUnwind {
     private LibUnwind() {}
 

--- a/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/Unwind.java
+++ b/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/Unwind.java
@@ -10,7 +10,7 @@ import org.qbicc.runtime.Build;
  * Unwind ABI as described at <a href="https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html">https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html</a>.
  */
 @include("<unwind.h>")
-@lib(value = "gcc_s", unless = Build.Target.IsMacOs.class) // todo: -static-libgcc
+@lib(value = "gcc_s", unless = { Build.Target.IsMacOs.class, Build.Target.IsWasm.class } ) // todo: -static-libgcc
 @lib(value = "gcc_s.1", when = Build.Target.IsMacOs.class) // todo: -static-libgcc
 public final class Unwind {
     private Unwind() {


### PR DESCRIPTION
- Configure some sensible defaults for `emcc` to compiler IR and link the Wasm+JS executable
- ~~Add Wasm to the list of Unix-like platforms~~
- Disable explicit linking of libunwind, gcc_s using `unless`
- Avoid invoking `mprotect()` during heap setup, since it is unsupported (prints a warning to stderr, causes the tests to fail)

Exceptions are still not supported (test TryCatch would fail, see also https://github.com/qbicc/qbicc/pull/1402) 