### PR TITLE
only warn when an element cannot be made reflectively available

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -521,7 +521,7 @@ public class Main implements Callable<DiagnosticContext> {
 
                                 builder.addPreHook(Phase.ANALYZE, new VMHelpersSetupHook());
                                 builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachable);
-                                builder.addPreHook(Phase.ANALYZE, ReachabilityRoots::processReachabilityRoots);
+                                builder.addPreHook(Phase.ANALYZE, ReachabilityRoots::processRootsForAnalyze);
                                 builder.addElementHandler(Phase.ANALYZE, new ElementBodyCopier());
                                 if (optEscapeAnalysis) {
                                     builder.addElementHandler(Phase.ANALYZE, new ElementVisitorAdapter(new EscapeAnalysisIntraMethodAnalysis()));
@@ -561,7 +561,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPostHook(Phase.ANALYZE, new DispatchTableBuilder());
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
 
-                                builder.addPreHook(Phase.LOWER, ReachabilityRoots::enqueueReachabilityRoots);
+                                builder.addPreHook(Phase.LOWER, ReachabilityRoots::processRootsForLower);
                                 builder.addPreHook(Phase.LOWER, new ClassObjectSerializer());
                                 if (optEscapeAnalysis) {
                                     builder.addCopyFactory(Phase.LOWER, EscapeAnalysisOptimizeVisitor::new);

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityRoots.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityRoots.java
@@ -96,7 +96,8 @@ public class ReachabilityRoots {
         return reflectiveFields.add(f);
     }
 
-    public static void processReachabilityRoots(CompilationContext ctxt) {
+    // During Analyze, we can allow reachability analysis to figure things out for us.
+    public static void processRootsForAnalyze(CompilationContext ctxt) {
         ReachabilityRoots roots = get(ctxt);
         ReachabilityInfo info = ReachabilityInfo.get(ctxt);
         for (ExecutableElement e : roots.autoQueuedMethods) {
@@ -116,13 +117,20 @@ public class ReachabilityRoots {
         }
     }
 
-    public static void enqueueReachabilityRoots(CompilationContext ctxt) {
+    // During Lower, we don't have to handle instance methods in the autoQueued or reflective sets.
+    // These methods are either in the dispatchTable set, or reachability analysis has determined that
+    // there cannot be an instantiated class that could invoke the method, and therefore it is not reachable.
+    public static void processRootsForLower(CompilationContext ctxt) {
         ReachabilityRoots roots = get(ctxt);
         for (ExecutableElement e : roots.autoQueuedMethods) {
-            ctxt.enqueue(e);
+            if (e.isStatic()) {
+                ctxt.enqueue(e);
+            }
         }
         for (ExecutableElement e : roots.reflectiveMethods) {
-            ctxt.enqueue(e);
+            if (e.isStatic()) {
+                ctxt.enqueue(e);
+            }
         }
         for (ExecutableElement e : roots.dispatchTableMethods) {
             ctxt.enqueue(e);

--- a/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/ReflectiveMethodAccessorGenerator.java
+++ b/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/ReflectiveMethodAccessorGenerator.java
@@ -1,6 +1,7 @@
 package org.qbicc.plugin.reflection;
 
 import org.qbicc.context.CompilationContext;
+import org.qbicc.interpreter.Thrown;
 import org.qbicc.plugin.reachability.ReachabilityRoots;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -23,10 +24,14 @@ public class ReflectiveMethodAccessorGenerator implements Consumer<ExecutableEle
         CompilationContext ctxt = executableElement.getEnclosingType().getContext().getCompilationContext();
         if (ReachabilityRoots.get(ctxt).getReflectiveMethods().contains(executableElement)) {
             Reflection r = Reflection.get(ctxt);
-            if (executableElement instanceof MethodElement me) {
-                r.makeAvailableForRuntimeReflection(me);
-            } else if (executableElement instanceof ConstructorElement ce) {
-                r.makeAvailableForRuntimeReflection(ce);
+            try {
+                if (executableElement instanceof MethodElement me) {
+                    r.makeAvailableForRuntimeReflection(me);
+                } else if (executableElement instanceof ConstructorElement ce) {
+                    r.makeAvailableForRuntimeReflection(ce);
+                }
+            } catch (Thrown e) {
+                ctxt.warning("Failed to make %s available for runtime reflection: %s", executableElement.toString(), e.getMessage());
             }
         }
     }


### PR DESCRIPTION
In the long run, this probably should be an error, but tolerate it while
qbicc's classlib is still missing many JDK modules.