### PR TITLE
Fix wrong default intrinsics for j.l.Throwable

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -85,7 +85,7 @@ public final class CoreIntrinsics {
         registerJavaLangSystemIntrinsics(ctxt);
         registerJavaLangStackTraceElementInstrinsics(ctxt);
         registerJavaLangThreadIntrinsics(ctxt);
-        if (ctxt.getPlatform().getCpu() != Cpu.WASM32) {
+        if (ctxt.getPlatform().getCpu() == Cpu.WASM32) {
             registerEmptyJavaLangThrowableIntrinsics(ctxt);
         } else {
             registerJavaLangThrowableIntrinsics(ctxt);


### PR DESCRIPTION
Introduced by mistake with #1416 