### PR TITLE
Add a couple necessary nodes for GC support

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
@@ -40,6 +40,10 @@ public interface ActionVisitor<T, R> {
         return visitUnknown(t, node);
     }
 
+    default R visit(T t, SafePoint node) {
+        return visitUnknown(t, node);
+    }
+
     default R visit(T t, Store node) {
         return visitUnknown(t, node);
     }
@@ -80,6 +84,10 @@ public interface ActionVisitor<T, R> {
         }
 
         default R visit(T t, Reachable node) {
+            return getDelegateActionVisitor().visit(t, node);
+        }
+
+        default R visit(T t, SafePoint node) {
             return getDelegateActionVisitor().visit(t, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ActionVisitor.java
@@ -36,6 +36,10 @@ public interface ActionVisitor<T, R> {
         return visitUnknown(t, node);
     }
 
+    default R visit(T t, Reachable node) {
+        return visitUnknown(t, node);
+    }
+
     default R visit(T t, Store node) {
         return visitUnknown(t, node);
     }
@@ -72,6 +76,10 @@ public interface ActionVisitor<T, R> {
         }
 
         default R visit(T t, MonitorExit node) {
+            return getDelegateActionVisitor().visit(t, node);
+        }
+
+        default R visit(T t, Reachable node) {
             return getDelegateActionVisitor().visit(t, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -540,6 +540,13 @@ public interface BasicBlockBuilder extends Locatable {
      */
     Node reachable(Value value);
 
+    /**
+     * Add a safepoint poll at this point.
+     *
+     * @return the node representing the safepoint poll
+     */
+    Node safePoint();
+
     // control flow - terminalBlock is updated to point to this terminator
 
     /**

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -532,6 +532,14 @@ public interface BasicBlockBuilder extends Locatable {
      */
     Node begin(BlockLabel blockLabel);
 
+    /**
+     * Establish that the given value is reachable at this point.
+     *
+     * @param value the reachable value (must not be {@code null})
+     * @return the node representing the reachability fence
+     */
+    Node reachable(Value value);
+
     // control flow - terminalBlock is updated to point to this terminator
 
     /**

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -375,6 +375,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().reachable(value);
     }
 
+    public Node safePoint() {
+        return getDelegate().safePoint();
+    }
+
     public BasicBlock callNoReturn(ValueHandle target, List<Value> arguments) {
         return getDelegate().callNoReturn(target, arguments);
     }

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -371,6 +371,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().begin(blockLabel);
     }
 
+    public Node reachable(final Value value) {
+        return getDelegate().reachable(value);
+    }
+
     public BasicBlock callNoReturn(ValueHandle target, List<Value> arguments) {
         return getDelegate().callNoReturn(target, arguments);
     }

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -375,6 +375,11 @@ public interface Node {
                 return param.getBlockBuilder().monitorExit(param.copyValue(node.getInstance()));
             }
 
+            public Node visit(Copier copier, Reachable node) {
+                copier.copyNode(node.getDependency());
+                return copier.getBlockBuilder().reachable(copier.copyValue(node.getReachableValue()));
+            }
+
             public Node visit(Copier param, InitCheck node) {
                 param.copyNode(node.getDependency());
                 return param.getBlockBuilder().initCheck(node.getInitializerElement(), param.copyValue(node.getInitThunk()));

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -380,6 +380,11 @@ public interface Node {
                 return copier.getBlockBuilder().reachable(copier.copyValue(node.getReachableValue()));
             }
 
+            public Node visit(Copier copier, SafePoint node) {
+                copier.copyNode(node.getDependency());
+                return copier.getBlockBuilder().safePoint();
+            }
+
             public Node visit(Copier param, InitCheck node) {
                 param.copyNode(node.getDependency());
                 return param.getBlockBuilder().initCheck(node.getInitializerElement(), param.copyValue(node.getInitThunk()));

--- a/compiler/src/main/java/org/qbicc/graph/Reachable.java
+++ b/compiler/src/main/java/org/qbicc/graph/Reachable.java
@@ -1,0 +1,70 @@
+package org.qbicc.graph;
+
+import java.util.Objects;
+
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ *
+ */
+public final class Reachable extends AbstractNode implements Action, OrderedNode {
+    private final Node dependency;
+    private final Value reachableValue;
+
+    Reachable(Node callSite, ExecutableElement element, int line, int bci, Node dependency, Value reachableValue) {
+        super(callSite, element, line, bci);
+        this.dependency = dependency;
+        this.reachableValue = reachableValue;
+    }
+
+    @Override
+    public int getValueDependencyCount() {
+        return 1;
+    }
+
+    @Override
+    public Value getValueDependency(int index) throws IndexOutOfBoundsException {
+        return switch (index) {
+            case 0 -> reachableValue;
+            default -> Util.throwIndexOutOfBounds(index);
+        };
+    }
+
+    public Value getReachableValue() {
+        return reachableValue;
+    }
+
+    @Override
+    public Node getDependency() {
+        return dependency;
+    }
+
+    @Override
+    String getNodeName() {
+        return "Reachable";
+    }
+
+    @Override
+    int calcHashCode() {
+        return Objects.hash(Reachable.class, dependency, reachableValue);
+    }
+
+    @Override
+    public StringBuilder toString(StringBuilder b) {
+        return reachableValue.toString(super.toString(b).append('(')).append(')');
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Reachable r && equals(r);
+    }
+
+    public boolean equals(Reachable other) {
+        return this == other || other != null && dependency.equals(other.dependency) && reachableValue.equals(other.reachableValue);
+    }
+
+    @Override
+    public <T, R> R accept(ActionVisitor<T, R> visitor, T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/SafePoint.java
+++ b/compiler/src/main/java/org/qbicc/graph/SafePoint.java
@@ -1,0 +1,46 @@
+package org.qbicc.graph;
+
+import java.util.Objects;
+
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ *
+ */
+public final class SafePoint extends AbstractNode implements Action, OrderedNode {
+    private final Node dependency;
+
+    SafePoint(Node callSite, ExecutableElement element, int line, int bci, Node dependency) {
+        super(callSite, element, line, bci);
+        this.dependency = dependency;
+    }
+
+    @Override
+    public Node getDependency() {
+        return dependency;
+    }
+
+    @Override
+    String getNodeName() {
+        return "SafePoint";
+    }
+
+    @Override
+    int calcHashCode() {
+        return Objects.hash(SafePoint.class, dependency);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof SafePoint r && equals(r);
+    }
+
+    public boolean equals(SafePoint other) {
+        return this == other || other != null && dependency.equals(other.dependency);
+    }
+
+    @Override
+    public <T, R> R accept(ActionVisitor<T, R> visitor, T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -771,6 +771,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return asDependency(new Reachable(callSite, element, line, bci, requireDependency(), value));
     }
 
+    public Node safePoint() {
+        return asDependency(new SafePoint(callSite, element, line, bci, requireDependency()));
+    }
+
     public BasicBlock callNoReturn(ValueHandle target, List<Value> arguments) {
         // todo: this should be done in a separate BBB
         ExceptionHandler exceptionHandler = getExceptionHandler();

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -767,6 +767,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
         return dependency = blockEntry = new BlockEntry(callSite, element, blockLabel);
     }
 
+    public Node reachable(final Value value) {
+        return asDependency(new Reachable(callSite, element, line, bci, requireDependency(), value));
+    }
+
     public BasicBlock callNoReturn(ValueHandle target, List<Value> arguments) {
         // todo: this should be done in a separate BBB
         ExceptionHandler exceptionHandler = getExceptionHandler();

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -84,6 +84,7 @@ import org.qbicc.graph.Or;
 import org.qbicc.graph.PhiValue;
 import org.qbicc.graph.PointerHandle;
 import org.qbicc.graph.PopCount;
+import org.qbicc.graph.Reachable;
 import org.qbicc.graph.ReadModifyWrite;
 import org.qbicc.graph.ReferenceHandle;
 import org.qbicc.graph.Ret;
@@ -1971,6 +1972,12 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         if (heldLocks != null) {
             heldLocks.remove(lock);
         }
+        return null;
+    }
+
+    @Override
+    public Void visit(VmThreadImpl vmThread, Reachable node) {
+        // no operation needed because we aggressively keep values live
         return null;
     }
 

--- a/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
+++ b/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Node;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.LiteralFactory;
@@ -79,6 +80,11 @@ public class NoGcBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         Value oop = valueConvert(ptrVal, arrayType.getReference());
         BasicHeaderInitializer.initializeRefArrayHeader(ctxt, this, referenceHandle(oop), elemTypeId, dimensions, size);
         return oop;
+    }
+
+    public Node safePoint() {
+        // No safepoints in NoGC
+        return nop();
     }
 
     private Value allocateArray(CompoundType compoundType, Value size, long elementSize) {

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -1042,6 +1042,7 @@ public final class CoreIntrinsics {
         ClassTypeDescriptor phantomReferenceDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/ref/PhantomReference");
 
         MethodDescriptor objToBool = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.Z, List.of(objDesc));
+        MethodDescriptor objToVoid = MethodDescriptor.synthesize(classContext, BaseTypeDescriptor.V, List.of(objDesc));
 
         InstanceIntrinsic refersTo0 = (builder, instance, target, arguments) ->
             builder.isEq(
@@ -1051,6 +1052,16 @@ public final class CoreIntrinsics {
 
         intrinsics.registerIntrinsic(Phase.ADD, referenceDesc, "refersTo0", objToBool, refersTo0);
         intrinsics.registerIntrinsic(Phase.ADD, phantomReferenceDesc, "refersTo0", objToBool, refersTo0);
+
+        StaticIntrinsic reachabilityFence = (builder, target, arguments) -> {
+            builder.reachable(arguments.get(0));
+            final ClassContext context = builder.getCurrentElement().getEnclosingType().getContext();
+            final TypeSystem ts = context.getTypeSystem();
+            final LiteralFactory lf = context.getLiteralFactory();
+            return lf.zeroInitializerLiteralOfType(ts.getVoidType());
+        };
+
+        intrinsics.registerIntrinsic(Phase.ADD, referenceDesc, "reachabilityFence", objToVoid, reachabilityFence);
     }
 
     private static Value traverseLoads(Value value) {

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -64,6 +64,7 @@ import org.qbicc.graph.Or;
 import org.qbicc.graph.ParameterValue;
 import org.qbicc.graph.PhiValue;
 import org.qbicc.graph.PointerHandle;
+import org.qbicc.graph.Reachable;
 import org.qbicc.graph.ReadModifyWrite;
 import org.qbicc.graph.ReferenceHandle;
 import org.qbicc.graph.Return;
@@ -309,6 +310,13 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         } else {
             return builder.fence(OrderingConstraint.seq_cst);
         }
+    }
+
+    public Instruction visit(final Void unused, final Reachable node) {
+        map(node.getDependency());
+        map(node.getReachableValue());
+        // nothing actually emitted
+        return null;
     }
 
     // terminators


### PR DESCRIPTION
The following node types are added:

- `Reachable` - this node provides the implementation of `Reference.reachabilityFence(Object)`, by causing the given value to stay alive until at least that point
- `SafePoint` - this node represents a safepoint poll; no GC implements this (including NoGC) but this will eventually lower to e.g. a `test` instruction on the safepoint page address