### PR TITLE
Put classes in directories by class loader name

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/VmClassLoader.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmClassLoader.java
@@ -10,6 +10,13 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 public interface VmClassLoader extends VmObject {
     ClassContext getClassContext();
 
+    /**
+     * Get the name of this class loader.
+     *
+     * @return the class loader name (not {@code null})
+     */
+    String getName();
+
     VmClass loadClass(String name) throws Thrown;
 
     VmClass defineClass(VmString name, VmArray content, VmObject protectionDomain) throws Thrown;

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -348,6 +348,9 @@ final class CompilationContextImpl implements CompilationContext {
 
     public Path getOutputDirectory(final DefinedTypeDefinition type) {
         Path base = outputDir;
+        VmClassLoader classLoader = type.getContext().getClassLoader();
+        final String name = classLoader == null ? "boot" : classLoader.getName();
+        base = base.resolve(name);
         String internalName = type.getInternalName();
         if (type.isHidden()) {
             internalName += "~" + type.getHiddenClassIndex();


### PR DESCRIPTION
It is possible to define two classes with the same package and name when they are defined by different class loaders. This especially becomes true with applications that are compiled by frameworks which might define more than one class loader.

Put classes in different directories by class loader so that we don't end up clobbering same-named classes by accident.