### PR TITLE
Typed memory implementation

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/InvalidMemoryAccessException.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/InvalidMemoryAccessException.java
@@ -1,4 +1,4 @@
-package org.qbicc.interpreter.impl;
+package org.qbicc.interpreter;
 
 import java.io.Serial;
 

--- a/compiler/src/main/java/org/qbicc/interpreter/Vm.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Vm.java
@@ -216,14 +216,6 @@ public interface Vm {
     VmObject getMainThreadGroup();
 
     /**
-     * Allocate memory of the given size.  If the memory size is 0, a shared instance may be returned.
-     *
-     * @param size the memory size (must be 0 or greater)
-     * @return the memory (not {@code null})
-     */
-    Memory allocate(int size);
-
-    /**
      * Allocate memory of the given dimensions. The memory may be strongly typed (i.e. storing values that do
      * not correspond to valid members of the given type may throw an exception).
      *

--- a/compiler/src/main/java/org/qbicc/type/ArrayType.java
+++ b/compiler/src/main/java/org/qbicc/type/ArrayType.java
@@ -47,6 +47,15 @@ public final class ArrayType extends ValueType {
         return other instanceof ArrayType && equals((ArrayType) other);
     }
 
+    @Override
+    public ValueType getTypeAtOffset(long offset) {
+        if (0 <= offset && offset < getSize()) {
+            return elementType.getTypeAtOffset(offset % elementSize);
+        } else {
+            return getTypeSystem().getVoidType();
+        }
+    }
+
     public boolean equals(final ArrayType other) {
         return this == other || super.equals(other) && elementCount == other.elementCount && elementType.equals(other.elementType);
     }

--- a/compiler/src/main/java/org/qbicc/type/CompoundType.java
+++ b/compiler/src/main/java/org/qbicc/type/CompoundType.java
@@ -241,6 +241,44 @@ public final class CompoundType extends ValueType {
         return getMembers().get(index);
     }
 
+    public Member getMemberByOffset(int offset) {
+        List<Member> list = getMembers();
+        int size = list.size();
+
+        // the usual binary search
+        int low = 0;
+        int high = size - 1;
+
+        Member member;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            member = list.get(mid);
+            int cmp = Integer.compare(member.getOffset(), offset);
+
+            if (cmp < 0) {
+                low = mid + 1;
+            } else if (cmp > 0) {
+                high = mid - 1;
+            } else {
+                // found it exactly
+                return member;
+            }
+        }
+        if (low >= size) {
+            // it's past the end
+            return null;
+        } else {
+            // see if the offset is within the next-lower member
+            member = list.get(low);
+            if (offset < member.getOffset() + member.getType().getSize()) {
+                return member;
+            } else {
+                // it fell into padding
+                return null;
+            }
+        }
+    }
+
     public Member getMember(String name) {
         Assert.assertFalse(isAnonymous()); /* anonymous structs do not have member names */
         Member member = getMembersByName().get(name);
@@ -297,6 +335,18 @@ public final class CompoundType extends ValueType {
 
     public boolean equals(final ValueType other) {
         return other instanceof CompoundType ct && equals(ct);
+    }
+
+    @Override
+    public ValueType getTypeAtOffset(long offset) {
+        if (offset > getSize()) {
+            return getTypeSystem().getVoidType();
+        }
+        CompoundType.Member member = getMemberByOffset((int) offset);
+        if (member == null) {
+            return getTypeSystem().getVoidType();
+        }
+        return member.getType().getTypeAtOffset(offset - member.getOffset());
     }
 
     public boolean equals(final CompoundType other) {

--- a/compiler/src/main/java/org/qbicc/type/CompoundType.java
+++ b/compiler/src/main/java/org/qbicc/type/CompoundType.java
@@ -540,6 +540,10 @@ public final class CompoundType extends ValueType {
             return members.get(members.size() - 1);
         }
 
+        public int getMemberCountSoFar() {
+            return members.size();
+        }
+
         private int nextMemberOffset(int offset, int align) {
             return (offset + (align - 1)) & -align;
         }

--- a/compiler/src/main/java/org/qbicc/type/CompoundType.java
+++ b/compiler/src/main/java/org/qbicc/type/CompoundType.java
@@ -535,6 +535,11 @@ public final class CompoundType extends ValueType {
             return this;
         }
 
+        public Member getLastAddedMember() {
+            // not ideal but `addNextMember` returns `Builder`
+            return members.get(members.size() - 1);
+        }
+
         private int nextMemberOffset(int offset, int align) {
             return (offset + (align - 1)) & -align;
         }

--- a/compiler/src/main/java/org/qbicc/type/ObjectType.java
+++ b/compiler/src/main/java/org/qbicc/type/ObjectType.java
@@ -67,6 +67,11 @@ public abstract class ObjectType extends ValueType {
         return newReferenceArrayObjectType;
     }
 
+    @Override
+    public ValueType getTypeAtOffset(long offset) {
+        return getTypeSystem().getVoidType();
+    }
+
     abstract ReferenceType createReferenceType();
 
     public abstract boolean hasSuperClass();

--- a/compiler/src/main/java/org/qbicc/type/PhysicalObjectType.java
+++ b/compiler/src/main/java/org/qbicc/type/PhysicalObjectType.java
@@ -29,6 +29,11 @@ public abstract class PhysicalObjectType extends ObjectType {
      */
     public abstract long getSize() throws IllegalStateException;
 
+    @Override
+    public ValueType getTypeAtOffset(final long offset) {
+        throw new IllegalStateException("Cannot probe type at offset of object type until layout is complete");
+    }
+
     public int getAlign() {
         return typeSystem.getPointerAlignment();
     }

--- a/compiler/src/main/java/org/qbicc/type/PoisonType.java
+++ b/compiler/src/main/java/org/qbicc/type/PoisonType.java
@@ -24,6 +24,10 @@ public final class PoisonType extends ValueType {
         return other instanceof PoisonType && super.equals(other);
     }
 
+    public ValueType getTypeAtOffset(final long offset) {
+        return this;
+    }
+
     public StringBuilder toString(final StringBuilder b) {
         return b.append("poison");
     }

--- a/compiler/src/main/java/org/qbicc/type/ScalarType.java
+++ b/compiler/src/main/java/org/qbicc/type/ScalarType.java
@@ -7,4 +7,8 @@ public abstract class ScalarType extends ValueType {
     ScalarType(final TypeSystem typeSystem, final int hashCode) {
         super(typeSystem, hashCode);
     }
+
+    public ValueType getTypeAtOffset(final long offset) {
+        return offset == 0 ? this : getTypeSystem().getVoidType();
+    }
 }

--- a/compiler/src/main/java/org/qbicc/type/UnresolvedType.java
+++ b/compiler/src/main/java/org/qbicc/type/UnresolvedType.java
@@ -21,6 +21,10 @@ public final class UnresolvedType extends ValueType {
         return this == other;
     }
 
+    public ValueType getTypeAtOffset(final long offset) {
+        return this;
+    }
+
     public StringBuilder toFriendlyString(final StringBuilder b) {
         return b.append("unresolved");
     }

--- a/compiler/src/main/java/org/qbicc/type/ValueType.java
+++ b/compiler/src/main/java/org/qbicc/type/ValueType.java
@@ -56,6 +56,10 @@ public abstract class ValueType extends Type {
         return super.equals(other);
     }
 
+    public ValueType getTypeAtOffset(long offset) {
+        return getTypeSystem().getVoidType();
+    }
+
     /**
      * Find the "join" of two types.  The returned type will represent a type that value of either type can be
      * implicitly converted to (i.e. a common supertype), one way or another.  If no join is possible, the poison

--- a/compiler/src/main/java/org/qbicc/type/VoidType.java
+++ b/compiler/src/main/java/org/qbicc/type/VoidType.java
@@ -24,6 +24,10 @@ public final class VoidType extends ValueType {
         return other instanceof VoidType && super.equals(other);
     }
 
+    public ValueType getTypeAtOffset(final long offset) {
+        return this;
+    }
+
     public StringBuilder toString(final StringBuilder b) {
         // don't print "incomplete" string
         return b.append("void");

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/BigEndianMemoryImpl.java
@@ -25,6 +25,10 @@ final class BigEndianMemoryImpl extends MemoryImpl {
         super(original);
     }
 
+    BigEndianMemoryImpl(final BigEndianMemoryImpl original, int newSize) {
+        super(original, newSize);
+    }
+
     @Override
     public int load16(long index, ReadAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
@@ -384,9 +388,7 @@ final class BigEndianMemoryImpl extends MemoryImpl {
         if (newSize == 0) {
             return EMPTY;
         }
-        BigEndianMemoryImpl newMemory = new BigEndianMemoryImpl(Math.toIntExact(newSize));
-        newMemory.storeMemory(0, this, 0, Math.min(data.length, newMemory.data.length));
-        return newMemory;
+        return new BigEndianMemoryImpl(this, Math.toIntExact(newSize));
     }
 
     public MemoryImpl clone() {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -140,6 +140,7 @@ import org.qbicc.graph.literal.StringLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.graph.literal.UndefinedLiteral;
 import org.qbicc.graph.literal.ZeroInitializerLiteral;
+import org.qbicc.interpreter.InvalidMemoryAccessException;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.Thrown;
 import org.qbicc.interpreter.Vm;

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -2138,7 +2138,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
             if (source == null) {
                 throw new Thrown(thread.vm.nullPointerException.newInstance("Invalid memory access"));
             }
-            memory.storeMemory(offset, source, 0, ct.getSize());
+            source.typedCopyTo(0, memory, 0, ct);
         } else {
             throw unsupportedType();
         }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/LittleEndianMemoryImpl.java
@@ -25,6 +25,10 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
         super(original);
     }
 
+    LittleEndianMemoryImpl(final LittleEndianMemoryImpl original, final int newSize) {
+        super(original, newSize);
+    }
+
     @Override
     public int load16(long index, ReadAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
@@ -384,9 +388,7 @@ final class LittleEndianMemoryImpl extends MemoryImpl {
         if (newSize == 0) {
             return EMPTY;
         }
-        LittleEndianMemoryImpl newMemory = new LittleEndianMemoryImpl(Math.toIntExact(newSize));
-        newMemory.storeMemory(0, this, 0, Math.min(data.length, newMemory.data.length));
-        return newMemory;
+        return new LittleEndianMemoryImpl(this, Math.toIntExact(newSize));
     }
 
     public MemoryImpl clone() {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
@@ -402,26 +402,6 @@ abstract class MemoryImpl implements Memory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        if (size > 0) {
-            MemoryImpl srcImpl = (MemoryImpl) src;
-            System.arraycopy(srcImpl.data, Math.toIntExact(srcIndex), data, Math.toIntExact(destIndex), Math.toIntExact(size));
-            // misaligned copies of things will get weird results
-            System.arraycopy(srcImpl.things, Math.toIntExact((srcIndex + 1) >> 1), things, Math.toIntExact((destIndex + 1) >> 1), Math.toIntExact((size + 1) >> 1));
-        }
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        if (size > 0) {
-            // just data
-            System.arraycopy(src, srcIndex, data, Math.toIntExact(destIndex), size);
-            // clear corresponding things
-            Arrays.fill(things, Math.toIntExact(destIndex >> 1), Math.toIntExact((destIndex + size + 1) >> 1), null);
-        }
-    }
-
-    @Override
     public abstract MemoryImpl copy(long newSize);
 
     byte[] getArray() {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/MemoryImpl.java
@@ -41,6 +41,13 @@ abstract class MemoryImpl implements Memory {
         things = original.things.clone();
     }
 
+    MemoryImpl(MemoryImpl original, int newSize) {
+        int thingSize = (newSize + 1) >> 1;
+        newSize = thingSize << 1;
+        data = Arrays.copyOf(original.data, newSize);
+        things = Arrays.copyOf(original.things, thingSize);
+    }
+
     static void checkAlign(long offs, int align) {
         int mask = align - 1;
         if ((offs & mask) != 0) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -57,7 +57,6 @@ import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.pointer.MemoryPointer;
-import org.qbicc.pointer.Pointer;
 import org.qbicc.pointer.StaticFieldPointer;
 import org.qbicc.type.ClassObjectType;
 import org.qbicc.type.CompoundType;
@@ -1227,18 +1226,11 @@ public final class VmImpl implements Vm {
     }
 
     @Override
-    public MemoryImpl allocate(int size) {
-        return emptyMemory.copy(size);
-    }
-
-    @Override
     public Memory allocate(ValueType type, long count) {
-        // todo: typed memory
         if (count == 0) {
             return MemoryFactory.getEmpty();
         } else if (count == 1) {
-            // todo: typed memory
-            return allocate(Math.toIntExact(type.getSize()));
+            return MemoryFactory.allocate(ctxt, type, count);
         } else {
             return MemoryFactory.replicate(allocate(type, 1), Math.toIntExact(count));
         }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -1230,7 +1230,8 @@ public final class VmImpl implements Vm {
         if (count == 0) {
             return MemoryFactory.getEmpty();
         } else if (count == 1) {
-            return MemoryFactory.allocate(ctxt, type, count);
+            // todo: select upgradeLongs based on a class attribute
+            return MemoryFactory.allocate(ctxt, type, count, true);
         } else {
             return MemoryFactory.replicate(allocate(type, 1), Math.toIntExact(count));
         }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
@@ -25,7 +25,8 @@ import org.qbicc.interpreter.Thrown;
 import org.qbicc.interpreter.VmInvokable;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmThread;
-import org.qbicc.type.ValueType;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.TypeSystem;
 import org.qbicc.type.definition.MethodBody;
 import org.qbicc.type.definition.element.ExecutableElement;
 import org.qbicc.type.definition.element.InitializerElement;
@@ -40,69 +41,64 @@ final class VmInvokableImpl implements VmInvokable {
 
     private final ExecutableElement element;
     private final Map<BasicBlock, List<Node>> scheduled;
+    private final CompoundType frameMemoryType;
     private final Schedule schedule;
-    private final int memorySize;
+    @SuppressWarnings("unused") // VarHandle
     private volatile long count;
 
     VmInvokableImpl(ExecutableElement element) {
         this.element = element;
-        int[] sizeHolder = new int[1];
-        scheduled = buildScheduled(element, sizeHolder);
+        TypeSystem ts = element.getEnclosingType().getContext().getTypeSystem();
+        final CompoundType.Builder builder = CompoundType.builder(ts);
+        scheduled = buildScheduled(element, builder);
+        frameMemoryType = builder.build();
         schedule = element.getMethodBody().getSchedule();
-        memorySize = sizeHolder[0];
     }
 
-    private static Map<BasicBlock, List<Node>> buildScheduled(final ExecutableElement element, final int[] sizeHolder) {
+    private static Map<BasicBlock, List<Node>> buildScheduled(final ExecutableElement element, CompoundType.Builder localVarLocations) {
         if (! element.tryCreateMethodBody()) {
             throw new IllegalStateException("No method body for " + element);
         }
+        TypeSystem ts = element.getEnclosingType().getContext().getTypeSystem();
         MethodBody body = element.getMethodBody();
         Map<BasicBlock, List<Node>> scheduled = new HashMap<>();
-        buildScheduled(body, new HashSet<>(), scheduled, body.getEntryBlock().getTerminator(), sizeHolder);
+        buildScheduled(body, new HashSet<>(), scheduled, body.getEntryBlock().getTerminator(), ts, localVarLocations);
         return scheduled;
     }
 
-    private static void buildScheduled(final MethodBody body, final Set<Node> visited, final Map<BasicBlock, List<Node>> scheduled, Node node, int[] sizeHolder) {
+    private static void buildScheduled(final MethodBody body, final Set<Node> visited, final Map<BasicBlock, List<Node>> scheduled, Node node, TypeSystem ts, CompoundType.Builder builder) {
         if (! visited.add(node)) {
             // already scheduled
             return;
         }
         if (node.hasValueHandleDependency()) {
-            buildScheduled(body, visited, scheduled, node.getValueHandle(), sizeHolder);
+            buildScheduled(body, visited, scheduled, node.getValueHandle(), ts, builder);
         }
         if (node instanceof OrderedNode) {
-            buildScheduled(body, visited, scheduled, ((OrderedNode) node).getDependency(), sizeHolder);
+            buildScheduled(body, visited, scheduled, ((OrderedNode) node).getDependency(), ts, builder);
         }
         int cnt = node.getValueDependencyCount();
         for (int i = 0; i < cnt; i ++) {
-            buildScheduled(body, visited, scheduled, node.getValueDependency(i), sizeHolder);
+            buildScheduled(body, visited, scheduled, node.getValueDependency(i), ts, builder);
         }
-        if (node instanceof Terminator) {
+        if (node instanceof Terminator terminator) {
             // add outbound values
-            Terminator terminator = (Terminator) node;
             Map<PhiValue, Value> outboundValues = terminator.getOutboundValues();
             for (PhiValue phiValue : outboundValues.keySet()) {
-                buildScheduled(body, visited, scheduled, terminator.getOutboundValue(phiValue), sizeHolder);
+                buildScheduled(body, visited, scheduled, terminator.getOutboundValue(phiValue), ts, builder);
             }
             // recurse to successors
             int sc = terminator.getSuccessorCount();
             for (int i = 0; i < sc; i ++) {
                 BasicBlock successor = terminator.getSuccessor(i);
-                buildScheduled(body, visited, scheduled, successor.getTerminator(), sizeHolder);
+                buildScheduled(body, visited, scheduled, successor.getTerminator(), ts, builder);
             }
         }
-        if (node instanceof LocalVariable) {
+        if (node instanceof LocalVariable lvn) {
             // reserve memory space
-            LocalVariableElement varElem = ((LocalVariable) node).getVariableElement();
-            ValueType varType = varElem.getType();
-            int size = (int) varType.getSize();
-            int align = varType.getAlign();
-            if (align > 1) {
-                int mask = align - 1;
-                sizeHolder[0] = (sizeHolder[0] + mask) & ~mask;
-            }
-            varElem.setOffset(sizeHolder[0]);
-            sizeHolder[0] += size;
+            LocalVariableElement varElem = lvn.getVariableElement();
+            builder.addNextMember(varElem.getName(), varElem.getType());
+            varElem.setOffset(builder.getLastAddedMember().getOffset());
         }
         if (! (node instanceof Terminator || node instanceof Unschedulable)) {
             // no need to explicitly add terminator since they're trivially findable and always last
@@ -138,7 +134,7 @@ final class VmInvokableImpl implements VmInvokable {
             ((VmClassImpl)element.getEnclosingType().load().getVmClass()).initialize(thread);
         }
         Frame caller = thread.currentFrame;
-        Memory memory = thread.getVM().allocate(memorySize);
+        Memory memory = thread.getVM().allocate(frameMemoryType, 1);
         Frame frame = new Frame(caller, element, memory);
         thread.currentFrame = frame;
         // bind inputs

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
@@ -84,7 +84,7 @@ class VmObjectImpl implements VmObject, Referenceable {
      */
     VmObjectImpl(VmImpl vm, @SuppressWarnings("unused") Class<?> unused, LayoutInfo instanceLayoutInfo) {
         this.clazz = (VmClassImpl) this;
-        memory = vm.allocate((int) instanceLayoutInfo.getCompoundType().getSize());
+        memory = vm.allocate(instanceLayoutInfo.getCompoundType(), 1);
     }
 
     /**

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/AbstractMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/AbstractMemory.java
@@ -1,0 +1,114 @@
+package org.qbicc.interpreter.memory;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ *
+ */
+public abstract class AbstractMemory implements Memory {
+    // load
+
+    public int load8(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public int load16(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public int load32(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public long load64(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    // store
+
+    public void store8(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public void store16(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public void store32(long index, int value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public void store64(long index, long value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    // atomic CAS
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public abstract Memory clone();
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/AbstractMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/AbstractMemory.java
@@ -111,4 +111,12 @@ public abstract class AbstractMemory implements Memory {
 
     @Override
     public abstract Memory clone();
+
+    protected AbstractMemory doClone() {
+        try {
+            return (AbstractMemory) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/AbstractMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/AbstractMemory.java
@@ -4,7 +4,7 @@ import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
+import org.qbicc.interpreter.InvalidMemoryAccessException;
 import org.qbicc.pointer.Pointer;
 import org.qbicc.type.ValueType;
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/BooleanArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/BooleanArrayMemory.java
@@ -57,16 +57,6 @@ public final class BooleanArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             boolean val = (load8(index, readMode) & 1) != 0;

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/BooleanArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/BooleanArrayMemory.java
@@ -13,15 +13,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by a {@code boolean} array which can be directly accessed.
  */
-public final class BooleanArrayMemory implements Memory {
+public final class BooleanArrayMemory extends AbstractMemory {
     private static final VarHandle h8 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, boolean[].class);
 
     private final boolean[] array;
@@ -48,36 +44,6 @@ public final class BooleanArrayMemory implements Memory {
     }
 
     @Override
-    public int load16(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load32(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long load64(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store8(long index, int value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[(int) index] = (value & 1) != 0;
@@ -88,36 +54,6 @@ public final class BooleanArrayMemory implements Memory {
         } else {
             h8.setVolatile(array, Math.toIntExact(index), (value & 1) != 0);
         }
-    }
-
-    @Override
-    public void store16(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store32(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store64(long index, long value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -145,36 +81,6 @@ public final class BooleanArrayMemory implements Memory {
         } else {
             return ((boolean) h8.compareAndExchange(array, Math.toIntExact(index), (expect & 1) != 0, (update & 1) != 0)) ? 1 : 0;
         }
-    }
-
-    @Override
-    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ByteArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ByteArrayMemory.java
@@ -11,15 +11,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by a {@code byte} array which can be directly accessed.
  */
-public abstract class ByteArrayMemory implements Memory {
+public abstract class ByteArrayMemory extends AbstractMemory {
     private static final VarHandle h8 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, byte[].class);
 
     final byte[] array;
@@ -89,21 +85,6 @@ public abstract class ByteArrayMemory implements Memory {
     }
 
     @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store8(long index, int value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[(int) index] = (byte) value;
@@ -153,21 +134,6 @@ public abstract class ByteArrayMemory implements Memory {
         } else {
             h64().setVolatile(array, Math.toIntExact(index), value);
         }
-    }
-
-    @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -246,21 +212,6 @@ public abstract class ByteArrayMemory implements Memory {
         } else {
             return (long) h64().compareAndExchange(array, Math.toIntExact(index), expect, update);
         }
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ByteArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ByteArrayMemory.java
@@ -137,16 +137,6 @@ public abstract class ByteArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = load8(index, readMode) & 0xff;

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/CharArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/CharArrayMemory.java
@@ -13,15 +13,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by a {@code char} array which can be directly accessed.
  */
-public final class CharArrayMemory implements Memory {
+public final class CharArrayMemory extends AbstractMemory {
     private static final VarHandle h16 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, char[].class);
 
     private final char[] array;
@@ -32,11 +28,6 @@ public final class CharArrayMemory implements Memory {
 
     public char[] getArray() {
         return array;
-    }
-
-    @Override
-    public int load8(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -53,36 +44,6 @@ public final class CharArrayMemory implements Memory {
     }
 
     @Override
-    public int load32(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long load64(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store8(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store16(long index, int value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[Math.toIntExact(index >>> 1)] = (char) value;
@@ -96,31 +57,6 @@ public final class CharArrayMemory implements Memory {
     }
 
     @Override
-    public void store32(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store64(long index, long value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
@@ -128,11 +64,6 @@ public final class CharArrayMemory implements Memory {
     @Override
     public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -150,31 +81,6 @@ public final class CharArrayMemory implements Memory {
         } else {
             return (int) h16.compareAndExchange(array, Math.toIntExact(index >>> 1), (char) expect, (char) update) & 0xffff;
         }
-    }
-
-    @Override
-    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/CharArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/CharArrayMemory.java
@@ -57,16 +57,6 @@ public final class CharArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = array[Math.toIntExact(index >>> 1)] & 0xffff;

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/CompositeMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/CompositeMemory.java
@@ -134,13 +134,7 @@ public final class CompositeMemory extends AbstractMemory {
         memories[which].storePointer(index - offsets[which], value, mode);
     }
 
-    @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
+    private void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/CompositeMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/CompositeMemory.java
@@ -12,7 +12,7 @@ import org.qbicc.type.ValueType;
 /**
  * A memory that is backed by multiple other concatenated memories of possibly varying sizes.
  */
-public final class CompositeMemory implements Memory {
+public final class CompositeMemory extends AbstractMemory {
     private final Memory[] memories;
     private final long[] offsets;
     private final long size;

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/DoubleArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/DoubleArrayMemory.java
@@ -13,15 +13,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by a {@code double} array which can be directly accessed.
  */
-public final class DoubleArrayMemory implements Memory {
+public final class DoubleArrayMemory extends AbstractMemory {
     private static final VarHandle h64 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, double[].class);
 
     private final double[] array;
@@ -32,21 +28,6 @@ public final class DoubleArrayMemory implements Memory {
 
     public double[] getArray() {
         return array;
-    }
-
-    @Override
-    public int load8(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load16(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load32(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -63,36 +44,6 @@ public final class DoubleArrayMemory implements Memory {
     }
 
     @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store8(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store16(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store32(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store64(long index, long value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[Math.toIntExact(index >>> 3)] = Double.longBitsToDouble(value);
@@ -106,21 +57,6 @@ public final class DoubleArrayMemory implements Memory {
     }
 
     @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
@@ -128,21 +64,6 @@ public final class DoubleArrayMemory implements Memory {
     @Override
     public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -160,21 +81,6 @@ public final class DoubleArrayMemory implements Memory {
         } else {
             return Double.doubleToRawLongBits((double) h64.compareAndExchange(array, Math.toIntExact(index >>> 3), Double.longBitsToDouble(expect), Double.longBitsToDouble(update)));
         }
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/DoubleArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/DoubleArrayMemory.java
@@ -57,16 +57,6 @@ public final class DoubleArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             double val = array[Math.toIntExact(index >>> 3)];

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/FloatArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/FloatArrayMemory.java
@@ -13,15 +13,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by an {@code float} array which can be directly accessed.
  */
-public final class FloatArrayMemory implements Memory {
+public final class FloatArrayMemory extends AbstractMemory {
     private static final VarHandle h32 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, float[].class);
 
     private final float[] array;
@@ -32,16 +28,6 @@ public final class FloatArrayMemory implements Memory {
 
     public float[] getArray() {
         return array;
-    }
-
-    @Override
-    public int load8(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load16(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -58,36 +44,6 @@ public final class FloatArrayMemory implements Memory {
     }
 
     @Override
-    public long load64(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store8(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store16(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store32(long index, int value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[Math.toIntExact(index >>> 2)] = Float.intBitsToFloat(value);
@@ -101,26 +57,6 @@ public final class FloatArrayMemory implements Memory {
     }
 
     @Override
-    public void store64(long index, long value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
@@ -128,16 +64,6 @@ public final class FloatArrayMemory implements Memory {
     @Override
     public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -155,26 +81,6 @@ public final class FloatArrayMemory implements Memory {
         } else {
             return Float.floatToRawIntBits((float) h32.compareAndExchange(array, Math.toIntExact(index >>> 2), Float.intBitsToFloat(expect), Float.intBitsToFloat(update)));
         }
-    }
-
-    @Override
-    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/FloatArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/FloatArrayMemory.java
@@ -57,16 +57,6 @@ public final class FloatArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             float val = array[Math.toIntExact(index >>> 2)];

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/IntArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/IntArrayMemory.java
@@ -57,16 +57,6 @@ public final class IntArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = array[Math.toIntExact(index >>> 2)];

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/IntArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/IntArrayMemory.java
@@ -13,15 +13,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by an {@code int} array which can be directly accessed.
  */
-public final class IntArrayMemory implements Memory {
+public final class IntArrayMemory extends AbstractMemory {
     private static final VarHandle h32 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, int[].class);
 
     private final int[] array;
@@ -32,16 +28,6 @@ public final class IntArrayMemory implements Memory {
 
     public int[] getArray() {
         return array;
-    }
-
-    @Override
-    public int load8(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load16(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -58,36 +44,6 @@ public final class IntArrayMemory implements Memory {
     }
 
     @Override
-    public long load64(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store8(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store16(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store32(long index, int value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[Math.toIntExact(index >>> 2)] = value;
@@ -101,26 +57,6 @@ public final class IntArrayMemory implements Memory {
     }
 
     @Override
-    public void store64(long index, long value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
@@ -128,16 +64,6 @@ public final class IntArrayMemory implements Memory {
     @Override
     public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -155,26 +81,6 @@ public final class IntArrayMemory implements Memory {
         } else {
             return (int) h32.compareAndExchange(array, Math.toIntExact(index >>> 2), expect, update);
         }
-    }
-
-    @Override
-    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/LongArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/LongArrayMemory.java
@@ -13,15 +13,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by a {@code long} array which can be directly accessed.
  */
-public final class LongArrayMemory implements Memory {
+public final class LongArrayMemory extends AbstractMemory {
     private static final VarHandle h64 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, long[].class);
 
     private final long[] array;
@@ -32,21 +28,6 @@ public final class LongArrayMemory implements Memory {
 
     public long[] getArray() {
         return array;
-    }
-
-    @Override
-    public int load8(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load16(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load32(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -63,36 +44,6 @@ public final class LongArrayMemory implements Memory {
     }
 
     @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store8(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store16(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store32(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store64(long index, long value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[Math.toIntExact(index >>> 3)] = value;
@@ -106,21 +57,6 @@ public final class LongArrayMemory implements Memory {
     }
 
     @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
@@ -128,21 +64,6 @@ public final class LongArrayMemory implements Memory {
     @Override
     public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -160,21 +81,6 @@ public final class LongArrayMemory implements Memory {
         } else {
             return (long) h64.compareAndExchange(array, Math.toIntExact(index >>> 3), expect, update);
         }
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/LongArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/LongArrayMemory.java
@@ -57,16 +57,6 @@ public final class LongArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             long val = array[Math.toIntExact(index >>> 3)];

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
@@ -1,17 +1,51 @@
 package org.qbicc.interpreter.memory;
 
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
-import java.util.List;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
+import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ConstantDynamic;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmObject;
+import org.qbicc.pointer.Pointer;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.IntegerType;
+import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
+import org.qbicc.type.TypeType;
+import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.VoidType;
 
@@ -19,6 +53,7 @@ import org.qbicc.type.VoidType;
  * Factory methods for producing memory instances.
  */
 public final class MemoryFactory {
+
     private MemoryFactory() {}
 
     private static final Memory EMPTY = new ByteArrayMemory.LE(new byte[0]);
@@ -142,14 +177,398 @@ public final class MemoryFactory {
         return new ReferenceArrayMemory(array, refType);
     }
 
+    static final class GenMemoryInfo {
+        final String clazzName;
+        final String clazzDesc;
+        final Supplier<Memory> supplier;
+
+        GenMemoryInfo(String clazzName, Supplier<Memory> supplier) {
+            this.clazzName = clazzName;
+            clazzDesc = "L" + clazzName + ";";
+            this.supplier = supplier;
+        }
+    }
+
+    private static final String CLASS_DESC_STR = Class.class.descriptorString();
+    private static final String OBJECT_DESC_STR = Object.class.descriptorString();
+    private static final String STRING_DESC_STR = String.class.descriptorString();
+    private static final String LOOKUP_DESC_STR = MethodHandles.Lookup.class.descriptorString();
+    private static final String GET_STATIC_FINAL_DESC_STR = "(" + LOOKUP_DESC_STR + STRING_DESC_STR + CLASS_DESC_STR + CLASS_DESC_STR + ")" + OBJECT_DESC_STR;
+
+    private static final AttachmentKey<Map<CompoundType, GenMemoryInfo>> MF_CACHE_KEY = new AttachmentKey<>();
+    private static final String[] MEM_INTERFACES = { "org/qbicc/interpreter/Memory", "java/lang/Cloneable" };
+
+    private static final AtomicLong seq = new AtomicLong();
+
+    public static Supplier<Memory> getMemoryFactory(CompilationContext ctxt, CompoundType ct) {
+        Map<CompoundType, GenMemoryInfo> map = ctxt.computeAttachmentIfAbsent(MF_CACHE_KEY, ConcurrentHashMap::new);
+        // avoid constructing the lambda instance if possible
+        GenMemoryInfo genMemoryInfo = map.get(ct);
+        if (genMemoryInfo != null) {
+            return genMemoryInfo.supplier;
+        }
+        return map.computeIfAbsent(ct, ct1 -> makeFactory(ctxt, ct1)).supplier;
+    }
+
+    private static final Supplier<?>[] NO_SUPPLIERS = new Supplier<?>[0];
+
+    private static GenMemoryInfo makeFactory(CompilationContext ctxt, final CompoundType ct) {
+        // produce class per compound type
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+
+        String simpleName = "GenMemory" + seq.getAndIncrement();
+        String clazzName = "org/qbicc/interpreter/memory/" + simpleName;
+        String clazzDesc = "L" + clazzName + ";";
+
+        cw.visit(Opcodes.V17, Opcodes.ACC_SUPER, clazzName, null, "org/qbicc/interpreter/memory/VarHandleMemory", MEM_INTERFACES);
+
+        // emit size method
+        MethodVisitor smv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getSize", "()J", null, null);
+        smv.visitCode();
+        smv.visitLdcInsn(Long.valueOf(ct.getSize()));
+        smv.visitInsn(Opcodes.LRETURN);
+        smv.visitMaxs(0, 0);
+        smv.visitEnd();
+
+        // mapping of offset to condy for each simple field; the condy creates the VarHandle on demand
+
+        MutableIntObjectMap<ConstantDynamic> handle8 = null;
+        MutableIntObjectMap<ConstantDynamic> handle16 = null;
+        MutableIntObjectMap<ConstantDynamic> handle32 = null;
+        MutableIntObjectMap<ConstantDynamic> handle64 = null;
+        MutableIntObjectMap<ConstantDynamic> handleType = null;
+        MutableIntObjectMap<ConstantDynamic> handleRef = null;
+        MutableIntObjectMap<ConstantDynamic> handlePtr = null;
+
+        // primitive type class condys
+        ConstantDynamic booleanClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Boolean.class));
+        ConstantDynamic byteClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Byte.class));
+        ConstantDynamic shortClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Short.class));
+        ConstantDynamic intClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Integer.class));
+        ConstantDynamic longClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Long.class));
+        ConstantDynamic charClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Character.class));
+        ConstantDynamic floatClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Float.class));
+        ConstantDynamic doubleClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Double.class));
+
+        // mapping of member to delegate Memory instance for each complex field
+
+        Map<CompoundType.Member, String> delegate = null;
+
+        Map<String, String> simpleFields = null;
+
+        for (CompoundType.Member member : ct.getMembers()) {
+            int offset = member.getOffset();
+            String name = member.getName();
+            String fieldName = name + '@' + offset;
+            Class<?> fieldClazz;
+            int fieldAccess;
+            ValueType memberType = member.getType();
+            if (memberType.getSize() == 0) {
+                continue;
+            }
+            // complex fields
+            if (memberType instanceof ArrayType || memberType instanceof CompoundType) {
+                fieldAccess = Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL;
+                if (delegate == null) {
+                    delegate = new HashMap<>();
+                }
+                fieldClazz = Memory.class;
+                delegate.put(member, fieldName);
+            } else {
+                // simple fields
+                if (simpleFields == null) simpleFields = new LinkedHashMap<>();
+                Object fieldTypeArg;
+                MutableIntObjectMap<ConstantDynamic> handleMap;
+                fieldAccess = Opcodes.ACC_PRIVATE;
+                if (memberType instanceof IntegerType it) {
+                    handleMap = switch (it.getMinBits()) {
+                        case 8 -> handle8 == null ? handle8 = IntObjectMaps.mutable.empty() : handle8;
+                        case 16 -> handle16 == null ? handle16 = IntObjectMaps.mutable.empty() : handle16;
+                        case 32 -> handle32 == null ? handle32 = IntObjectMaps.mutable.empty() : handle32;
+                        case 64 -> handle64 == null ? handle64 = IntObjectMaps.mutable.empty() : handle64;
+                        default -> throw new IllegalStateException();
+                    };
+                    fieldClazz = switch (it.getMinBits()) {
+                        case 8 -> byte.class;
+                        case 16 -> it instanceof UnsignedIntegerType ? char.class : short.class;
+                        case 32 -> int.class;
+                        case 64 -> long.class;
+                        default -> throw new IllegalStateException();
+                    };
+                    fieldTypeArg = switch (it.getMinBits()) {
+                        case 8 -> byteClassConstant;
+                        case 16 -> it instanceof UnsignedIntegerType ? charClassConstant : shortClassConstant;
+                        case 32 -> intClassConstant;
+                        case 64 -> longClassConstant;
+                        default -> throw new IllegalStateException();
+                    };
+                } else if (memberType instanceof FloatType ft) {
+                    handleMap = switch (ft.getMinBits()) {
+                        case 32 -> handle32 == null ? handle32 = IntObjectMaps.mutable.empty() : handle32;
+                        case 64 -> handle64 == null ? handle64 = IntObjectMaps.mutable.empty() : handle64;
+                        default -> throw new IllegalStateException();
+                    };
+                    fieldClazz = switch (ft.getMinBits()) {
+                        case 32 -> float.class;
+                        case 64 -> double.class;
+                        default -> throw new IllegalStateException();
+                    };
+                    fieldTypeArg = switch (ft.getMinBits()) {
+                        case 32 -> floatClassConstant;
+                        case 64 -> doubleClassConstant;
+                        default -> throw new IllegalStateException();
+                    };
+                } else if (memberType instanceof BooleanType) {
+                    handleMap = handle8 == null ? handle8 = IntObjectMaps.mutable.empty() : handle8;
+                    fieldClazz = boolean.class;
+                    fieldTypeArg = booleanClassConstant;
+                } else if (memberType instanceof TypeType) {
+                    handleMap = handleType == null ? handleType = IntObjectMaps.mutable.empty() : handleType;
+                    fieldClazz = ValueType.class;
+                    fieldTypeArg = Type.getType(fieldClazz);
+                } else if (memberType instanceof PointerType) {
+                    handleMap = handlePtr == null ? handlePtr = IntObjectMaps.mutable.empty() : handlePtr;
+                    fieldClazz = Pointer.class;
+                    fieldTypeArg = Type.getType(fieldClazz);
+                } else if (memberType instanceof ReferenceType) {
+                    handleMap = handleRef == null ? handleRef = IntObjectMaps.mutable.empty() : handleRef;
+                    fieldClazz = VmObject.class;
+                    fieldTypeArg = Type.getType(fieldClazz);
+                } else {
+                    throw new IllegalStateException("Unknown type");
+                }
+                Handle bmh = new Handle(
+                    Opcodes.H_INVOKESTATIC,
+                    "java/lang/invoke/ConstantBootstraps",
+                    "fieldVarHandle",
+                    "("
+                        + LOOKUP_DESC_STR
+                        + STRING_DESC_STR
+                        + CLASS_DESC_STR
+                        + CLASS_DESC_STR
+                        + CLASS_DESC_STR
+                    + ")" + VarHandle.class.descriptorString(),
+                    false
+                );
+                ConstantDynamic constant = new ConstantDynamic(fieldName, VarHandle.class.descriptorString(), bmh,
+                    Type.getObjectType(clazzName),
+                    fieldTypeArg
+                );
+                handleMap.put(offset, constant);
+                simpleFields.put(fieldName, fieldClazz.descriptorString());
+            }
+
+            // instance field
+            FieldVisitor fieldVisitor = cw.visitField(fieldAccess, fieldName, fieldClazz.descriptorString(), null, null);
+            fieldVisitor.visitEnd();
+        }
+        // emit all "handle" methods
+        emitHandleMethod(cw, "getHandle8", handle8);
+        emitHandleMethod(cw, "getHandle16", handle16);
+        emitHandleMethod(cw, "getHandle32", handle32);
+        emitHandleMethod(cw, "getHandle64", handle64);
+        emitHandleMethod(cw, "getHandleType", handleType);
+        emitHandleMethod(cw, "getHandleRef", handleRef);
+        emitHandleMethod(cw, "getHandlePointer", handlePtr);
+        // emit ctor
+        MethodVisitor ctor = cw.visitMethod(0, "<init>", "()V", null, null);
+        ctor.visitCode();
+        ctor.visitVarInsn(Opcodes.ALOAD, 0);
+        ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "org/qbicc/interpreter/memory/VarHandleMemory", "<init>", "()V", false);
+
+        // emit "clone" method
+        MethodVisitor cmv = cw.visitMethod(Opcodes.ACC_PUBLIC, "clone", "()" + Memory.class.descriptorString(), null, null);
+        cmv.visitCode();
+        if (delegate == null) {
+            // shallow clone, cool!
+            cmv.visitVarInsn(Opcodes.ALOAD, 0);
+            cmv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "clone", "()" + Object.class.descriptorString(), false);
+            cmv.visitTypeInsn(Opcodes.CHECKCAST, "org/qbicc/interpreter/Memory");
+            cmv.visitInsn(Opcodes.ARETURN);
+        } else {
+            // deep clone :( emit a copy constructor and call it
+            MethodVisitor ccmv = cw.visitMethod(Opcodes.ACC_PRIVATE, "<init>", "(" + Memory.class.descriptorString() + ")V", null, null);
+            ccmv.visitParameter("orig", 0);
+            ccmv.visitCode();
+            // call super
+            ccmv.visitVarInsn(Opcodes.ALOAD, 0);
+            ccmv.visitMethodInsn(Opcodes.INVOKESPECIAL, "org/qbicc/interpreter/memory/VarHandleMemory", "<init>", "()V", false);
+            // cast the plain memory object
+            ccmv.visitVarInsn(Opcodes.ALOAD, 1);
+            ccmv.visitTypeInsn(Opcodes.CHECKCAST, clazzName);
+            ccmv.visitVarInsn(Opcodes.ASTORE, 1);
+            // shallow-copy all of the little fields
+            if (simpleFields != null) for (Map.Entry<String, String> entry : simpleFields.entrySet()) {
+                String fieldName = entry.getKey();
+                String fieldDesc = entry.getValue();
+                ccmv.visitVarInsn(Opcodes.ALOAD, 0);
+                ccmv.visitVarInsn(Opcodes.ALOAD, 1);
+                ccmv.visitFieldInsn(Opcodes.GETFIELD, clazzName, fieldName, fieldDesc);
+                ccmv.visitFieldInsn(Opcodes.PUTFIELD, clazzName, fieldName, fieldDesc);
+            }
+            // deep-copy all of the sub-memories
+            for (String fieldName : delegate.values()) {
+                ccmv.visitVarInsn(Opcodes.ALOAD, 0);
+                ccmv.visitVarInsn(Opcodes.ALOAD, 1);
+                ccmv.visitFieldInsn(Opcodes.GETFIELD, clazzName, fieldName, Memory.class.descriptorString());
+                ccmv.visitMethodInsn(Opcodes.INVOKEINTERFACE, "org/qbicc/interpreter/Memory", "clone", "()" + Memory.class.descriptorString(), true);
+                ccmv.visitFieldInsn(Opcodes.PUTFIELD, clazzName, fieldName, Memory.class.descriptorString());
+            }
+
+            ccmv.visitInsn(Opcodes.RETURN);
+            ccmv.visitMaxs(0, 0);
+            ccmv.visitEnd();
+
+            cmv.visitTypeInsn(Opcodes.NEW, clazzName);
+            cmv.visitInsn(Opcodes.DUP);
+            cmv.visitVarInsn(Opcodes.ALOAD, 0);
+            cmv.visitMethodInsn(Opcodes.INVOKESPECIAL, clazzName, "<init>", "(" + Memory.class.descriptorString() + ")V", false);
+            cmv.visitInsn(Opcodes.ARETURN);
+        }
+        cmv.visitMaxs(0, 0);
+        cmv.visitEnd();
+
+        Supplier<?>[] factoryArray = NO_SUPPLIERS;
+        // emit "getDelegateMemory" if needed
+        if (delegate != null) {
+            //java.lang.invoke.MethodHandles.classData
+            factoryArray = new Supplier<?>[delegate.size()];
+            Handle classObjectBootstrap = new Handle(
+                Opcodes.H_INVOKESTATIC,
+                "java/lang/invoke/MethodHandles",
+                "classData",
+                "(" + LOOKUP_DESC_STR + STRING_DESC_STR + CLASS_DESC_STR + ")" + OBJECT_DESC_STR,
+                false
+            );
+            ConstantDynamic factoryArrayConstant = new ConstantDynamic("_", OBJECT_DESC_STR, classObjectBootstrap);
+
+            int fi = 0;
+            //    protected Memory getDelegateMemory(int offset) {
+            MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PROTECTED, "getDelegateMemory", "(I)" + Memory.class.descriptorString(), null, null);
+            mv.visitParameter("offset", 0);
+            mv.visitCode();
+            // now it's just there, on the stack
+
+            for (Map.Entry<CompoundType.Member, String> entry : delegate.entrySet()) {
+                CompoundType.Member member = entry.getKey();
+                String fieldName = entry.getValue();
+                Label outOfRange = new Label();
+                // index < min || (min + size) <= index
+                mv.visitVarInsn(Opcodes.ILOAD, 1);
+                mv.visitLdcInsn(Integer.valueOf(member.getOffset()));
+                mv.visitJumpInsn(Opcodes.IF_ICMPLT, outOfRange);
+                mv.visitLdcInsn(Integer.valueOf((int) (member.getOffset() + member.getType().getSize())));
+                mv.visitVarInsn(Opcodes.ILOAD, 1);
+                mv.visitJumpInsn(Opcodes.IF_ICMPLE, outOfRange);
+                mv.visitVarInsn(Opcodes.ALOAD, 0);
+                mv.visitFieldInsn(Opcodes.GETFIELD, clazzName, fieldName, Memory.class.descriptorString());
+                mv.visitInsn(Opcodes.ARETURN);
+                mv.visitLabel(outOfRange);
+
+                // also insert the init code for the field to the ctor
+                Supplier<Memory> factory = () -> MemoryFactory.allocate(ctxt, member.getType(), 1);
+                factoryArray[fi] = factory;
+                ctor.visitVarInsn(Opcodes.ALOAD, 0); // this
+                ctor.visitLdcInsn(factoryArrayConstant); // this factoryArray
+                ctor.visitTypeInsn(Opcodes.CHECKCAST, "[Ljava/util/function/Supplier;");
+                ctor.visitLdcInsn(Integer.valueOf(fi)); // this factoryArray index
+                ctor.visitInsn(Opcodes.AALOAD); // this factory
+                ctor.visitMethodInsn(Opcodes.INVOKEINTERFACE, "java/util/function/Supplier", "get", "()" + OBJECT_DESC_STR, true); // this memory
+                ctor.visitTypeInsn(Opcodes.CHECKCAST, "org/qbicc/interpreter/Memory");
+                ctor.visitFieldInsn(Opcodes.PUTFIELD, clazzName, fieldName, Memory.class.descriptorString());
+                fi ++;
+            }
+            // all out of range
+            mv.visitInsn(Opcodes.ACONST_NULL);
+            mv.visitInsn(Opcodes.ARETURN);
+            mv.visitMaxs(0, 0);
+            mv.visitEnd();
+        }
+
+        ctor.visitInsn(Opcodes.RETURN);
+        ctor.visitMaxs(0, 0);
+        ctor.visitEnd();
+        cw.visitEnd();
+
+        byte[] bytes = cw.toByteArray();
+        try {
+            Files.write(Paths.get("/tmp", simpleName + ".class"), bytes, StandardOpenOption.CREATE);
+        } catch (IOException ignored) {
+        }
+        Class<? extends Memory> clazz;
+        MethodHandles.Lookup hiddenClassLookup;
+        try {
+            hiddenClassLookup = lookup.defineHiddenClassWithClassData(bytes, factoryArray, false);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Unexpected illegal access", e);
+        }
+        clazz = hiddenClassLookup.lookupClass().asSubclass(Memory.class);
+        MethodHandle constructor;
+        try {
+            constructor = hiddenClassLookup.findConstructor(clazz, MethodType.methodType(void.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new IllegalStateException("Unexpected failure finding constructor", e);
+        }
+        return new GenMemoryInfo(clazzName, () -> {
+            try {
+                return (Memory) constructor.invoke();
+            } catch (Throwable e) {
+                throw new IllegalStateException("Unexpected construction failure", e);
+            }
+        });
+    }
+
+    private static void emitHandleMethod(ClassVisitor cv, String name, MutableIntObjectMap<ConstantDynamic> handleMap) {
+        if (handleMap == null) {
+            // nothing to do
+            return;
+        }
+        String descriptor = "(I)" + VarHandle.class.descriptorString();
+        MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PROTECTED, name, descriptor, null, null);
+        mv.visitParameter("offset", 0);
+        mv.visitCode();
+        // emit a switch statement to map offsets to condys
+        Label noMatch = new Label();
+        int cnt = handleMap.size();
+        int[] keys = new int[cnt];
+        Label[] labels = new Label[cnt];
+        ConstantDynamic[] constants = new ConstantDynamic[cnt];
+        int i = 0;
+        RichIterable<IntObjectPair<ConstantDynamic>> iter = handleMap.keyValuesView();
+        ArrayList<IntObjectPair<ConstantDynamic>> list = iter.into(new ArrayList<>());
+        list.sort(Comparator.comparingInt(IntObjectPair::getOne));
+        for (IntObjectPair<ConstantDynamic> pair : list) {
+            keys[i] = pair.getOne();
+            labels[i] = new Label();
+            constants[i] = pair.getTwo();
+            i ++;
+        }
+        mv.visitVarInsn(Opcodes.ILOAD, 1); // offset
+        mv.visitLookupSwitchInsn(noMatch, keys, labels);
+        for (i = 0; i < cnt; i ++) {
+            mv.visitLabel(labels[i]);
+            mv.visitLdcInsn(constants[i]);
+            mv.visitInsn(Opcodes.ARETURN);
+        }
+        mv.visitLabel(noMatch);
+        mv.visitVarInsn(Opcodes.ALOAD, 0); // this
+        mv.visitVarInsn(Opcodes.ILOAD, 1); // offset
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "org/qbicc/interpreter/memory/VarHandleMemory", name, descriptor, false);
+        mv.visitInsn(Opcodes.ARETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+    }
+
     /**
      * Allocate a strongly typed memory with the given type and count.
      *
+     * @param ctxt the compilation context (must not be {@code null})
      * @param type the type (must not be {@code null})
      * @param count the number of sequential elements to allocate
      * @return the memory
      */
-    public static Memory allocate(ValueType type, long count) {
+    public static Memory allocate(CompilationContext ctxt, ValueType type, long count) {
         ByteOrder byteOrder = type.getTypeSystem().getEndianness();
         if (type instanceof VoidType || count == 0) {
             return getEmpty();
@@ -162,31 +581,15 @@ public final class MemoryFactory {
             }
             ValueType et = at.getElementType();
             if (ec == 1) {
-                return allocate(et, 1);
+                return allocate(ctxt, et, 1);
             } else {
-                return allocate(et, ec);
+                return allocate(ctxt, et, ec);
             }
         }
         int intCount = Math.toIntExact(count);
         // vectored
         if (type instanceof CompoundType ct) {
-            // todo: dynamically produce more efficient memory impls
-            int cnt = ct.getMemberCount();
-            if (cnt == 1 && ct.getMember(0).getOffset() == 0) {
-                return allocate(ct.getMember(0).getType(), 1);
-            }
-            List<CompoundType.Member> padded = ct.getPaddedMembers();
-            int pc = padded.size();
-            Memory[] memories = new Memory[pc];
-            for (int i = 0; i < pc; i ++) {
-                memories[i] = allocate(padded.get(i).getType(), 1);
-            }
-            Memory result = compose(memories);
-            // create a vector of memories if there is more than one
-            if (count > 1) {
-                result = replicate(result, intCount);
-            }
-            return result;
+            return getMemoryFactory(ctxt, ct).get();
         } else if (type instanceof IntegerType it) {
             // todo: more compact impls
             return switch (it.getMinBits()) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
@@ -383,8 +383,7 @@ public final class MemoryFactory {
         if (delegate == null) {
             // shallow clone, cool!
             cmv.visitVarInsn(Opcodes.ALOAD, 0);
-            cmv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "clone", "()" + Object.class.descriptorString(), false);
-            cmv.visitTypeInsn(Opcodes.CHECKCAST, "org/qbicc/interpreter/Memory");
+            cmv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/qbicc/interpreter/memory/AbstractMemory", "doClone", "()" + AbstractMemory.class.descriptorString(), false);
             cmv.visitInsn(Opcodes.ARETURN);
         } else {
             // deep clone :( emit a copy constructor and call it

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
@@ -1,14 +1,10 @@
 package org.qbicc.interpreter.memory;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -193,7 +189,7 @@ public final class MemoryFactory {
     private static final String OBJECT_DESC_STR = Object.class.descriptorString();
     private static final String STRING_DESC_STR = String.class.descriptorString();
     private static final String LOOKUP_DESC_STR = MethodHandles.Lookup.class.descriptorString();
-    private static final String GET_STATIC_FINAL_DESC_STR = "(" + LOOKUP_DESC_STR + STRING_DESC_STR + CLASS_DESC_STR + CLASS_DESC_STR + ")" + OBJECT_DESC_STR;
+    private static final String PRIMITIVE_CLASS_DESC = "(" + LOOKUP_DESC_STR + STRING_DESC_STR + CLASS_DESC_STR + ")" + CLASS_DESC_STR;
 
     private static final AttachmentKey<Map<CompoundType, GenMemoryInfo>> MF_CACHE_KEY = new AttachmentKey<>();
     private static final String[] MEM_INTERFACES = { "org/qbicc/interpreter/Memory", "java/lang/Cloneable" };
@@ -235,14 +231,14 @@ public final class MemoryFactory {
         final MutableIntObjectMap<ConstantDynamic> handles = IntObjectMaps.mutable.empty();
 
         // primitive type class condys
-        ConstantDynamic booleanClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Boolean.class));
-        ConstantDynamic byteClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Byte.class));
-        ConstantDynamic shortClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Short.class));
-        ConstantDynamic intClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Integer.class));
-        ConstantDynamic longClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Long.class));
-        ConstantDynamic charClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Character.class));
-        ConstantDynamic floatClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Float.class));
-        ConstantDynamic doubleClassConstant = new ConstantDynamic("TYPE", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "getStaticFinal", GET_STATIC_FINAL_DESC_STR, false), Type.getType(Double.class));
+        ConstantDynamic booleanClassConstant = new ConstantDynamic("Z", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
+        ConstantDynamic byteClassConstant = new ConstantDynamic("B", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
+        ConstantDynamic shortClassConstant = new ConstantDynamic("S", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
+        ConstantDynamic intClassConstant = new ConstantDynamic("I", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
+        ConstantDynamic longClassConstant = new ConstantDynamic("J", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
+        ConstantDynamic charClassConstant = new ConstantDynamic("C", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
+        ConstantDynamic floatClassConstant = new ConstantDynamic("F", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
+        ConstantDynamic doubleClassConstant = new ConstantDynamic("D", CLASS_DESC_STR, new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/ConstantBootstraps", "primitiveClass", PRIMITIVE_CLASS_DESC, false));
 
         // mapping of member to delegate Memory instance for each complex field
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ReferenceArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ReferenceArrayMemory.java
@@ -65,16 +65,6 @@ public final class ReferenceArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             VmObject val = array[Math.toIntExact(index >>> shift)];

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ReferenceArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ReferenceArrayMemory.java
@@ -14,15 +14,12 @@ import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
 import org.qbicc.type.ReferenceType;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by a reference array which can be directly accessed.
  */
-public final class ReferenceArrayMemory implements Memory {
+public final class ReferenceArrayMemory extends AbstractMemory {
     private static final VarHandle hr = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, VmObject[].class);
 
     private final VmObject[] array;
@@ -42,26 +39,6 @@ public final class ReferenceArrayMemory implements Memory {
     }
 
     @Override
-    public int load8(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load16(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int load32(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long load64(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public VmObject loadRef(long index, ReadAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             return array[Math.toIntExact(index >>> shift)];
@@ -72,36 +49,6 @@ public final class ReferenceArrayMemory implements Memory {
         } else {
             return (VmObject) hr.getVolatile(array, Math.toIntExact(index >>> shift));
         }
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store8(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store16(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store32(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store64(long index, long value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -118,16 +65,6 @@ public final class ReferenceArrayMemory implements Memory {
     }
 
     @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
@@ -135,26 +72,6 @@ public final class ReferenceArrayMemory implements Memory {
     @Override
     public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -172,16 +89,6 @@ public final class ReferenceArrayMemory implements Memory {
         } else {
             return (VmObject) hr.compareAndExchange(array, Math.toIntExact(index >>> shift), expect, update);
         }
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ShortArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ShortArrayMemory.java
@@ -54,16 +54,6 @@ public final class ShortArrayMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
             int val = array[Math.toIntExact(index >>> 1)] & 0xffff;

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ShortArrayMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ShortArrayMemory.java
@@ -10,15 +10,11 @@ import java.util.Arrays;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.interpreter.Memory;
-import org.qbicc.interpreter.VmObject;
-import org.qbicc.interpreter.impl.InvalidMemoryAccessException;
-import org.qbicc.pointer.Pointer;
-import org.qbicc.type.ValueType;
 
 /**
  * A memory region which is backed by a {@code short} array which can be directly accessed.
  */
-public final class ShortArrayMemory implements Memory {
+public final class ShortArrayMemory extends AbstractMemory {
     private static final VarHandle h16 = ConstantBootstraps.arrayVarHandle(MethodHandles.lookup(), "ignored", VarHandle.class, short[].class);
 
     private final short[] array;
@@ -29,11 +25,6 @@ public final class ShortArrayMemory implements Memory {
 
     public short[] getArray() {
         return array;
-    }
-
-    @Override
-    public int load8(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -50,36 +41,6 @@ public final class ShortArrayMemory implements Memory {
     }
 
     @Override
-    public int load32(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long load64(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject loadRef(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType loadType(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer loadPointer(long index, ReadAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store8(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void store16(long index, int value, WriteAccessMode mode) {
         if (GlobalPlain.includes(mode)) {
             array[Math.toIntExact(index >>> 1)] = (short) value;
@@ -93,31 +54,6 @@ public final class ShortArrayMemory implements Memory {
     }
 
     @Override
-    public void store32(long index, int value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void store64(long index, long value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storeType(long index, ValueType value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
     public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
         throw new UnsupportedOperationException();
     }
@@ -125,11 +61,6 @@ public final class ShortArrayMemory implements Memory {
     @Override
     public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override
@@ -147,31 +78,6 @@ public final class ShortArrayMemory implements Memory {
         } else {
             return (int) h16.compareAndExchange(array, Math.toIntExact(index >>> 1), (short) expect, (short) update) & 0xffff;
         }
-    }
-
-    @Override
-    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
-    }
-
-    @Override
-    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
-        throw new InvalidMemoryAccessException();
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/VarHandleMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/VarHandleMemory.java
@@ -32,37 +32,37 @@ public abstract class VarHandleMemory extends AbstractMemory {
     }
 
     protected VarHandle getHandle8(int offset) {
-        throw new InvalidMemoryAccessException();
+        throw invalidMemoryAccess();
     }
 
     protected VarHandle getHandle16(int offset) {
-        throw new InvalidMemoryAccessException();
+        throw invalidMemoryAccess();
     }
 
     protected VarHandle getHandle32(int offset) {
-        throw new InvalidMemoryAccessException();
+        throw invalidMemoryAccess();
     }
 
     protected VarHandle getHandle64(int offset) {
-        throw new InvalidMemoryAccessException();
+        throw invalidMemoryAccess();
     }
 
     protected VarHandle getHandleType(int offset) {
-        throw new InvalidMemoryAccessException();
+        throw invalidMemoryAccess();
     }
 
     protected VarHandle getHandleRef(int offset) {
-        throw new InvalidMemoryAccessException();
+        throw invalidMemoryAccess();
     }
 
     protected VarHandle getHandlePointer(int offset) {
-        throw new InvalidMemoryAccessException();
+        throw invalidMemoryAccess();
     }
 
     @Override
     public int load8(long offset, ReadAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -95,7 +95,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int load16(long offset, ReadAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -116,7 +116,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int load32(long offset, ReadAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -149,7 +149,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public long load64(long offset, ReadAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -191,7 +191,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public VmObject loadRef(long offset, ReadAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -212,7 +212,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public ValueType loadType(long offset, ReadAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -233,7 +233,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public Pointer loadPointer(long offset, ReadAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -254,7 +254,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public void store8(long offset, int value, WriteAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -287,7 +287,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public void store16(long offset, int value, WriteAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -320,7 +320,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public void store32(long offset, int value, WriteAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -353,7 +353,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public void store64(long offset, long value, WriteAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -390,7 +390,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public void storeRef(long offset, VmObject value, WriteAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -411,7 +411,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public void storeType(long offset, ValueType value, WriteAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -432,7 +432,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public void storePointer(long offset, Pointer value, WriteAccessMode mode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -453,7 +453,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int compareAndExchange8(long offset, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -494,7 +494,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int compareAndExchange16(long offset, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -535,7 +535,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int compareAndExchange32(long offset, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -576,7 +576,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public long compareAndExchange64(long offset, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -633,7 +633,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public VmObject compareAndExchangeRef(long offset, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -658,7 +658,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public ValueType compareAndExchangeType(long offset, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -683,7 +683,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public Pointer compareAndExchangePointer(long offset, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -742,7 +742,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndSet8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -779,7 +779,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndSet16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -816,7 +816,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndSet32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -853,7 +853,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public long getAndSet64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -905,7 +905,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public VmObject getAndSetRef(long offset, VmObject value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -928,7 +928,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public ValueType getAndSetType(long offset, ValueType value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -951,7 +951,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public Pointer getAndSetPointer(long offset, Pointer value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -987,7 +987,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndAdd8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1010,7 +1010,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndAdd16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1047,7 +1047,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndAdd32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1071,7 +1071,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public long getAndAdd64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1100,7 +1100,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseAnd8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1123,7 +1123,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseAnd16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1160,7 +1160,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseAnd32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1183,7 +1183,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public long getAndBitwiseAnd64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1211,7 +1211,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseOr8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1234,7 +1234,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseOr16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1271,7 +1271,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseOr32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1294,7 +1294,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public long getAndBitwiseOr64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1322,7 +1322,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseXor8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1345,7 +1345,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseXor16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1382,7 +1382,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public int getAndBitwiseXor32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1405,7 +1405,7 @@ public abstract class VarHandleMemory extends AbstractMemory {
     @Override
     public long getAndBitwiseXor64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
         if (offset > Integer.MAX_VALUE) {
-            throw new InvalidMemoryAccessException();
+            throw invalidMemoryAccess();
         }
         Memory delegateMemory = getDelegateMemory((int) offset);
         if (delegateMemory != null) {
@@ -1441,5 +1441,9 @@ public abstract class VarHandleMemory extends AbstractMemory {
 
     private static InvalidMemoryAccessException pointerAsInteger() {
         return new InvalidMemoryAccessException("Pointer as integer");
+    }
+
+    private static InvalidMemoryAccessException invalidMemoryAccess() {
+        return new InvalidMemoryAccessException();
     }
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/VarHandleMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/VarHandleMemory.java
@@ -1,0 +1,1325 @@
+package org.qbicc.interpreter.memory;
+
+import static org.qbicc.graph.atomic.AccessModes.*;
+
+import java.lang.invoke.VarHandle;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.InvalidMemoryAccessException;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory implementation which uses {@link java.lang.invoke.VarHandle} to access its members.
+ */
+public abstract class VarHandleMemory extends AbstractMemory {
+    /**
+     * Construct a new instance.
+     */
+    protected VarHandleMemory() {
+    }
+
+    protected Memory getDelegateMemory(int offset) {
+        return null;
+    }
+
+    protected VarHandle getHandle8(int offset) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    protected VarHandle getHandle16(int offset) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    protected VarHandle getHandle32(int offset) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    protected VarHandle getHandle64(int offset) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    protected VarHandle getHandleType(int offset) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    protected VarHandle getHandleRef(int offset) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    protected VarHandle getHandlePointer(int offset) {
+        throw new InvalidMemoryAccessException();
+    }
+
+    @Override
+    public int load8(long offset, ReadAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.load8(offset, mode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (handle.varType() == boolean.class) {
+            if (GlobalPlain.includes(mode)) {
+                return (boolean) handle.get(this) ? 1 : 0;
+            } else if (SingleOpaque.includes(mode)) {
+                return (boolean) handle.getOpaque(this) ? 1 : 0;
+            } else if (GlobalAcquire.includes(mode)) {
+                return (boolean) handle.getAcquire(this) ? 1 : 0;
+            } else {
+                return (boolean) handle.getVolatile(this) ? 1 : 0;
+            }
+        } else {
+            if (GlobalPlain.includes(mode)) {
+                return (int) handle.get(this) & 0xff;
+            } else if (SingleOpaque.includes(mode)) {
+                return (int) handle.getOpaque(this) & 0xff;
+            } else if (GlobalAcquire.includes(mode)) {
+                return (int) handle.getAcquire(this) & 0xff;
+            } else {
+                return (int) handle.getVolatile(this) & 0xff;
+            }
+        }
+    }
+
+    @Override
+    public int load16(long offset, ReadAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.load16(offset, mode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (GlobalPlain.includes(mode)) {
+            return (int) handle.get(this) & 0xffff;
+        } else if (SingleOpaque.includes(mode)) {
+            return (int) handle.getOpaque(this) & 0xffff;
+        } else if (GlobalAcquire.includes(mode)) {
+            return (int) handle.getAcquire(this) & 0xffff;
+        } else {
+            return (int) handle.getVolatile(this) & 0xffff;
+        }
+    }
+
+    @Override
+    public int load32(long offset, ReadAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.load32(offset, mode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        if (handle.varType() == float.class) {
+            if (GlobalPlain.includes(mode)) {
+                return Float.floatToRawIntBits((float) handle.get(this));
+            } else if (SingleOpaque.includes(mode)) {
+                return Float.floatToRawIntBits((float) handle.getOpaque(this));
+            } else if (GlobalAcquire.includes(mode)) {
+                return Float.floatToRawIntBits((float) handle.getAcquire(this));
+            } else {
+                return Float.floatToRawIntBits((float) handle.getVolatile(this));
+            }
+        } else {
+            if (GlobalPlain.includes(mode)) {
+                return (int) handle.get(this);
+            } else if (SingleOpaque.includes(mode)) {
+                return (int) handle.getOpaque(this);
+            } else if (GlobalAcquire.includes(mode)) {
+                return (int) handle.getAcquire(this);
+            } else {
+                return (int) handle.getVolatile(this);
+            }
+        }
+    }
+
+    @Override
+    public long load64(long offset, ReadAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.load64(offset, mode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        if (handle.varType() == double.class) {
+            if (GlobalPlain.includes(mode)) {
+                return Double.doubleToRawLongBits((double) handle.get(this));
+            } else if (SingleOpaque.includes(mode)) {
+                return Double.doubleToRawLongBits((double) handle.getOpaque(this));
+            } else if (GlobalAcquire.includes(mode)) {
+                return Double.doubleToRawLongBits((double) handle.getAcquire(this));
+            } else {
+                return Double.doubleToRawLongBits((double) handle.getVolatile(this));
+            }
+        } else {
+            if (GlobalPlain.includes(mode)) {
+                return (long) handle.get(this);
+            } else if (SingleOpaque.includes(mode)) {
+                return (long) handle.getOpaque(this);
+            } else if (GlobalAcquire.includes(mode)) {
+                return (long) handle.getAcquire(this);
+            } else {
+                return (long) handle.getVolatile(this);
+            }
+        }
+    }
+
+    @Override
+    public VmObject loadRef(long offset, ReadAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.loadRef(offset, mode);
+        }
+        VarHandle handle = getHandleRef((int) offset);
+        if (GlobalPlain.includes(mode)) {
+            return (VmObject) handle.get(this);
+        } else if (SingleOpaque.includes(mode)) {
+            return (VmObject) handle.getOpaque(this);
+        } else if (GlobalAcquire.includes(mode)) {
+            return (VmObject) handle.getAcquire(this);
+        } else {
+            return (VmObject) handle.getVolatile(this);
+        }
+    }
+
+    @Override
+    public ValueType loadType(long offset, ReadAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.loadType(offset, mode);
+        }
+        VarHandle handle = getHandleType((int) offset);
+        if (GlobalPlain.includes(mode)) {
+            return (ValueType) handle.get(this);
+        } else if (SingleOpaque.includes(mode)) {
+            return (ValueType) handle.getOpaque(this);
+        } else if (GlobalAcquire.includes(mode)) {
+            return (ValueType) handle.getAcquire(this);
+        } else {
+            return (ValueType) handle.getVolatile(this);
+        }
+    }
+
+    @Override
+    public Pointer loadPointer(long offset, ReadAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.loadPointer(offset, mode);
+        }
+        VarHandle handle = getHandlePointer((int) offset);
+        if (GlobalPlain.includes(mode)) {
+            return (Pointer) handle.get(this);
+        } else if (SingleOpaque.includes(mode)) {
+            return (Pointer) handle.getOpaque(this);
+        } else if (GlobalAcquire.includes(mode)) {
+            return (Pointer) handle.getAcquire(this);
+        } else {
+            return (Pointer) handle.getVolatile(this);
+        }
+    }
+
+    @Override
+    public void store8(long offset, int value, WriteAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            delegateMemory.store8(offset, value, mode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (handle.varType() == boolean.class) {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, (value & 1) != 0);
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, (value & 1) != 0);
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, (value & 1) != 0);
+            } else {
+                handle.setVolatile(this, (value & 1) != 0);
+            }
+        } else {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, (byte) value);
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, (byte) value);
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, (byte) value);
+            } else {
+                handle.setVolatile(this, (byte) value);
+            }
+        }
+    }
+
+    @Override
+    public void store16(long offset, int value, WriteAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            delegateMemory.store16(offset, value, mode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (handle.varType() == char.class) {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, (char) value);
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, (char) value);
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, (char) value);
+            } else {
+                handle.setVolatile(this, (char) value);
+            }
+        } else {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, (short) value);
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, (short) value);
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, (short) value);
+            } else {
+                handle.setVolatile(this, (short) value);
+            }
+        }
+    }
+
+    @Override
+    public void store32(long offset, int value, WriteAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            delegateMemory.store32(offset, value, mode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        if (handle.varType() == float.class) {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, Float.intBitsToFloat(value));
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, Float.intBitsToFloat(value));
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, Float.intBitsToFloat(value));
+            } else {
+                handle.setVolatile(this, Float.intBitsToFloat(value));
+            }
+        } else {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, value);
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, value);
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, value);
+            } else {
+                handle.setVolatile(this, value);
+            }
+        }
+    }
+
+    @Override
+    public void store64(long offset, long value, WriteAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            delegateMemory.store64(offset, value, mode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        if (handle.varType() == double.class) {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, Double.longBitsToDouble(value));
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, Double.longBitsToDouble(value));
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, Double.longBitsToDouble(value));
+            } else {
+                handle.setVolatile(this, Double.longBitsToDouble(value));
+            }
+        } else {
+            if (GlobalPlain.includes(mode)) {
+                handle.set(this, value);
+            } else if (SingleOpaque.includes(mode)) {
+                handle.setOpaque(this, value);
+            } else if (GlobalRelease.includes(mode)) {
+                handle.setRelease(this, value);
+            } else {
+                handle.setVolatile(this, value);
+            }
+        }
+    }
+
+    @Override
+    public void storeRef(long offset, VmObject value, WriteAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            delegateMemory.storeRef(offset, value, mode);
+        }
+        VarHandle handle = getHandleRef((int) offset);
+        if (GlobalPlain.includes(mode)) {
+            handle.set(this, value);
+        } else if (SingleOpaque.includes(mode)) {
+            handle.setOpaque(this, value);
+        } else if (GlobalRelease.includes(mode)) {
+            handle.setRelease(this, value);
+        } else {
+            handle.setVolatile(this, value);
+        }
+    }
+
+    @Override
+    public void storeType(long offset, ValueType value, WriteAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            delegateMemory.storeType(offset, value, mode);
+        }
+        VarHandle handle = getHandleType((int) offset);
+        if (GlobalPlain.includes(mode)) {
+            handle.set(this, value);
+        } else if (SingleOpaque.includes(mode)) {
+            handle.setOpaque(this, value);
+        } else if (GlobalRelease.includes(mode)) {
+            handle.setRelease(this, value);
+        } else {
+            handle.setVolatile(this, value);
+        }
+    }
+
+    @Override
+    public void storePointer(long offset, Pointer value, WriteAccessMode mode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            delegateMemory.storePointer(offset, value, mode);
+        }
+        VarHandle handle = getHandlePointer((int) offset);
+        if (GlobalPlain.includes(mode)) {
+            handle.set(this, value);
+        } else if (SingleOpaque.includes(mode)) {
+            handle.setOpaque(this, value);
+        } else if (GlobalRelease.includes(mode)) {
+            handle.setRelease(this, value);
+        } else {
+            handle.setVolatile(this, value);
+        }
+    }
+
+    @Override
+    public int compareAndExchange8(long offset, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.compareAndExchange8(offset, expect, update, readMode, writeMode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (handle.varType() == boolean.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (boolean) handle.get(this) ? 1 : 0;
+                if (val == (expect & 0x1)) {
+                    handle.set(this, (update & 1) != 0);
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (boolean) handle.compareAndExchangeAcquire(this, (expect & 1) != 0, (update & 1) != 0) ? 1 : 0;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (boolean) handle.compareAndExchangeRelease(this, (expect & 1) != 0, (update & 1) != 0) ? 1 : 0;
+            } else {
+                return (boolean) handle.compareAndExchange(this, (expect & 1) != 0, (update & 1) != 0) ? 1 : 0;
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                if (val == (expect & 0xff)) {
+                    handle.set(this, (byte) update);
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.compareAndExchangeAcquire(this, (byte) expect, (byte) update) & 0xff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.compareAndExchangeRelease(this, (byte) expect, (byte) update) & 0xff;
+            } else {
+                return (int) handle.compareAndExchange(this, (byte) expect, (byte) update) & 0xff;
+            }
+        }
+    }
+
+    @Override
+    public int compareAndExchange16(long offset, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.compareAndExchange16(offset, expect, update, readMode, writeMode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (handle.varType() == char.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                if (val == (expect & 0xffff)) {
+                    handle.set(this, (char) update);
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.compareAndExchangeAcquire(this, (char) expect, (char) update);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.compareAndExchangeRelease(this, (char) expect, (char) update);
+            } else {
+                return (int) handle.compareAndExchange(this, (char) expect, (char) update);
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this) & 0xffff;
+                if (val == (expect & 0xffff)) {
+                    handle.set(this, (short) update);
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.compareAndExchangeAcquire(this, (short) expect, (short) update) & 0xffff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.compareAndExchangeRelease(this, (short) expect, (short) update) & 0xffff;
+            } else {
+                return (int) handle.compareAndExchange(this, (short) expect, (short) update) & 0xffff;
+            }
+        }
+    }
+
+    @Override
+    public int compareAndExchange32(long offset, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.compareAndExchange32(offset, expect, update, readMode, writeMode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        if (handle.varType() == float.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = Float.floatToRawIntBits((float) handle.get(this));
+                if (val == expect) {
+                    handle.set(this, Float.intBitsToFloat(update));
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return Float.floatToRawIntBits((float) handle.compareAndExchangeAcquire(this, Float.intBitsToFloat(expect), Float.intBitsToFloat(update)));
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return Float.floatToRawIntBits((float) handle.compareAndExchangeRelease(this, Float.intBitsToFloat(expect), Float.intBitsToFloat(update)));
+            } else {
+                return Float.floatToRawIntBits((float) handle.compareAndExchange(this, Float.intBitsToFloat(expect), Float.intBitsToFloat(update)));
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                if (val == expect) {
+                    handle.set(this, update);
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.compareAndExchangeAcquire(this, expect, update);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.compareAndExchangeRelease(this, expect, update);
+            } else {
+                return (int) handle.compareAndExchange(this, expect, update);
+            }
+        }
+    }
+
+    @Override
+    public long compareAndExchange64(long offset, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.compareAndExchange64(offset, expect, update, readMode, writeMode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        if (handle.varType() == double.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                long val = Double.doubleToRawLongBits((double) handle.get(this));
+                if (val == expect) {
+                    handle.set(this, Double.longBitsToDouble(update));
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return Double.doubleToRawLongBits((double) handle.compareAndExchangeAcquire(this, Double.longBitsToDouble(expect), Double.longBitsToDouble(update)));
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return Double.doubleToRawLongBits((double) handle.compareAndExchangeRelease(this, Double.longBitsToDouble(expect), Double.longBitsToDouble(update)));
+            } else {
+                return Double.doubleToRawLongBits((double) handle.compareAndExchange(this, Double.longBitsToDouble(expect), Double.longBitsToDouble(update)));
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                long val = (long) handle.get(this);
+                if (val == expect) {
+                    handle.set(this, update);
+                }
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (long) handle.compareAndExchangeAcquire(this, expect, update);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (long) handle.compareAndExchangeRelease(this, expect, update);
+            } else {
+                return (long) handle.compareAndExchange(this, expect, update);
+            }
+        }
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long offset, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.compareAndExchangeRef(offset, expect, update, readMode, writeMode);
+        }
+        VarHandle handle = getHandleRef((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            VmObject val = (VmObject) handle.get(this);
+            if (val == expect) {
+                handle.set(this, update);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (VmObject) handle.compareAndExchangeAcquire(this, expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (VmObject) handle.compareAndExchangeRelease(this, expect, update);
+        } else {
+            return (VmObject) handle.compareAndExchange(this, expect, update);
+        }
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long offset, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.compareAndExchangeType(offset, expect, update, readMode, writeMode);
+        }
+        VarHandle handle = getHandleType((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            ValueType val = (ValueType) handle.get(this);
+            if (val == expect) {
+                handle.set(this, update);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (ValueType) handle.compareAndExchangeAcquire(this, expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (ValueType) handle.compareAndExchangeRelease(this, expect, update);
+        } else {
+            return (ValueType) handle.compareAndExchange(this, expect, update);
+        }
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long offset, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.compareAndExchangePointer(offset, expect, update, readMode, writeMode);
+        }
+        VarHandle handle = getHandlePointer((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            Pointer val = (Pointer) handle.get(this);
+            if (val == expect) {
+                handle.set(this, update);
+            }
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (Pointer) handle.compareAndExchangeAcquire(this, expect, update);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (Pointer) handle.compareAndExchangeRelease(this, expect, update);
+        } else {
+            return (Pointer) handle.compareAndExchange(this, expect, update);
+        }
+    }
+
+    @Override
+    public int getAndSet8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndSet8(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (handle.varType() == boolean.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (boolean) handle.get(this) ? 1 : 0;
+                handle.set(this, (value & 1) != 0);
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (boolean) handle.getAndSetAcquire(this, (value & 1) != 0) ? 1 : 0;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (boolean) handle.getAndSetRelease(this, (value & 1) != 0) ? 1 : 0;
+            } else {
+                return (boolean) handle.getAndSet(this, (value & 1) != 0) ? 1 : 0;
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this) & 0xff;
+                handle.set(this, (byte) value);
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndSetAcquire(this, (byte) value) & 0xff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndSetRelease(this, (byte) value) & 0xff;
+            } else {
+                return (int) handle.getAndSet(this, (byte) value) & 0xff;
+            }
+        }
+    }
+
+    @Override
+    public int getAndSet16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndSet16(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (handle.varType() == char.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                handle.set(this, (char) value);
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndSetAcquire(this, (char) value);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndSetRelease(this, (char) value);
+            } else {
+                return (int) handle.getAndSet(this, (char) value);
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this) & 0xffff;
+                handle.set(this, (short) value);
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndSetAcquire(this, (short) value) & 0xffff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndSetRelease(this, (short) value) & 0xffff;
+            } else {
+                return (int) handle.getAndSet(this, (short) value) & 0xffff;
+            }
+        }
+    }
+
+    @Override
+    public int getAndSet32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndSet32(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        if (handle.varType() == float.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = Float.floatToRawIntBits((float) handle.get(this));
+                handle.set(this, Float.intBitsToFloat(value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return Float.floatToRawIntBits((float) handle.getAndSetAcquire(this, Float.intBitsToFloat(value)));
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return Float.floatToRawIntBits((float) handle.getAndSetRelease(this, Float.intBitsToFloat(value)));
+            } else {
+                return Float.floatToRawIntBits((float) handle.getAndSet(this, Float.intBitsToFloat(value)));
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                handle.set(this, value);
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndSetAcquire(this, value);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndSetRelease(this, value);
+            } else {
+                return (int) handle.getAndSet(this, value);
+            }
+        }
+    }
+
+    @Override
+    public long getAndSet64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndSet64(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        if (handle.varType() == double.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                long val = Double.doubleToRawLongBits((double) handle.get(this));
+                handle.set(this, Double.longBitsToDouble(value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return Double.doubleToRawLongBits((double) handle.getAndSetAcquire(this, Double.longBitsToDouble(value)));
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return Double.doubleToRawLongBits((double) handle.getAndSetRelease(this, Double.longBitsToDouble(value)));
+            } else {
+                return Double.doubleToRawLongBits((double) handle.getAndSet(this, Double.longBitsToDouble(value)));
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                long val = (long) handle.get(this);
+                handle.set(this, value);
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (long) handle.getAndSetAcquire(this, value);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (long) handle.getAndSetRelease(this, value);
+            } else {
+                return (long) handle.getAndSet(this, value);
+            }
+        }
+    }
+
+    @Override
+    public VmObject getAndSetRef(long offset, VmObject value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndSetRef(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandleRef((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            VmObject val = (VmObject) handle.get(this);
+            handle.set(this, value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (VmObject) handle.getAndSetAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (VmObject) handle.getAndSetRelease(this, value);
+        } else {
+            return (VmObject) handle.getAndSet(this, value);
+        }
+    }
+
+    @Override
+    public ValueType getAndSetType(long offset, ValueType value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndSetType(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandleType((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            ValueType val = (ValueType) handle.get(this);
+            handle.set(this, value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (ValueType) handle.getAndSetAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (ValueType) handle.getAndSetRelease(this, value);
+        } else {
+            return (ValueType) handle.getAndSet(this, value);
+        }
+    }
+
+    @Override
+    public Pointer getAndSetPointer(long offset, Pointer value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndSetPointer(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandlePointer((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            Pointer val = (Pointer) handle.get(this);
+            handle.set(this, value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (Pointer) handle.getAndSetAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (Pointer) handle.getAndSetRelease(this, value);
+        } else {
+            return (Pointer) handle.getAndSet(this, value);
+        }
+    }
+
+    @Override
+    public int getAndAdd8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndAdd8(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this) & 0xff;
+            handle.set(this, (byte) (val + value));
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndAddAcquire(this, (byte) value) & 0xff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndAddRelease(this, (byte) value) & 0xff;
+        } else {
+            return (int) handle.getAndAdd(this, (byte) value) & 0xff;
+        }
+    }
+
+    @Override
+    public int getAndAdd16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndAdd16(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (handle.varType() == char.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                handle.set(this, (char) (val + value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndAddAcquire(this, (char) value);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndAddRelease(this, (char) value);
+            } else {
+                return (int) handle.getAndAdd(this, (char) value);
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this) & 0xffff;
+                handle.set(this, (short) (val + value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndAddAcquire(this, (short) value) & 0xffff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndAddRelease(this, (short) value) & 0xffff;
+            } else {
+                return (int) handle.getAndAdd(this, (short) value) & 0xffff;
+            }
+        }
+    }
+
+    @Override
+    public int getAndAdd32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndAdd32(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        // TODO: float behavior?
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this);
+            handle.set(this, val + value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndAddAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndAddRelease(this, value);
+        } else {
+            return (int) handle.getAndAdd(this, value);
+        }
+    }
+
+    @Override
+    public long getAndAdd64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndAdd64(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        // TODO: double behavior?
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = (long) handle.get(this);
+            handle.set(this, val + value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (long) handle.getAndAddAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (long) handle.getAndAddRelease(this, value);
+        } else {
+            return (long) handle.getAndAdd(this, value);
+        }
+    }
+
+    @Override
+    public int getAndBitwiseAnd8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseAnd8(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this) & 0xff;
+            handle.set(this, (byte) (val & value));
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndBitwiseAndAcquire(this, (byte) value) & 0xff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndBitwiseAndRelease(this, (byte) value) & 0xff;
+        } else {
+            return (int) handle.getAndBitwiseAnd(this, (byte) value) & 0xff;
+        }
+    }
+
+    @Override
+    public int getAndBitwiseAnd16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseAnd16(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (handle.varType() == char.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                handle.set(this, (char) (val & value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndBitwiseAndAcquire(this, (char) value);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndBitwiseAndRelease(this, (char) value);
+            } else {
+                return (int) handle.getAndBitwiseAnd(this, (char) value);
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this) & 0xffff;
+                handle.set(this, (short) (val & value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndBitwiseAndAcquire(this, (short) value) & 0xffff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndBitwiseAndRelease(this, (short) value) & 0xffff;
+            } else {
+                return (int) handle.getAndBitwiseAnd(this, (short) value) & 0xffff;
+            }
+        }
+    }
+
+    @Override
+    public int getAndBitwiseAnd32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseAnd32(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this);
+            handle.set(this, val & value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndBitwiseAndAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndBitwiseAndRelease(this, value);
+        } else {
+            return (int) handle.getAndBitwiseAnd(this, value);
+        }
+    }
+
+    @Override
+    public long getAndBitwiseAnd64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseAnd64(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = (long) handle.get(this);
+            handle.set(this, val & value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (long) handle.getAndBitwiseAndAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (long) handle.getAndBitwiseAndRelease(this, value);
+        } else {
+            return (long) handle.getAndBitwiseAnd(this, value);
+        }
+    }
+
+    @Override
+    public int getAndBitwiseOr8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseOr8(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this) & 0xff;
+            handle.set(this, (byte) (val & value));
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndBitwiseOrAcquire(this, (byte) value) & 0xff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndBitwiseOrRelease(this, (byte) value) & 0xff;
+        } else {
+            return (int) handle.getAndBitwiseOr(this, (byte) value) & 0xff;
+        }
+    }
+
+    @Override
+    public int getAndBitwiseOr16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseOr16(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (handle.varType() == char.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                handle.set(this, (char) (val & value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndBitwiseOrAcquire(this, (char) value);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndBitwiseOrRelease(this, (char) value);
+            } else {
+                return (int) handle.getAndBitwiseOr(this, (char) value);
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this) & 0xffff;
+                handle.set(this, (short) (val & value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndBitwiseOrAcquire(this, (short) value) & 0xffff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndBitwiseOrRelease(this, (short) value) & 0xffff;
+            } else {
+                return (int) handle.getAndBitwiseOr(this, (short) value) & 0xffff;
+            }
+        }
+    }
+
+    @Override
+    public int getAndBitwiseOr32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseOr32(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this);
+            handle.set(this, val & value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndBitwiseOrAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndBitwiseOrRelease(this, value);
+        } else {
+            return (int) handle.getAndBitwiseOr(this, value);
+        }
+    }
+
+    @Override
+    public long getAndBitwiseOr64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseOr64(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = (long) handle.get(this);
+            handle.set(this, val & value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (long) handle.getAndBitwiseOrAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (long) handle.getAndBitwiseOrRelease(this, value);
+        } else {
+            return (long) handle.getAndBitwiseOr(this, value);
+        }
+    }
+
+    @Override
+    public int getAndBitwiseXor8(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseXor8(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle8((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this) & 0xff;
+            handle.set(this, (byte) (val & value));
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndBitwiseXorAcquire(this, (byte) value) & 0xff;
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndBitwiseXorRelease(this, (byte) value) & 0xff;
+        } else {
+            return (int) handle.getAndBitwiseXor(this, (byte) value) & 0xff;
+        }
+    }
+
+    @Override
+    public int getAndBitwiseXor16(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseXor16(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle16((int) offset);
+        if (handle.varType() == char.class) {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this);
+                handle.set(this, (char) (val & value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndBitwiseXorAcquire(this, (char) value);
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndBitwiseXorRelease(this, (char) value);
+            } else {
+                return (int) handle.getAndBitwiseXor(this, (char) value);
+            }
+        } else {
+            if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                int val = (int) handle.get(this) & 0xffff;
+                handle.set(this, (short) (val & value));
+                return val;
+            } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+                return (int) handle.getAndBitwiseXorAcquire(this, (short) value) & 0xffff;
+            } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+                return (int) handle.getAndBitwiseXorRelease(this, (short) value) & 0xffff;
+            } else {
+                return (int) handle.getAndBitwiseXor(this, (short) value) & 0xffff;
+            }
+        }
+    }
+
+    @Override
+    public int getAndBitwiseXor32(long offset, int value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseXor32(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle32((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            int val = (int) handle.get(this);
+            handle.set(this, val & value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (int) handle.getAndBitwiseXorAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (int) handle.getAndBitwiseXorRelease(this, value);
+        } else {
+            return (int) handle.getAndBitwiseXor(this, value);
+        }
+    }
+
+    @Override
+    public long getAndBitwiseXor64(long offset, long value, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (offset > Integer.MAX_VALUE) {
+            throw new InvalidMemoryAccessException();
+        }
+        Memory delegateMemory = getDelegateMemory((int) offset);
+        if (delegateMemory != null) {
+            return delegateMemory.getAndBitwiseXor64(offset, value, readMode, writeMode);
+        }
+        VarHandle handle = getHandle64((int) offset);
+        if (GlobalPlain.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            long val = (long) handle.get(this);
+            handle.set(this, val & value);
+            return val;
+        } else if (GlobalAcquire.includes(readMode) && GlobalPlain.includes(writeMode)) {
+            return (long) handle.getAndBitwiseXorAcquire(this, value);
+        } else if (GlobalPlain.includes(readMode) && GlobalRelease.includes(writeMode)) {
+            return (long) handle.getAndBitwiseXorRelease(this, value);
+        } else {
+            return (long) handle.getAndBitwiseXor(this, value);
+        }
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        if (newSize == getSize()) {
+            return clone();
+        } else {
+            throw new IllegalArgumentException("Fixed memory cannot be resized");
+        }
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/VectorMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/VectorMemory.java
@@ -155,16 +155,6 @@ public final class VectorMemory extends AbstractMemory {
     }
 
     @Override
-    public void storeMemory(long destIndex, Memory src, long srcIndex, long size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeMemory(long destIndex, byte[] src, int srcIndex, int size) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
         int number = (int) (index / divisor);
         long offset = index % divisor;

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/VectorMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/VectorMemory.java
@@ -10,7 +10,7 @@ import org.qbicc.type.ValueType;
 /**
  * A memory which is backed by an array of a uniform delegate memory.
  */
-public final class VectorMemory implements Memory {
+public final class VectorMemory extends AbstractMemory {
     private final long divisor;
     private final Memory[] memories;
 


### PR DESCRIPTION
This change implements fully typed `Memory` instances.

The `Memory` instances for a given input type are bytecode-generated using the ASM API and loaded as hidden classes into the host JVM. Each member of the source structure is reflected by a correctly-typed and clearly-named field on the typed memory class. The performance characteristics are similar to the untyped memory implementation, but debuggability is vastly improved since every member of an object or structure can be easily examined in a debugger.

The base `VarHandleMemory` class works by implementing the `Memory` API with methods that delegate to a target `VarHandle`. The primary responsibility of the generated class is to contain an implementation of the `getHandle()` method which maps the given offset to a `VarHandle` for the appropriate field. Each `VarHandle` is a dynamic constant, so fields which are never accessed will never cause a `VarHandle` to be instantiated for it. At most, one `VarHandle` per member per type is generated, and reused for all instances of that type.

A property of hidden classes is that they may be defined with a "class data" object which can be easily loaded using a dynamic constant. This mechanism is used to populate the class with delegate factories for the case where a `Memory` contains nested `Memory` instances.

The vast majority of typed `Memory` implementations can be cloned using the JDK's `Object#clone()` shallow copy mechanism. This is very efficient, but only works when a shallow clone is sufficient. For memories which contain nested structures, a deep-clone copy constructor is generated and used by the `clone()` method.

A mechanism is included to automatically upgrade `long`-typed fields to `Pointer` type. For now, this flag is turned on all of the time, but in the future we could conceivably restrict this behavior to classes which are known to handle pointers in `long`-typed fields. Because typed memory is now also used for local variable storage, the same thing applies: the flag is always on for now, but can be changed later to use the same per-class logic. Note that if I finish implementing the method JIT mechanism then that *may* use standard Java local variables for local variable storage instead.