### PR TITLE
Add isPThreads() build-time property

### DIFF
--- a/runtime/api/src/main/java/org/qbicc/runtime/Build.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/Build.java
@@ -220,6 +220,11 @@ public final class Build {
         }
 
         @Fold
+        public static boolean isPThreads() {
+            return ! isWasm();
+        }
+
+        @Fold
         public static boolean isMusl() {
             return defined(__MUSL__);
         }
@@ -334,6 +339,12 @@ public final class Build {
         public static final class IsGLibCLike implements BooleanSupplier {
             public boolean getAsBoolean() {
                 return isGLibCLike();
+            }
+        }
+
+        public static final class IsPThreads implements BooleanSupplier {
+            public boolean getAsBoolean() {
+                return isPThreads();
             }
         }
 


### PR DESCRIPTION
Allows to opt-out of PThreads support if that is not available (currently only Wasm is affected)

(this can be rebased on #1435 if it makes more sense to use `isWasi()` instead)