### PR TITLE
Properly handle block types in LLVM

### DIFF
--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/Types.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/Types.java
@@ -29,6 +29,8 @@ public final class Types {
 
     public static final LLValue metadata = LLVM.metadata;
 
+    public static final LLValue label = LLVM.label;
+
     public static LLValue ptrTo(LLValue type) {
         return LLVM.ptrTo(type, 0);
     }

--- a/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/LLVM.java
+++ b/machine/llvm/src/main/java/org/qbicc/machine/llvm/impl/LLVM.java
@@ -47,6 +47,8 @@ public final class LLVM {
 
     public static final LLValue metadata = new MetadataType(null);
 
+    public static final LLValue label = new SingleWord("label");
+
     public static final LLValue ZERO = new IntConstant(0);
 
     public static final LLValue FALSE = new SingleWord("false");

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -48,6 +48,7 @@ import org.qbicc.pointer.Pointer;
 import org.qbicc.pointer.ProgramObjectPointer;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ArrayType;
+import org.qbicc.type.BlockType;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.FloatType;
@@ -190,6 +191,8 @@ final class LLVMModuleNodeVisitor implements ValueVisitor<Void, LLValue>, Pointe
             } else {
                 res = struct;
             }
+        } else if (type instanceof BlockType) {
+            res = label;
         } else {
             throw new IllegalStateException("Can't map Type("+ type.toString() + ")");
         }


### PR DESCRIPTION
Fill in a missing bit of LLVM lowering around block types. Mostly this impacts `jsr` handling, so not very critical.