### PR TITLE
WASM: Lower `throw` to `abort()`

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -96,6 +96,7 @@ import org.qbicc.plugin.llvm.LLVMGenerator;
 import org.qbicc.plugin.llvm.LLVMIntrinsics;
 import org.qbicc.plugin.llvm.LLVMReferencePointerFactory;
 import org.qbicc.plugin.llvm.LLVMStripStackMapStage;
+import org.qbicc.plugin.lowering.AbortingThrowLoweringBasicBlockBuilder;
 import org.qbicc.plugin.lowering.BooleanAccessCopier;
 import org.qbicc.plugin.lowering.FunctionLoweringElementHandler;
 import org.qbicc.plugin.lowering.InitCheckLoweringBasicBlockBuilder;
@@ -574,7 +575,11 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addCopyFactory(Phase.LOWER, MemberPointerCopier::new);
                                 builder.addCopyFactory(Phase.LOWER, ObjectLiteralSerializingVisitor::new);
 
-                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ThrowLoweringBasicBlockBuilder::new);
+                                if (isWasm) {
+                                    builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, AbortingThrowLoweringBasicBlockBuilder::new);
+                                } else {
+                                    builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, ThrowLoweringBasicBlockBuilder::new);
+                                }
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, DevirtualizingBasicBlockBuilder::new);
                                 if (nogc) {
                                     builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, NoGcBasicBlockBuilder::new);

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/AbortingThrowLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/AbortingThrowLoweringBasicBlockBuilder.java
@@ -1,0 +1,32 @@
+package org.qbicc.plugin.lowering;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Value;
+import org.qbicc.object.FunctionDeclaration;
+import org.qbicc.object.ProgramModule;
+import org.qbicc.type.FunctionType;
+import org.qbicc.type.TypeSystem;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+import java.util.List;
+
+public class AbortingThrowLoweringBasicBlockBuilder extends DelegatingBasicBlockBuilder {
+    private final CompilationContext ctxt;
+
+    public AbortingThrowLoweringBasicBlockBuilder(final CompilationContext ctxt, final BasicBlockBuilder delegate) {
+        super(delegate);
+        this.ctxt = ctxt;
+    }
+
+    public BasicBlock throw_(final Value value) {
+        TypeSystem ts = ctxt.getTypeSystem();
+        ExecutableElement el = getDelegate().getRootElement();
+        ProgramModule programModule = ctxt.getOrAddProgramModule(el);
+        FunctionType abortSignature = ts.getFunctionType(ts.getVoidType(), List.of());
+        FunctionDeclaration fd = programModule.declareFunction(null, "abort", abortSignature);
+        return callNoReturn(pointerHandle(ctxt.getLiteralFactory().literalOf(fd)), List.of());
+    }
+}


### PR DESCRIPTION
Current implementation of EH leverages `libunwind`; lowering to a supported EH mechanism requires a supported runtime (in general this currently means "only NodeJS" or "V8"), which makes it harder to support smaller, embeddable runtimes such as `wasmer` and `wasmtime`.

This PR lowers `throw` to `abort()` allowing to do away with `libunwind` and EH in general for the time being. While this is not ideal, it is good enough to build self-contained nontrivial programs (e.g. good for simple plugin extensions, such as Envoy's*).

- WASM: AbortingThrowLoweringBasicBlockBuilder, abort()s instead of throwing
- WASM: Do not try to fill the stack trace

this is a follow-up to https://github.com/qbicc/qbicc/pull/1403 but may be merged independently

(*) disclaimer: Envoy currently has further limitations on the supported API surface so it does not work yet