### PR TITLE
Do not emit intrinsic which returns `null` in an `invoke` situation

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/IntrinsicBasicBlockBuilder.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/IntrinsicBasicBlockBuilder.java
@@ -235,9 +235,11 @@ public final class IntrinsicBasicBlockBuilder extends DelegatingBasicBlockBuilde
                 Value result = intrinsic.emitIntrinsic(getFirstBuilder(),
                     (StaticMethodElementHandle) target,
                     arguments);
-                ImmutableMap<Slot, Value> immutableMap = Maps.immutable.ofMap(targetArguments);
-                goto_(resumeLabel, immutableMap.newWithKeyValue(Slot.result(), result).castToMap());
-                return result;
+                if (result != null) {
+                    ImmutableMap<Slot, Value> immutableMap = Maps.immutable.ofMap(targetArguments);
+                    goto_(resumeLabel, immutableMap.newWithKeyValue(Slot.result(), result).castToMap());
+                    return result;
+                }
             }
         } else if (target instanceof InstanceMethodElementHandle) {
             InstanceMethodElementHandle decodedTarget = (InstanceMethodElementHandle) target;
@@ -249,9 +251,11 @@ public final class IntrinsicBasicBlockBuilder extends DelegatingBasicBlockBuilde
                     instance,
                     (InstanceMethodElementHandle) target,
                     arguments);
-                ImmutableMap<Slot, Value> immutableMap = Maps.immutable.ofMap(targetArguments);
-                goto_(resumeLabel, immutableMap.newWithKeyValue(Slot.result(), result).castToMap());
-                return result;
+                if (result != null) {
+                    ImmutableMap<Slot, Value> immutableMap = Maps.immutable.ofMap(targetArguments);
+                    goto_(resumeLabel, immutableMap.newWithKeyValue(Slot.result(), result).castToMap());
+                    return result;
+                }
             }
         }
         return super.invoke(target, arguments, catchLabel, resumeLabel, targetArguments);


### PR DESCRIPTION
The intrinsic contract is that if an intrinsic returns `null`, then it is not emitted at that call site. However, implementing this behavior for `Invoke` was overlooked.