### PR TITLE
Disable destructor

### DIFF
--- a/runtime/gc/heap/src/main/java/org/qbicc/runtime/gc/heap/Heap.java
+++ b/runtime/gc/heap/src/main/java/org/qbicc/runtime/gc/heap/Heap.java
@@ -420,7 +420,7 @@ public final class Heap {
         return num;
     }
 
-    @destructor(priority = 0)
+    //@destructor(priority = 0)
     @export
     static void destroyHeap() {
         if (Build.Target.isWasm()) {


### PR DESCRIPTION
The theory here is that the destructor runs once the main thread exits, even if other threads are running, resulting in SIGSEGV for memory that was valid heap only moments before. The proper fix will probably involve blocking the destructor until all other threads have exited, potentially forcing daemon threads to terminate abruptly first.