### PR TITLE
the VmClass of a reachable type is a heap root

### DIFF
--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/RapidTypeAnalysis.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.interpreter.VmObject;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.InterfaceObjectType;
 import org.qbicc.type.ObjectType;
@@ -75,8 +76,8 @@ public final class RapidTypeAnalysis implements ReachabilityAnalysis {
         processInstantiatedClass(ltd, true, currentElement);
     }
 
-    public synchronized void processReachableObjectLiteral(ObjectLiteral objectLiteral, ExecutableElement currentElement) {
-        heapAnalyzer.traceHeap(ctxt, this, objectLiteral.getValue(), currentElement);
+    public synchronized void processReachableObject(VmObject object, ExecutableElement currentElement) {
+        heapAnalyzer.traceHeap(ctxt, this, object, currentElement);
     }
 
     public synchronized void processReachableRuntimeInitializer(final InitializerElement target, ExecutableElement currentElement) {

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnalysis.java
@@ -1,6 +1,7 @@
 package org.qbicc.plugin.reachability;
 
 import org.qbicc.graph.literal.ObjectLiteral;
+import org.qbicc.interpreter.VmObject;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -18,7 +19,7 @@ interface ReachabilityAnalysis {
 
     void processBuildtimeInstantiatedObjectType(LoadedTypeDefinition ltd, ExecutableElement currentElement);
 
-    void processReachableObjectLiteral(ObjectLiteral objectLiteral, ExecutableElement currentElement);
+    void processReachableObject(VmObject objectLiteral, ExecutableElement currentElement);
 
     void processReachableRuntimeInitializer(final InitializerElement target, ExecutableElement currentElement);
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityBlockBuilder.java
@@ -139,7 +139,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
         @Override
         public Void visit(ReachabilityContext param, ObjectLiteral value) {
-            param.analysis.processReachableObjectLiteral(value, param.currentElement);
+            param.analysis.processReachableObject(value.getValue(), param.currentElement);
             return null;
         }
 
@@ -159,7 +159,7 @@ public class ReachabilityBlockBuilder extends DelegatingBasicBlockBuilder implem
 
         @Override
         public Void visit(ReachabilityContext param, ReferenceAsPointer pointer) {
-            param.analysis.processReachableObjectLiteral(param.ctxt.getLiteralFactory().literalOf(pointer.getReference()), param.currentElement);
+            param.analysis.processReachableObject(pointer.getReference(), param.currentElement);
             return null;
         }
 

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityInfo.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 import org.jboss.logging.Logger;
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
+import org.qbicc.interpreter.VmObject;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.ConstructorElement;
@@ -280,6 +281,9 @@ public class ReachabilityInfo {
                     }
                 }
             }
+
+            // The Class object of a reachable type is a heap root.
+            analysis.processReachableObject(type.getVmClass(), null);
         }
     }
 
@@ -325,6 +329,9 @@ public class ReachabilityInfo {
                     }
                 }
             }
+
+            // The Class object of a reachable type is a heap root.
+            analysis.processReachableObject(type.getVmClass(), null);
         }
     }
 


### PR DESCRIPTION
Bug fix in reachability analysis.  When a type becomes reachable,
we must trace its java.lang.Class instance as a heap root.