### PR TITLE
compatibility kludge to allow relocation of qbicc_bound_thread field

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -88,6 +88,7 @@ final class CNativeIntrinsics {
         ClassTypeDescriptor thrDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/Thread");
         ClassTypeDescriptor strDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/String");
         ClassTypeDescriptor classDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/Class");
+        ClassTypeDescriptor qthrDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/ThreadSupportQbicc");
 
         ClassTypeDescriptor boolPtrDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/CNative$_Bool_ptr");
 
@@ -178,10 +179,13 @@ final class CNativeIntrinsics {
         intrinsics.registerIntrinsic(cNativeDesc, "ptrToRef", MethodDescriptor.synthesize(classContext, objDesc, List.of(ptrDesc)), ptrToRef);
 
         StaticIntrinsic attachNewThread = (builder, target, arguments) -> {
-            //java.lang.Thread.nextThreadID
+            // Allocate uninitialized Thread object
             Value thread = builder.new_(thrDesc);
-            // immediately set the thread to be the current thread
-            builder.store(builder.staticField(vmDesc, "_qbicc_bound_thread", thrDesc), thread, SingleUnshared);
+            // immediately set the newly allocated thread object to be the current thread
+            DefinedTypeDefinition tlq = classContext.findDefinedType("java/lang/ThreadSupportQbicc");
+            ClassTypeDescriptor qbtDesc = classContext.findDefinedType("java/lang/ThreadSupportQbicc") == null ? vmDesc : qthrDesc; // TODO: ?: is class Library Compatibility kludge
+            builder.store(builder.staticField(qbtDesc, "_qbicc_bound_thread", thrDesc), thread, SingleUnshared);
+
             // now start initializing
             DefinedTypeDefinition jlt = classContext.findDefinedType("java/lang/Thread");
             LoadedTypeDefinition jltVal = jlt.load();


### PR DESCRIPTION
This will make more sense in the context of the rest of my PRs...

Basically to get shutdown hooks working properly, I needed to relocate the last remnants of pthread support code from VM and VmHelpers to the class library.  Having it in one place should also make it less painful to evolve going forward.