### PR TITLE
Annotations to register reflective access to other elements

### DIFF
--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnnotationTypeBuilder.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityAnnotationTypeBuilder.java
@@ -61,9 +61,9 @@ public class ReachabilityAnnotationTypeBuilder implements DefinedTypeDefinition.
                     int cnt = array.getElementCount();
                     for (int j = 0; j < cnt; j ++) {
                         Annotation element = (Annotation) array.getValue(j);
+                        TypeDescriptor clazz = ((ClassAnnotationValue) element.getValue("clazz")).getDescriptor();
+                        String method = ((StringAnnotationValue) element.getValue("method")).getString();
                         try {
-                            TypeDescriptor clazz = ((ClassAnnotationValue) element.getValue("clazz")).getDescriptor();
-                            String method = ((StringAnnotationValue) element.getValue("method")).getString();
                             ValueType vt = classCtxt.resolveTypeFromDescriptor(clazz, TypeParameterContext.EMPTY, TypeSignature.synthesize(classCtxt, clazz));
                             if (vt instanceof ClassObjectType ct) {
                                 LoadedTypeDefinition ltd = ct.getDefinition().load();
@@ -80,7 +80,7 @@ public class ReachabilityAnnotationTypeBuilder implements DefinedTypeDefinition.
                                         if (args.size() != params.length) {
                                             return false;
                                         }
-                                        for (int i=0; i<params.length; i++) {
+                                        for (int i = 0; i < params.length; i++) {
                                             if (!args.get(i).equals(params[i])) {
                                                 return false;
                                             }
@@ -93,19 +93,19 @@ public class ReachabilityAnnotationTypeBuilder implements DefinedTypeDefinition.
                                     if (idx != -1) {
                                         roots.registerReflectiveConstructor(ltd.getConstructor(idx));
                                     } else {
-                                        ctxt.warning("No match for @ReflectivelyAccessedElement %s", annotation);
+                                        ctxt.warning("@RA Annotation not processed on %s. No match for %s.%s", this.getLocation(), clazz, method);
                                     }
                                 } else {
                                     int idx = ltd.findSingleMethodIndex(me -> me.nameEquals(method) && checkParams.test(me.getDescriptor().getParameterTypes()));
                                     if (idx != -1) {
                                         roots.registerReflectiveMethod(ltd.getMethod(idx));
                                     } else {
-                                        ctxt.warning("No match for @ReflectivelyAccessedElement %s", annotation);
+                                        ctxt.warning("RA Annotation not processed on %s. No match for %s.%s", this.getLocation(), clazz, method);
                                     }
                                 }
                             }
                         } catch (Exception e) {
-                            ctxt.warning(e,"Failed to process @ReflectivelyAccessedElement annotation %s", element.toString());
+                            ctxt.warning(e,"RA Annotation not processed in %s. No unique match for  %s.%s", this.getLocation(), clazz,  method);
                         }
                     }
                 }

--- a/runtime/api/src/main/java/org/qbicc/runtime/ReflectivelyAccessedElement.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/ReflectivelyAccessedElement.java
@@ -1,0 +1,16 @@
+package org.qbicc.runtime;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Used in @ReflectivelyAccesses annotations to list the fields and methods
+ * of another class that the annotated class might access reflectively.
+ */
+@Retention(RetentionPolicy.CLASS)
+public @interface ReflectivelyAccessedElement {
+    Class<?> clazz();
+    String method() default "";
+    String field() default "";
+    Class<?>[] params() default {};
+}

--- a/runtime/api/src/main/java/org/qbicc/runtime/ReflectivelyAccesses.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/ReflectivelyAccesses.java
@@ -1,0 +1,27 @@
+package org.qbicc.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.BooleanSupplier;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface ReflectivelyAccesses {
+    /**
+     * Cause this annotation to take effect only if <em>all</em> of the given conditions return {@code true}.
+     *
+     * @return the condition classes
+     */
+    Class<? extends BooleanSupplier>[] when() default {};
+
+    /**
+     * Prevent this annotation from taking effect if <em>all</em> of the given conditions return {@code true}.
+     *
+     * @return the condition classes
+     */
+    Class<? extends BooleanSupplier>[] unless() default {};
+
+    ReflectivelyAccessedElement[] value() default {};
+}


### PR DESCRIPTION
Add annotations to allow a class to indicate that it will reflectively
access fields, methods, and constructors defined in other
classes. This complements the existing @ReflectivelyAccessed
annotation which allows annotating an element "in place" as being
reflectively accessed.