### PR TITLE
Fix vtable entry for the native method that has its implementation

### DIFF
--- a/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
+++ b/plugins/dispatch/src/main/java/org/qbicc/plugin/dispatch/DispatchTables.java
@@ -256,7 +256,7 @@ public class DispatchTables {
         HashMap<CompoundType.Member, Literal> valueMap = new HashMap<>();
         for (int i = 0; i < vtable.length; i++) {
             FunctionType funType = ctxt.getFunctionTypeForElement(vtable[i]);
-            if (vtable[i].isAbstract() || vtable[i].hasAllModifiersOf(ClassFile.ACC_NATIVE)) {
+            if (vtable[i].isAbstract() || (vtable[i].hasAllModifiersOf(ClassFile.ACC_NATIVE) && ctxt.getExactFunctionIfExists(vtable[i]) == null)) {
                 MethodElement stub = methodFinder.getMethod(vtable[i].isAbstract() ? "raiseAbstractMethodError" : "raiseUnsatisfiedLinkError");
                 Function stubImpl = ctxt.getExactFunction(stub);
                 FunctionDeclaration decl = programModule.declareFunction(stub, stubImpl.getName(), stubImpl.getValueType());


### PR DESCRIPTION
Since some native methods' implementations are given by the `$_native` class in the qbicc-class-library, it looks fine to fill proper entries in vtables. `Runtime$_native` methods can be invoked with this change.