### PR TITLE
WASM: Add __EMSCRIPTEN__ to isWasi

### DIFF
--- a/runtime/api/src/main/java/org/qbicc/runtime/Build.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/Build.java
@@ -197,7 +197,7 @@ public final class Build {
 
         @Fold
         public static boolean isWasi() {
-            return defined(__wasi__);
+            return defined(__wasi__) || defined(__EMSCRIPTEN__);
         }
 
 
@@ -272,6 +272,7 @@ public final class Build {
         private static final object __aarch64__ = constant();
         private static final object __wasm__ = constant();
         private static final object __wasi__ = constant();
+        private static final object __EMSCRIPTEN__ = constant();
         private static final object _M_ARM = constant();
         @include("<features.h>")
         private static final c_int __GNU_LIBRARY__ = constant();


### PR DESCRIPTION
While testing the changes I discovered that the current build setup will not work -- apparently when building with `emcc` the `__wasi__` constant may not be defined. I plan to do some follow-up PRs to actually switch to pure clang+wasi and/or keep emcc around as an alternate toolchain.

In the meantime, I am building the generated `*.ll`s (that compile fine with `emcc`) manually using clang+wasi at the shell prompt.

for now, though, I am setting `isWasi() := true` when either `__wasi__` or `__EMSCRIPTEN__` are defined, even if it is not 100% correct. I will clean it up when the two are actually split.

