### PR TITLE
plugin for processing a qbicc build feature

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -114,6 +114,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-initialization-control</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-instanceof-checkcast</artifactId>
         </dependency>
         <dependency>

--- a/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/GraalFeatureProcessor.java
+++ b/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/GraalFeatureProcessor.java
@@ -18,8 +18,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-public class FeatureProcessor {
-    public static void processBuildFeature(CompilationContext ctxt, List<String> features, ClassLoader cl) {
+public class GraalFeatureProcessor {
+    public static void process(CompilationContext ctxt, List<String> features, ClassLoader cl) {
         if (features.isEmpty()) {
             return;
         }

--- a/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccRuntimeClassInitializationSupport.java
+++ b/plugins/graalvm-nativeimage-emulation/src/main/java/org/qbicc/plugin/nativeimage/QbiccRuntimeClassInitializationSupport.java
@@ -2,6 +2,7 @@ package org.qbicc.plugin.nativeimage;
 
 import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
 import org.qbicc.context.CompilationContext;
+import org.qbicc.plugin.initializationcontrol.FeaturePatcher;
 
 public class QbiccRuntimeClassInitializationSupport implements RuntimeClassInitializationSupport {
     private final CompilationContext ctxt;
@@ -12,12 +13,13 @@ public class QbiccRuntimeClassInitializationSupport implements RuntimeClassIniti
 
     @Override
     public void initializeAtRunTime(String name, String reason) {
-        ctxt.warning("ignoring: initializeAtRuntime %s %s", name, reason);
+        String internalName = name.replace('.', '/');
+        FeaturePatcher.get(ctxt).addRuntimeInitializedClass(internalName);
     }
 
     @Override
     public void initializeAtBuildTime(String name, String reason) {
-        // No-op for qbicc; this is what we do anyways
+        // No-op for qbicc; this is what we do by default
     }
 
     @Override
@@ -39,7 +41,7 @@ public class QbiccRuntimeClassInitializationSupport implements RuntimeClassIniti
 
     @Override
     public void initializeAtBuildTime(Class<?> aClass, String reason) {
-        // No-op for qbicc; this is what we do anyways
+        // No-op for qbicc; this is what we do by default
     }
 
     @Override

--- a/plugins/initialization-control/pom.xml
+++ b/plugins/initialization-control/pom.xml
@@ -10,10 +10,10 @@
         <version>0.46.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>qbicc-plugin-graalvm-nativeimage-emulation</artifactId>
+    <artifactId>qbicc-plugin-initialization-control</artifactId>
 
-    <name>Qbicc Plugin: GraalVM NativeImage Emulation</name>
-    <description>Emulates build-time Feature support of GraalVM's native-image tool</description>
+    <name>Qbicc Plugin: Initialization Control</name>
+    <description>Support for customizing build-time initialization</description>
 
     <dependencies>
         <dependency>
@@ -23,23 +23,18 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-apploader</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>qbicc-plugin-initialization-control</artifactId>
+            <artifactId>qbicc-plugin-patcher</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-reachability</artifactId>
         </dependency>
-
-        <!-- Match svm version used by Quarkus (2.7 ==>  21.3.0; 2.12 ==> 22.2.0) -->
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-            <version>22.2.0</version>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.13.3</version>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/FeaturePatcher.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/FeaturePatcher.java
@@ -1,4 +1,4 @@
-package org.qbicc.plugin.nativeimage;
+package org.qbicc.plugin.initializationcontrol;
 
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
@@ -6,7 +6,7 @@ import org.qbicc.context.CompilationContext;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-class FeaturePatcher {
+public class FeaturePatcher {
 
     private static final AttachmentKey<FeaturePatcher> KEY = new AttachmentKey<>();
 
@@ -29,11 +29,11 @@ class FeaturePatcher {
         return patcher;
     }
 
-    void addRuntimeInitializedClass(String internalName) {
+    public void addRuntimeInitializedClass(String internalName) {
         runtimeInitializedClasses.add(internalName);
     }
 
-    boolean isRuntimeInitializedClass(String internalName) {
+    public boolean isRuntimeInitializedClass(String internalName) {
         return runtimeInitializedClasses.contains(internalName);
     }
 }

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeature.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeature.java
@@ -1,0 +1,5 @@
+package org.qbicc.plugin.initializationcontrol;
+
+final class QbiccFeature {
+    String[] initializeAtRuntime;
+}

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureProcessor.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureProcessor.java
@@ -1,0 +1,48 @@
+package org.qbicc.plugin.initializationcontrol;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.qbicc.context.CompilationContext;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.List;
+
+public class QbiccFeatureProcessor {
+    public static void process(CompilationContext ctxt, List<Path> features) {
+        if (features.isEmpty()) {
+            return;
+        }
+
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        for (Path feature: features) {
+            QbiccFeature qf;
+            try {
+                InputStream fs = new FileInputStream(feature.toFile());
+                qf = mapper.readValue(fs, QbiccFeature.class);
+            } catch (FileNotFoundException e) {
+                ctxt.error("Failed to open qbicc-feature %s", feature);
+                continue;
+            } catch (IOException e) {
+                ctxt.error(e, "Failed to parse qbicc-feature %s ",feature);
+                continue;
+            }
+
+            ctxt.info("Processing build feature %s", feature);
+            for (String className: qf.initializeAtRuntime) {
+                String internalName = className.replace('.', '/');
+                FeaturePatcher.get(ctxt).addRuntimeInitializedClass(internalName);
+            }
+        }
+    }
+}

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/RuntimeInitializingTypeBuilder.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/RuntimeInitializingTypeBuilder.java
@@ -1,4 +1,4 @@
-package org.qbicc.plugin.nativeimage;
+package org.qbicc.plugin.initializationcontrol;
 
 import org.qbicc.context.ClassContext;
 import org.qbicc.plugin.patcher.OnceRunTimeInitializerResolver;

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -26,6 +26,7 @@
         <module>correctness</module>
         <module>dispatch</module>
         <module>dot</module>
+        <module>initialization-control</module>
         <module>instanceof-checkcast</module>
         <module>intrinsics</module>
         <module>gc</module>

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,12 @@
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>qbicc-plugin-initialization-control</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>qbicc-plugin-instanceof-checkcast</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Add the ability to provide yaml file(s) to qbicc that can be used to fine-tune build-time initialization of the application being compiled.  This leverages the same mechanisms that we use for graalvm nativeimage Features, but exposes them to the user in a more declarative fashion.

In the initial version, the only implemented feature is the ability to provide a list of classes whose initialization should be deferred to runtime.  


 