### PR TITLE
Fix version check pattern for Ubuntu distro clang

### DIFF
--- a/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangToolProvider.java
+++ b/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/ClangToolProvider.java
@@ -27,7 +27,7 @@ public class ClangToolProvider implements ToolProvider {
         return list;
     }
 
-    static final Pattern VERSION_PATTERN = Pattern.compile("^(?:clang|Apple (?:LLVM|clang)|Ubuntu|Homebrew (?:LLVM|clang)) version (\\S+)");
+    static final Pattern VERSION_PATTERN = Pattern.compile("^(?:clang|Apple (?:LLVM|clang)|Ubuntu (?:LLVM|clang)|Homebrew (?:LLVM|clang)) version (\\S+)");
 
     private <T extends Tool> void tryOne(final Class<T> type, final Platform platform, final ArrayList<T> list, final Path path) {
         if (path != null && Files.isExecutable(path)) {


### PR DESCRIPTION
In Ubuntu 22.04, all distro clang (11+) and llc 12+ match to this format.  In Ubuntu 20.04, distro clang 11+ (i.e., 11 and 12) match to this format (though they are too old for us).