### PR TITLE
add intrinsic to get a C function pointer to a Java static method

### DIFF
--- a/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
@@ -32,6 +32,16 @@ public class CompilerIntrinsics {
     public static native boolean saveNativeThread(void_ptr thread, PThread.pthread_t_ptr pthreadPtr);
 
     /**
+     * This intrinsic gets a C-style function pointer to the specified static method.
+     * The method should be annotated with @export and must be the only method of that
+     * name defined in the given class (not overloaded).
+     *
+     * @param clazz the fully qualified class name
+     * @param method the name of the method
+     */
+    public static native void_ptr_unaryoperator_function_ptr nativeFunctionPointer(String clazz, String method);
+
+    /**
      * This intrinsic sets up and executes the `public void run()` of threadParam.
      * @param threadParam - java.lang.Thread object that has been cast to a void pointer to be compatible with pthread_create
      * @return null - this return value will not be used


### PR DESCRIPTION
Use case: passing a pointer to an @export function as a callback
down to a CNative function. By having a generic intrinsic
for this, we can be more flexible in where these functions are defined.

I explored trying to do addr_of_function on a Class::methodr instead of
adding an intrinsic, but the invokedynamic machinery causes enough
indirection that it seemed overly challenging to identify the pattern
and ensure that we get the function pointer we need (one that goes
directly to the function with the @export annotation).