### PR TITLE
use AppClassLoader as Thread.contextClassLoader in interpreter

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmImpl.java
@@ -26,6 +26,7 @@ import java.util.zip.CRC32;
 import io.smallrye.common.constraint.Assert;
 import org.qbicc.context.ClassContext;
 import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.atomic.AccessModes;
 import org.qbicc.graph.literal.BooleanLiteral;
 import org.qbicc.graph.literal.ByteArrayLiteral;
 import org.qbicc.graph.literal.FloatLiteral;
@@ -666,15 +667,18 @@ public final class VmImpl implements Vm {
 
             // Thread
             VmClassImpl threadNativeClass = bootstrapClassLoader.loadClass("java/lang/Thread");
-
             threadNativeClass.registerInvokable("yield", (thread, target, args) -> {
                 Thread.yield();
                 return null;
             });
-
             threadNativeClass.registerInvokable("start", (thread, target, args) -> {
                 startedThreads.add(vmThread);
                 return null;
+            });
+            threadNativeClass.registerInvokable("getContextClassLoader", (thread, target, args) -> {
+                VmClassImpl classLoaders = bootstrapClassLoader.loadClass("jdk/internal/loader/ClassLoaders");
+                VmClassLoader appClassLoader = (VmClassLoader) classLoaders.getStaticMemory().loadRef(classLoaders.indexOfStatic(classLoaders.getTypeDefinition().findField("APP_LOADER")), AccessModes.SinglePlain);
+                return appClassLoader;
             });
 
             // Throwable


### PR DESCRIPTION
A quick patch to avoid some NPEs at build time.

This does have the side-effect of all serialized thread instances will have the AppClassLoader as their CCL. If we want to prevent this, we could add a compensating hack of setting their CCLs to null during serialization.