### PR TITLE
Extend GraalVM emulation layer

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -15,12 +15,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
@@ -781,7 +783,7 @@ public class Main implements Callable<DiagnosticContext> {
             .prependBootPaths(optionsProcessor.prependedBootPathEntries)
             .addAppPaths(optionsProcessor.appPathEntries)
             .processJarArgument(optionsProcessor.inputJar)
-            .addBuildFeatures(optionsProcessor.buildFeatures)
+            .addBuildFeatures(optionsProcessor.buildFeatures.stream().toList())
             .setOutputPath(optionsProcessor.outputPath)
             .setOutputName(optionsProcessor.outputName)
             .setMainClass(optionsProcessor.mainClass)
@@ -888,7 +890,7 @@ public class Main implements Callable<DiagnosticContext> {
 
         @CommandLine.Option(names ="--build-feature", description = "GraalVM native-image Feature")
         void addBuildFeature(List<String> features) { buildFeatures.addAll(features); }
-        private final List<String> buildFeatures = new ArrayList<>();
+        private final Set<String> buildFeatures = new HashSet<>();
 
         @CommandLine.Option(names = "--jar", description = "Compile an executable jar")
         private Path inputJar;

--- a/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/FeatureProcessor.java
+++ b/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/FeatureProcessor.java
@@ -1,7 +1,10 @@
 package org.qbicc.plugin.nativeimage;
 
 import com.oracle.svm.core.BuildPhaseProvider;
+import com.oracle.svm.core.configure.ResourcesRegistry;
 import com.oracle.svm.core.jdk.Resources;
+import com.oracle.svm.core.jdk.localization.LocalizationFeature;
+import com.oracle.svm.core.jdk.localization.LocalizationSupport;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
@@ -10,7 +13,10 @@ import org.qbicc.context.CompilationContext;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 public class FeatureProcessor {
     public static void processBuildFeature(CompilationContext ctxt, List<String> features, ClassLoader cl) {
@@ -24,6 +30,9 @@ public class FeatureProcessor {
         QbiccImageSingletonsSupport qiss = new QbiccImageSingletonsSupport();
         qiss.add(RuntimeReflectionSupport.class, new QbiccRuntimeReflectionSupport(ctxt));
         qiss.add(RuntimeClassInitializationSupport.class, new QbiccRuntimeClassInitializationSupport(ctxt));
+        qiss.add(ResourcesRegistry.class, new QbiccResourcesRegistry(ctxt));
+        qiss.add(LocalizationSupport.class, new QbiccLocalizationSupport(Locale.getDefault(), Set.of(), Charset.defaultCharset()));
+        qiss.add(LocalizationFeature.class, new QbiccLocalizationFeature());
         try {
             Class<BuildPhaseProvider> buildPhaseProviderClass = (Class<BuildPhaseProvider>)Class.forName("com.oracle.svm.core.BuildPhaseProvider");
             Constructor<BuildPhaseProvider> bc = buildPhaseProviderClass.getDeclaredConstructor();

--- a/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccLocalizationFeature.java
+++ b/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccLocalizationFeature.java
@@ -1,0 +1,6 @@
+package org.qbicc.plugin.nativeimage;
+
+import com.oracle.svm.core.jdk.localization.LocalizationFeature;
+
+public class QbiccLocalizationFeature extends LocalizationFeature {
+}

--- a/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccLocalizationSupport.java
+++ b/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccLocalizationSupport.java
@@ -1,0 +1,13 @@
+package org.qbicc.plugin.nativeimage;
+
+import com.oracle.svm.core.jdk.localization.LocalizationSupport;
+
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.Set;
+
+public class QbiccLocalizationSupport extends LocalizationSupport {
+    public QbiccLocalizationSupport(Locale defaultLocale, Set<Locale> locales, Charset defaultCharset) {
+        super(defaultLocale, locales, defaultCharset);
+    }
+}

--- a/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccResourcesRegistry.java
+++ b/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccResourcesRegistry.java
@@ -1,0 +1,42 @@
+package org.qbicc.plugin.nativeimage;
+
+import com.oracle.svm.core.configure.ResourcesRegistry;
+import org.graalvm.nativeimage.impl.ConfigurationCondition;
+import org.qbicc.context.CompilationContext;
+
+import java.util.Collection;
+import java.util.Locale;
+
+public class QbiccResourcesRegistry implements ResourcesRegistry {
+    private final CompilationContext ctxt;
+
+    QbiccResourcesRegistry(CompilationContext ctxt) {
+        this.ctxt = ctxt;
+    }
+
+    @Override
+    public void addResources(ConfigurationCondition condition, String pattern) {
+        ctxt.warning("ignoring: addResources %s %s", condition.toString(), pattern);
+    }
+
+    @Override
+    public void ignoreResources(ConfigurationCondition condition, String pattern) {
+        ctxt.warning("ignoring: ignoreResources %s %s", condition.toString(), pattern);
+    }
+
+    @Override
+    public void addResourceBundles(ConfigurationCondition condition, String name) {
+        ctxt.warning("ignoring: addResourceBundles %s %s", condition.toString(), name);
+    }
+
+    @Override
+    public void addResourceBundles(ConfigurationCondition condition, String basename, Collection<Locale> locales) {
+        ctxt.warning("ignoring: addResourceBundles %s %s %s", condition.toString(), basename, locales.toString());
+
+    }
+
+    @Override
+    public void addClassBasedResourceBundle(ConfigurationCondition condition, String basename, String className) {
+        ctxt.warning("ignoring: addClassBasedResourceBundle %s %s", condition.toString(), basename, className);
+    }
+}


### PR DESCRIPTION
Stub out enough additional pieces of the emulation layer that Quarkus's generated Feature can now be completely executed at build time without raising any errors.
