### PR TITLE
Recursive block building API

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -5,6 +5,8 @@ import static org.qbicc.graph.atomic.AccessModes.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.qbicc.context.ClassContext;
 import org.qbicc.context.CompilationContext;
@@ -618,6 +620,31 @@ public interface BasicBlockBuilder extends Locatable {
      * @return the node representing the block entry
      */
     Node begin(BlockLabel blockLabel);
+
+    /**
+     * Begin a new block, suspending the current block until it is complete.
+     * If the maker throws a {@link BlockEarlyTermination}, then it will be caught before this method returns.
+     * If the maker does not terminate the block, an error will be raised and the block will be
+     * terminated as if by {@link #unreachable()}.
+     *
+     * @param blockLabel the label of the new block (must not be {@code null} or resolved)
+     * @param arg the argument to the maker
+     * @param maker the callback which builds the block (must not be {@code null})
+     * @return the resolved target of {@code blockLabel} (not {@code null})
+     * @param <T> the type of the argument to the maker
+     */
+    <T> BasicBlock begin(BlockLabel blockLabel, T arg, BiConsumer<T, BasicBlockBuilder> maker);
+
+    /**
+     * Begin a new block, suspending the current block until it is complete.
+     *
+     * @param blockLabel the label of the new block (must not be {@code null} or resolved)
+     * @param maker the callback which builds the block (must not be {@code null})
+     * @return the completed block (not {@code null})
+     */
+    default BasicBlock begin(BlockLabel blockLabel, Consumer<BasicBlockBuilder> maker) {
+        return begin(blockLabel, maker, Consumer::accept);
+    }
 
     /**
      * Establish that the given value is reachable at this point.

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -3,6 +3,7 @@ package org.qbicc.graph;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import org.qbicc.context.Location;
 import org.qbicc.graph.atomic.GlobalAccessMode;
@@ -369,6 +370,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
 
     public Node begin(final BlockLabel blockLabel) {
         return getDelegate().begin(blockLabel);
+    }
+
+    public <T> BasicBlock begin(BlockLabel blockLabel, T arg, BiConsumer<T, BasicBlockBuilder> maker) {
+        return getDelegate().begin(blockLabel, arg, maker);
     }
 
     public Node reachable(final Value value) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -808,6 +808,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
 
     private <T> BasicBlock doBegin(final BlockLabel blockLabel, final T arg, final BiConsumer<T, BasicBlockBuilder> maker) {
         try {
+            currentBlock = blockLabel;
+            if (firstBlock == null) {
+                firstBlock = blockLabel;
+            }
             dependency = blockEntry = new BlockEntry(callSite, element, blockLabel);
             parameters = SortedMaps.immutable.empty();
             maker.accept(arg, firstBuilder);

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import io.smallrye.common.constraint.Assert;
 import org.eclipse.collections.api.factory.SortedMaps;
@@ -765,6 +766,58 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder, BasicBlockBuil
             firstBlock = blockLabel;
         }
         return dependency = blockEntry = new BlockEntry(callSite, element, blockLabel);
+    }
+
+    @Override
+    public <T> BasicBlock begin(BlockLabel blockLabel, T arg, BiConsumer<T, BasicBlockBuilder> maker) {
+        if (!started) {
+            throw new IllegalStateException("begin() called before startMethod()");
+        }
+        Assert.checkNotNullParam("blockLabel", blockLabel);
+        Assert.checkNotNullParam("maker", maker);
+        if (blockLabel.hasTarget()) {
+            throw new IllegalStateException("Block already terminated");
+        }
+        // save all state on the stack
+        final ExceptionHandlerPolicy oldPolicy = policy;
+        final int oldLine = line;
+        final int oldBci = bci;
+        final Node oldDependency = dependency;
+        final BlockEntry oldBlockEntry = blockEntry;
+        final BlockLabel oldCurrentBlock = currentBlock;
+        final BasicBlock oldTerminatedBlock = terminatedBlock;
+        final ExecutableElement oldElement = element;
+        final Node oldCallSite = callSite;
+        final ImmutableSortedMap<Slot, BlockParameter> oldParameters = parameters;
+        try {
+            return doBegin(blockLabel, arg, maker);
+        } finally {
+            // restore all state
+            parameters = oldParameters;
+            callSite = oldCallSite;
+            element = oldElement;
+            terminatedBlock = oldTerminatedBlock;
+            currentBlock = oldCurrentBlock;
+            blockEntry = oldBlockEntry;
+            dependency = oldDependency;
+            bci = oldBci;
+            line = oldLine;
+            policy = oldPolicy;
+        }
+    }
+
+    private <T> BasicBlock doBegin(final BlockLabel blockLabel, final T arg, final BiConsumer<T, BasicBlockBuilder> maker) {
+        try {
+            dependency = blockEntry = new BlockEntry(callSite, element, blockLabel);
+            parameters = SortedMaps.immutable.empty();
+            maker.accept(arg, firstBuilder);
+            if (currentBlock != null) {
+                getContext().error(getLocation(), "Block not terminated");
+                firstBuilder.unreachable();
+            }
+        } catch (BlockEarlyTermination bet) {
+        }
+        return BlockLabel.getTargetOf(blockLabel);
     }
 
     public Node reachable(final Value value) {

--- a/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/DefinedTypeDefinitionImpl.java
@@ -341,11 +341,13 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
                                             bbb.startMethod(paramValues);
                                             // build the entry block
                                             BlockLabel entryLabel = new BlockLabel();
-                                            bbb.begin(entryLabel);
-                                            ClassContext bc = context.getCompilationContext().getBootstrapClassContext();
-                                            LoadedTypeDefinition vmHelpers = bc.findDefinedType("org/qbicc/runtime/main/VMHelpers").load();
-                                            MethodElement icce = vmHelpers.resolveMethodElementExact("raiseIncompatibleClassChangeError", MethodDescriptor.synthesize(bc, BaseTypeDescriptor.V, List.of()));
-                                            BasicBlock entryBlock = bbb.callNoReturn(bbb.staticMethod(icce), List.of());
+                                            BasicBlock entryBlock = bbb.begin(entryLabel, ib -> {
+                                                ClassContext bc = ib.getContext().getBootstrapClassContext();
+                                                LoadedTypeDefinition vmHelpers = bc.findDefinedType("org/qbicc/runtime/main/VMHelpers").load();
+                                                MethodElement icce = vmHelpers.resolveMethodElementExact("raiseIncompatibleClassChangeError", MethodDescriptor.synthesize(bc, BaseTypeDescriptor.V, List.of()));
+                                                ib.callNoReturn(ib.staticMethod(icce), List.of());
+                                            });
+                                            // that's all
                                             bbb.finish();
                                             Schedule schedule = Schedule.forMethod(entryBlock);
                                             return MethodBody.of(entryBlock, schedule, thisValue, paramValues);
@@ -387,10 +389,9 @@ final class DefinedTypeDefinitionImpl implements DefinedTypeDefinition {
                                     bbb.startMethod(paramValues);
                                     // build the entry block
                                     BlockLabel entryLabel = new BlockLabel();
-                                    bbb.begin(entryLabel);
                                     // just cast the list because it's fine; todo: maybe this method should accept List<? extends Value>
                                     //noinspection unchecked,rawtypes
-                                    BasicBlock entryBlock = bbb.tailCall(bbb.exactMethodOf(thisValue, finalDefaultMethod), (List<Value>) (List) paramValues);
+                                    BasicBlock entryBlock = bbb.begin(entryLabel, ib -> ib.tailCall(ib.exactMethodOf(thisValue, finalDefaultMethod), (List<Value>) (List) paramValues));
                                     bbb.finish();
                                     Schedule schedule = Schedule.forMethod(entryBlock);
                                     return MethodBody.of(entryBlock, schedule, thisValue, paramValues);

--- a/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
+++ b/plugins/try-catch/src/main/java/org/qbicc/plugin/trycatch/SynchronizedMethodBasicBlockBuilder.java
@@ -2,6 +2,7 @@ package org.qbicc.plugin.trycatch;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlock;
@@ -102,6 +103,20 @@ public class SynchronizedMethodBasicBlockBuilder extends DelegatingBasicBlockBui
             return monitorEnter;
         }
         return node;
+    }
+
+    @Override
+    public <T> BasicBlock begin(BlockLabel blockLabel, T arg, BiConsumer<T, BasicBlockBuilder> maker) {
+        if (! started) {
+            // method start
+            return super.begin(blockLabel, bbb -> {
+                started = true;
+                monitorEnter(monitor);
+                getDelegate().setExceptionHandlerPolicy(this);
+            });
+        } else {
+            return super.begin(blockLabel, arg, maker);
+        }
     }
 
     public BasicBlock return_(final Value value) {


### PR DESCRIPTION
Introduce a recursion-friendly block building API. The purpose behind this API is to be able to construct blocks in the midst of constructing another block. The API presents a cleaner way of handling block early termination (by completely preventing its escape). It also encourages a safer pattern of returning the first block created rather than the last (or some other) block (as may happen when a terminator call is intercepted and replaced with a complex subprogram).

Another problem that arises from the current architecture is that the concept of the "first" or "entry" block is vague at best. In some cases we're creating the "first" block second, causing some difficult wiring situations since the builder assumes the first block begun will be the entry block.

Using something like this recursive API exclusively has the advantage that the first block will always be the first block; we could for example cause all block building to `finish` when the first block is done, returning the entry block. We could ensure that further blocks are not built after the first block completes, and therefore that all successor blocks must be created within the lexical scope of the first block.

The following use cases would be expected to be solved by this API:

* Method parsing:
   * Creating exception handlers on demand at their first use site
   * Reduce the amount of saved state needed
* Inliner:
   * Creating the inlined control structure while the calling block is active allows the inliner to avoid creating extraneous control breaks when inlining is canceled due to cost
