### PR TITLE
WASM: Add isWasi() build-time property

### DIFF
--- a/runtime/api/src/main/java/org/qbicc/runtime/Build.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/Build.java
@@ -195,6 +195,12 @@ public final class Build {
             return defined(__wasm__);
         }
 
+        @Fold
+        public static boolean isWasi() {
+            return defined(__wasi__);
+        }
+
+
         // Toolchain
 
         @Fold
@@ -265,6 +271,7 @@ public final class Build {
         private static final object __arm__ = constant();
         private static final object __aarch64__ = constant();
         private static final object __wasm__ = constant();
+        private static final object __wasi__ = constant();
         private static final object _M_ARM = constant();
         @include("<features.h>")
         private static final c_int __GNU_LIBRARY__ = constant();
@@ -315,6 +322,12 @@ public final class Build {
         public static final class IsWasm implements BooleanSupplier {
             public boolean getAsBoolean() {
                 return isWasm();
+            }
+        }
+
+        public static final class IsWasi implements BooleanSupplier {
+            public boolean getAsBoolean() {
+                return isWasi();
             }
         }
         //


### PR DESCRIPTION
currently we only have an `IsWasm` property; add `isWasi` to be more specific to the rt env.

will be useful for https://github.com/qbicc/qbicc-class-library/pull/253