### PR TITLE
enforce that RuntimeAspect fields cannot be accessed at build-time

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -2297,7 +2297,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         public Memory visit(Frame frame, StaticFieldPointer pointer) {
             StaticFieldElement variableElement = pointer.getStaticField();
             if (variableElement.hasAllModifiersOf(ClassFile.I_ACC_RUN_TIME)) {
-                throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run time field"));
+                throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run-time field "+ variableElement));
             }
             DefinedTypeDefinition enclosingType = variableElement.getEnclosingType();
             VmClassImpl clazz = (VmClassImpl) enclosingType.load().getVmClass();
@@ -2326,7 +2326,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         public Memory visit(Frame frame, InstanceFieldOf node) {
             InstanceFieldElement variableElement = node.getVariableElement();
             if (variableElement.hasAllModifiersOf(ClassFile.I_ACC_RUN_TIME)) {
-                throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run time field"));
+                throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run-time field "+variableElement));
             }
             return node.getValueHandle().accept(this, frame);
         }
@@ -2345,7 +2345,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         public Memory visit(Frame frame, StaticField node) {
             StaticFieldElement variableElement = node.getVariableElement();
             if (variableElement.hasAllModifiersOf(ClassFile.I_ACC_RUN_TIME)) {
-                throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run time field"));
+                throw new Thrown(((VmImpl) Vm.requireCurrent()).linkageErrorClass.newInstance("Invalid build-time access of run-time field "+variableElement));
             }
             DefinedTypeDefinition enclosingType = variableElement.getEnclosingType();
             VmClassImpl clazz = (VmClassImpl) enclosingType.load().getVmClass();

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/ClassContextPatchInfo.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/ClassContextPatchInfo.java
@@ -385,7 +385,7 @@ final class ClassContextPatchInfo {
                     if (isStatic && runTimeAspect) {
                         classPatchInfo.runtimeInitField(new RuntimeInitializerPatchInfo(internalName, i, initResolver, initIndex, fieldDesc, fieldName, controllingAnnotation));
                     }
-                    classPatchInfo.addField(new FieldPatchInfo(internalName, i, addModifiers, classFile, fieldDesc, fieldName, controllingAnnotation, null));
+                    classPatchInfo.addField(new FieldPatchInfo(internalName, i, 0, classFile, fieldDesc, fieldName, controllingAnnotation, null));
                 } else if (kind == K_REMOVE) {
                     classPatchInfo.deleteField(fieldName, fieldDesc, internalName, controllingAnnotation);
                 } else if (kind == K_REPLACE) {

--- a/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/PatchedTypeBuilder.java
+++ b/plugins/patcher/src/main/java/org/qbicc/plugin/patcher/PatchedTypeBuilder.java
@@ -16,6 +16,7 @@ import org.qbicc.type.definition.FieldResolver;
 import org.qbicc.type.definition.InitializerResolver;
 import org.qbicc.type.definition.MethodBodyFactory;
 import org.qbicc.type.definition.MethodResolver;
+import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ConstructorElement;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.InitializerElement;
@@ -334,7 +335,9 @@ final class PatchedTypeBuilder implements DefinedTypeDefinition.Builder.Delegati
         public FieldElement resolveField(int index, DefinedTypeDefinition enclosing, FieldElement.Builder builder) {
             InitializerElement rtInit = initInfo.getInitializerResolver().resolveInitializer(initInfo.getInitializerResolverIndex(), enclosing, InitializerElement.builder());
             builder.setRunTimeInitializer(rtInit);
-            return fieldResolver.resolveField(index, enclosing, builder);
+            FieldElement fieldElement = fieldResolver.resolveField(index, enclosing, builder);
+            fieldElement.setModifierFlags(ClassFile.I_ACC_RUN_TIME);
+            return fieldElement;
         }
     }
 


### PR DESCRIPTION
This cannot be merged until a class library that includes https://github.com/qbicc/qbicc-class-library/pull/290 has released.