### PR TITLE
WASM: do not emit `gc "example-statepoint"` when isWasm

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -193,6 +193,7 @@ public class Main implements Callable<DiagnosticContext> {
     private final boolean optEscapeAnalysis;
     private final Platform platform;
     private final boolean isWasm;
+    private final boolean gcSupport;
     private final boolean smallTypeIds;
     private final List<Path> librarySearchPaths;
     private final List<String> buildFeatures;
@@ -218,6 +219,7 @@ public class Main implements Callable<DiagnosticContext> {
         optEscapeAnalysis = builder.optEscapeAnalysis;
         platform = builder.platform;
         isWasm = platform.getCpu() == Cpu.WASM32;
+        gcSupport = !isWasm;
         smallTypeIds = builder.smallTypeIds;
         backend = builder.backend;
         ArrayList<ClassPathEntry> bootPaths = new ArrayList<>(builder.bootPathsPrepend.size() + 6 + builder.bootPathsAppend.size());
@@ -620,7 +622,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPreHook(Phase.GENERATE, new DispatchTableEmitter());
 
                                 if (llvm) {
-                                    builder.addPreHook(Phase.GENERATE, new LLVMGenerator(isPie ? 2 : 0, isPie ? 2 : 0, referencePointerFactory));
+                                    builder.addPreHook(Phase.GENERATE, new LLVMGenerator(isPie ? 2 : 0, isPie ? 2 : 0, gcSupport, referencePointerFactory));
                                 }
 
                                 builder.addPostHook(Phase.GENERATE, new DotGenerator(Phase.GENERATE, graphGenConfig));
@@ -631,7 +633,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 }
                                 if (llvm) {
                                     builder.addPostHook(Phase.GENERATE, new MethodDataEmitter());
-                                    builder.addPostHook(Phase.GENERATE, new LLVMDefaultModuleCompileStage(isPie, compileOutput, referencePointerFactory, llvmCompilerFactory, optOptions, llcOptions));
+                                    builder.addPostHook(Phase.GENERATE, new LLVMDefaultModuleCompileStage(isPie, compileOutput, gcSupport, referencePointerFactory, llvmCompilerFactory, optOptions, llcOptions));
                                     if (! isWasm) {
                                         builder.addPostHook(Phase.GENERATE, new LLVMStripStackMapStage());
                                     }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMDefaultModuleCompileStage.java
@@ -10,14 +10,16 @@ import java.util.function.Consumer;
 public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContext> {
     private final boolean isPie;
     private final boolean compileOutput;
+    private final boolean gcSupport;
     private final LLVMReferencePointerFactory refFactory;
     private LLVMCompiler.Factory llvmCompilerFactory;
     private List<String> optOptions;
     private List<String> llcOptions;
 
-    public LLVMDefaultModuleCompileStage(boolean isPie, boolean compileOutput, LLVMReferencePointerFactory refFactory, LLVMCompiler.Factory llvmCompilerFactory, List<String> optOptions, List<String> llcOptions) {
+    public LLVMDefaultModuleCompileStage(boolean isPie, boolean compileOutput, boolean gcSupport, LLVMReferencePointerFactory refFactory, LLVMCompiler.Factory llvmCompilerFactory, List<String> optOptions, List<String> llcOptions) {
         this.isPie = isPie;
         this.compileOutput = compileOutput;
+        this.gcSupport = gcSupport;
         this.refFactory = refFactory;
         this.llvmCompilerFactory = llvmCompilerFactory;
         this.optOptions = optOptions;
@@ -26,7 +28,7 @@ public class LLVMDefaultModuleCompileStage implements Consumer<CompilationContex
 
     @Override
     public void accept(CompilationContext context) {
-        LLVMModuleGenerator generator = new LLVMModuleGenerator(context, isPie ? 2 : 0, isPie ? 2 : 0, refFactory);
+        LLVMModuleGenerator generator = new LLVMModuleGenerator(context, isPie ? 2 : 0, isPie ? 2 : 0, gcSupport, refFactory);
         DefinedTypeDefinition defaultTypeDefinition = context.getDefaultTypeDefinition();
         Path modulePath = generator.processProgramModule(context.getOrAddProgramModule(defaultTypeDefinition));
         if (compileOutput) {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMGenerator.java
@@ -17,15 +17,17 @@ public class LLVMGenerator implements Consumer<CompilationContext>, ValueVisitor
     private final int picLevel;
     private final int pieLevel;
     private final LLVMReferencePointerFactory refFactory;
+    private final boolean gcSupport;
 
-    public LLVMGenerator(final int picLevel, final int pieLevel, final LLVMReferencePointerFactory refFactory) {
+    public LLVMGenerator(final int picLevel, final int pieLevel, final boolean gcSupport, final LLVMReferencePointerFactory refFactory) {
         this.picLevel = picLevel;
         this.pieLevel = pieLevel;
+        this.gcSupport = gcSupport;
         this.refFactory = refFactory;
     }
 
     public void accept(final CompilationContext compilationContext) {
-        LLVMModuleGenerator generator = new LLVMModuleGenerator(compilationContext, picLevel, pieLevel, refFactory);
+        LLVMModuleGenerator generator = new LLVMModuleGenerator(compilationContext, picLevel, pieLevel, gcSupport, refFactory);
         List<ProgramModule> allProgramModules = compilationContext.getAllProgramModules();
         Iterator<ProgramModule> iterator = allProgramModules.iterator();
         compilationContext.runParallelTask(ctxt -> {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -54,12 +54,14 @@ final class LLVMModuleGenerator {
     private final CompilationContext context;
     private final int picLevel;
     private final int pieLevel;
+    private final boolean gcSupport;
     private final LLVMReferencePointerFactory refFactory;
 
-    LLVMModuleGenerator(final CompilationContext context, final int picLevel, final int pieLevel, final LLVMReferencePointerFactory refFactory) {
+    LLVMModuleGenerator(final CompilationContext context, final int picLevel, final int pieLevel, final boolean gcSupport, final LLVMReferencePointerFactory refFactory) {
         this.context = context;
         this.picLevel = picLevel;
         this.pieLevel = pieLevel;
+        this.gcSupport = gcSupport;
         this.refFactory = refFactory;
     }
 
@@ -162,7 +164,9 @@ final class LLVMModuleGenerator {
                     }
                     functionDefinition.attribute(FunctionAttributes.framePointer("non-leaf"));
                     functionDefinition.attribute(FunctionAttributes.uwtable);
-                    functionDefinition.gc("statepoint-example");
+                    if (gcSupport) {
+                        functionDefinition.gc("statepoint-example");
+                    }
                     if (fn.isNoReturn()) {
                         functionDefinition.attribute(FunctionAttributes.noreturn);
                     }


### PR DESCRIPTION
The latest version of the [wasi-sdk (v16, llvm 14)](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-16) complains loudly when this attribute is present, because it is not really supported (it will abort the build).

This patch adds a boolean `gcSupport := !isWasm` (for now) that is threaded through the stack to LLVMGenerator that simply won't set `gc "example-statepoint"`. 

(I do know this may be misleading, suggestions welcome)
