### PR TITLE
Offline probe results (Main)

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -57,7 +57,6 @@ import org.qbicc.interpreter.impl.VmImpl;
 import org.qbicc.machine.arch.Cpu;
 import org.qbicc.machine.arch.Platform;
 import org.qbicc.machine.object.ObjectFileProvider;
-import org.qbicc.machine.probe.CProbe;
 import org.qbicc.machine.tool.CToolChain;
 import org.qbicc.machine.vfs.AbsoluteVirtualPath;
 import org.qbicc.machine.vfs.VFSUtils;
@@ -80,7 +79,6 @@ import org.qbicc.plugin.gc.common.GcCommon;
 import org.qbicc.plugin.gc.common.MultiNewArrayExpansionBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcSetupHook;
-import org.qbicc.plugin.gc.nogc.NoGcTypeSystemConfigurator;
 import org.qbicc.plugin.initializationcontrol.QbiccFeatureProcessor;
 import org.qbicc.plugin.instanceofcheckcast.InstanceOfCheckCastBasicBlockBuilder;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayBuilder;
@@ -173,7 +171,6 @@ import org.qbicc.plugin.vfs.VFS;
 import org.qbicc.plugin.vio.VIO;
 import org.qbicc.tool.llvm.LlvmToolChain;
 import org.qbicc.type.TypeSystem;
-import org.qbicc.type.definition.element.ExecutableElement;
 import picocli.CommandLine;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.ParseResult;
@@ -339,7 +336,9 @@ public class Main implements Callable<DiagnosticContext> {
                     // probe the basic system sizes
                     try {
                         PlatformTypeSystemLoader platformTypeSystemLoader = new PlatformTypeSystemLoader(
-                            platform, toolChain, objectFileProvider, initialContext, smallTypeIds, nogc);
+                            platform, toolChain, objectFileProvider, initialContext,
+                            PlatformTypeSystemLoader.ReferenceType.POINTER,
+                            smallTypeIds, nogc);
                         TypeSystem typeSystem = platformTypeSystemLoader.load();
 
                         {

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -337,80 +337,13 @@ public class Main implements Callable<DiagnosticContext> {
                     CToolChain toolChain = toolChains.next();
                     builder.setToolChain(toolChain);
                     // probe the basic system sizes
-                    CProbe.Builder probeBuilder = CProbe.builder();
-                    probeBuilder.include("<stdint.h>");
-                    probeBuilder.include("<limits.h>");
-                    // size and signedness of char
-                    CProbe.Type char_t = CProbe.Type.builder().setName("char").build();
-                    probeBuilder.probeType(char_t);
-                    // int sizes
-                    CProbe.Type int8_t = CProbe.Type.builder().setName("int8_t").build();
-                    probeBuilder.probeType(int8_t);
-                    CProbe.Type int16_t = CProbe.Type.builder().setName("int16_t").build();
-                    probeBuilder.probeType(int16_t);
-                    CProbe.Type int32_t = CProbe.Type.builder().setName("int32_t").build();
-                    probeBuilder.probeType(int32_t);
-                    CProbe.Type int64_t = CProbe.Type.builder().setName("int64_t").build();
-                    probeBuilder.probeType(int64_t);
-                    // float sizes
-                    CProbe.Type float_t = CProbe.Type.builder().setName("float").build();
-                    probeBuilder.probeType(float_t);
-                    CProbe.Type double_t = CProbe.Type.builder().setName("double").build();
-                    probeBuilder.probeType(double_t);
-                    // bool
-                    CProbe.Type _Bool = CProbe.Type.builder().setName("_Bool").build();
-                    probeBuilder.probeType(_Bool);
-                    // pointer
-                    CProbe.Type void_p = CProbe.Type.builder().setName("void *").build();
-                    probeBuilder.probeType(void_p);
-                    // number of bits in char
-                    probeBuilder.probeConstant("CHAR_BIT");
-                    // max alignment
-                    CProbe.Type max_align_t = CProbe.Type.builder().setName("max_align_t").build();
-                    probeBuilder.probeType(max_align_t);
-                    // execute
-                    CProbe probe = probeBuilder.build();
                     try {
-                        CProbe.Result probeResult = probe.run(toolChain, objectFileProvider, initialContext);
-                        if (probeResult == null) {
-                            initialContext.error("Type system probe compiler execution failed");
-                        } else {
-                            long charSize = probeResult.getTypeInfo(char_t).getSize();
-                            if (charSize != 1) {
-                                initialContext.error("Unexpected size of `char`: %d", Long.valueOf(charSize));
-                            }
-                            TypeSystem.Builder tsBuilder = TypeSystem.builder();
-                            tsBuilder.setBoolSize((int) probeResult.getTypeInfo(_Bool).getSize());
-                            tsBuilder.setBoolAlignment((int) probeResult.getTypeInfo(_Bool).getAlign());
-                            tsBuilder.setByteBits(probeResult.getConstantInfo("CHAR_BIT").getValueAsInt());
-                            tsBuilder.setSignedChar(probeResult.getTypeInfo(char_t).isSigned());
-                            tsBuilder.setInt8Size((int) probeResult.getTypeInfo(int8_t).getSize());
-                            tsBuilder.setInt8Alignment((int) probeResult.getTypeInfo(int8_t).getAlign());
-                            tsBuilder.setInt16Size((int) probeResult.getTypeInfo(int16_t).getSize());
-                            tsBuilder.setInt16Alignment((int) probeResult.getTypeInfo(int16_t).getAlign());
-                            tsBuilder.setInt32Size((int) probeResult.getTypeInfo(int32_t).getSize());
-                            tsBuilder.setInt32Alignment((int) probeResult.getTypeInfo(int32_t).getAlign());
-                            tsBuilder.setInt64Size((int) probeResult.getTypeInfo(int64_t).getSize());
-                            tsBuilder.setInt64Alignment((int) probeResult.getTypeInfo(int64_t).getAlign());
-                            tsBuilder.setFloat32Size((int) probeResult.getTypeInfo(float_t).getSize());
-                            tsBuilder.setFloat32Alignment((int) probeResult.getTypeInfo(float_t).getAlign());
-                            tsBuilder.setFloat64Size((int) probeResult.getTypeInfo(double_t).getSize());
-                            tsBuilder.setFloat64Alignment((int) probeResult.getTypeInfo(double_t).getAlign());
-                            tsBuilder.setPointerSize((int) probeResult.getTypeInfo(void_p).getSize());
-                            tsBuilder.setPointerAlignment((int) probeResult.getTypeInfo(void_p).getAlign());
-                            tsBuilder.setMaxAlignment((int) probeResult.getTypeInfo(max_align_t).getAlign());
-                            // todo: function alignment probe
-                            // for now, references == pointers
-                            tsBuilder.setReferenceSize((int) probeResult.getTypeInfo(void_p).getSize());
-                            tsBuilder.setReferenceAlignment((int) probeResult.getTypeInfo(void_p).getAlign());
-                            CProbe.Type type_id_type = smallTypeIds ? int16_t : int32_t;
-                            tsBuilder.setTypeIdSize((int) probeResult.getTypeInfo(type_id_type).getSize());
-                            tsBuilder.setTypeIdAlignment((int) probeResult.getTypeInfo(type_id_type).getAlign());
-                            tsBuilder.setEndianness(probeResult.getByteOrder());
-                            if (nogc) {
-                                new NoGcTypeSystemConfigurator().accept(tsBuilder);
-                            }
-                            builder.setTypeSystem(tsBuilder.build());
+                        PlatformTypeSystemLoader platformTypeSystemLoader = new PlatformTypeSystemLoader(
+                            platform, toolChain, objectFileProvider, initialContext, smallTypeIds, nogc);
+                        TypeSystem typeSystem = platformTypeSystemLoader.load();
+
+                        {
+                            builder.setTypeSystem(typeSystem);
                             // add additional manual initializers by chaining `.andThen(...)`
                             builder.setVmFactory(cc -> {
                                 CoreClasses.init(cc);

--- a/main/src/main/java/org/qbicc/main/PlatformTypeSystemLoader.java
+++ b/main/src/main/java/org/qbicc/main/PlatformTypeSystemLoader.java
@@ -1,0 +1,213 @@
+package org.qbicc.main;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.jboss.logging.Logger;
+import org.qbicc.context.DiagnosticContext;
+import org.qbicc.machine.arch.Platform;
+import org.qbicc.machine.object.ObjectFileProvider;
+import org.qbicc.machine.probe.CProbe;
+import org.qbicc.machine.tool.CToolChain;
+import org.qbicc.plugin.gc.nogc.NoGcTypeSystemConfigurator;
+import org.qbicc.type.TypeSystem;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteOrder;
+
+public class PlatformTypeSystemLoader {
+
+    private static final Logger log = Logger.getLogger("org.qbicc.main.PlatformTypeSystemLoader");
+
+    private static final CProbe.Type char_t = CProbe.Type.builder().setName("char").build();
+    private static final CProbe.Type int8_t = CProbe.Type.builder().setName("int8_t").build();
+    private static final CProbe.Type int16_t = CProbe.Type.builder().setName("int16_t").build();
+    private static final CProbe.Type int32_t = CProbe.Type.builder().setName("int32_t").build();
+    private static final CProbe.Type int64_t = CProbe.Type.builder().setName("int64_t").build();
+    private static final CProbe.Type float_t = CProbe.Type.builder().setName("float").build();
+    private static final CProbe.Type double_t = CProbe.Type.builder().setName("double").build();
+    private static final CProbe.Type _Bool = CProbe.Type.builder().setName("_Bool").build();
+    private static final CProbe.Type void_p = CProbe.Type.builder().setName("void *").build();
+    private static final CProbe.Type max_align_t = CProbe.Type.builder().setName("max_align_t").build();
+
+    private final Platform platform;
+    private final CToolChain toolChain;
+    private final ObjectFileProvider objectFileProvider;
+    private final DiagnosticContext initialContext;
+    private final boolean smallTypeIds;
+    private final boolean nogc;
+
+    public PlatformTypeSystemLoader(
+        Platform platform,
+        CToolChain toolChain,
+        ObjectFileProvider objectFileProvider,
+        DiagnosticContext initialContext,
+        boolean smallTypeIds,
+        boolean nogc) {
+        this.platform = platform;
+        this.toolChain = toolChain;
+        this.objectFileProvider = objectFileProvider;
+        this.initialContext = initialContext;
+        this.smallTypeIds = smallTypeIds;
+        this.nogc = nogc;
+    }
+
+    private static CProbe makeProbe() {
+        CProbe.Builder probeBuilder = CProbe.builder();
+        probeBuilder.include("<stdint.h>");
+        probeBuilder.include("<limits.h>");
+        // size and signedness of char
+        probeBuilder.probeType(char_t);
+        // int sizes
+        probeBuilder.probeType(int8_t);
+        probeBuilder.probeType(int16_t);
+        probeBuilder.probeType(int32_t);
+        probeBuilder.probeType(int64_t);
+        // float sizes
+        probeBuilder.probeType(float_t);
+        probeBuilder.probeType(double_t);
+        // bool
+        probeBuilder.probeType(_Bool);
+        // pointer
+        probeBuilder.probeType(void_p);
+        // number of bits in char
+        probeBuilder.probeConstant("CHAR_BIT");
+        // max alignment
+        probeBuilder.probeType(max_align_t);
+        // execute
+        return probeBuilder.build();
+    }
+
+    TypeSystem load() throws IOException {
+        TypeSystem typeSystem = this.fromYaml();
+        if (typeSystem == null) {
+            log.warnf("Failed to load type info for platform %s, using probe.", platform);
+            // no such manifest: use a probe
+            typeSystem = this.fromProbe();
+        }
+        return typeSystem;
+    }
+
+    TypeSystem fromProbe() throws IOException {
+        CProbe probe = makeProbe();
+        CProbe.Result probeResult = probe.run(toolChain, objectFileProvider, initialContext);
+        if (probeResult == null) {
+            initialContext.error("Type system probe compiler execution failed");
+        } else {
+            long charSize = probeResult.getTypeInfo(char_t).getSize();
+            if (charSize != 1) {
+                initialContext.error("Unexpected size of `char`: %d", Long.valueOf(charSize));
+            }
+            TypeSystem.Builder tsBuilder = TypeSystem.builder();
+            tsBuilder.setBoolSize((int) probeResult.getTypeInfo(_Bool).getSize());
+            tsBuilder.setBoolAlignment((int) probeResult.getTypeInfo(_Bool).getAlign());
+            tsBuilder.setByteBits(probeResult.getConstantInfo("CHAR_BIT").getValueAsInt());
+            tsBuilder.setSignedChar(probeResult.getTypeInfo(char_t).isSigned());
+            tsBuilder.setInt8Size((int) probeResult.getTypeInfo(int8_t).getSize());
+            tsBuilder.setInt8Alignment((int) probeResult.getTypeInfo(int8_t).getAlign());
+            tsBuilder.setInt16Size((int) probeResult.getTypeInfo(int16_t).getSize());
+            tsBuilder.setInt16Alignment((int) probeResult.getTypeInfo(int16_t).getAlign());
+            tsBuilder.setInt32Size((int) probeResult.getTypeInfo(int32_t).getSize());
+            tsBuilder.setInt32Alignment((int) probeResult.getTypeInfo(int32_t).getAlign());
+            tsBuilder.setInt64Size((int) probeResult.getTypeInfo(int64_t).getSize());
+            tsBuilder.setInt64Alignment((int) probeResult.getTypeInfo(int64_t).getAlign());
+            tsBuilder.setFloat32Size((int) probeResult.getTypeInfo(float_t).getSize());
+            tsBuilder.setFloat32Alignment((int) probeResult.getTypeInfo(float_t).getAlign());
+            tsBuilder.setFloat64Size((int) probeResult.getTypeInfo(double_t).getSize());
+            tsBuilder.setFloat64Alignment((int) probeResult.getTypeInfo(double_t).getAlign());
+            tsBuilder.setPointerSize((int) probeResult.getTypeInfo(void_p).getSize());
+            tsBuilder.setPointerAlignment((int) probeResult.getTypeInfo(void_p).getAlign());
+            tsBuilder.setMaxAlignment((int) probeResult.getTypeInfo(max_align_t).getAlign());
+            // todo: function alignment probe
+            // for now, references == pointers
+            tsBuilder.setReferenceSize((int) probeResult.getTypeInfo(void_p).getSize());
+            tsBuilder.setReferenceAlignment((int) probeResult.getTypeInfo(void_p).getAlign());
+            CProbe.Type type_id_type = smallTypeIds ? int16_t : int32_t;
+            tsBuilder.setTypeIdSize((int) probeResult.getTypeInfo(type_id_type).getSize());
+            tsBuilder.setTypeIdAlignment((int) probeResult.getTypeInfo(type_id_type).getAlign());
+            tsBuilder.setEndianness(probeResult.getByteOrder());
+            if (nogc) {
+                new NoGcTypeSystemConfigurator().accept(tsBuilder);
+            }
+
+            return tsBuilder.build();
+        }
+        return null;
+    }
+
+    TypeSystem fromYaml() throws IOException {
+        String fpath = "bundles/" + platform.toString() + "/platform-type-info.yaml";
+        InputStream stream = this.getClass().getClassLoader().getResourceAsStream(fpath);
+        if (stream == null) return null;
+        JsonNode jsonNode = new ObjectMapper(new YAMLFactory()).readTree(stream);
+        JsonNode platformTypeInfo = jsonNode.get("platform-type-info");
+
+        TypeSystem.Builder tsBuilder = TypeSystem.builder();
+
+        JsonNode boolean_t = platformTypeInfo.get("boolean");
+        tsBuilder.setBoolSize(boolean_t.get("size").asInt());
+        tsBuilder.setBoolAlignment(boolean_t.get("align").asInt());
+
+        tsBuilder.setByteBits(platformTypeInfo.get("byte-bits").asInt());
+
+        tsBuilder.setSignedChar(platformTypeInfo.get("signed-char").asBoolean());
+
+        JsonNode int8_t = platformTypeInfo.get("int8");
+        tsBuilder.setInt8Size(int8_t.get("size").asInt());
+        tsBuilder.setInt8Alignment(int8_t.get("align").asInt());
+
+        JsonNode int16_t = platformTypeInfo.get("int16");
+        tsBuilder.setInt16Size(int16_t.get("size").asInt());
+        tsBuilder.setInt16Alignment(int16_t.get("align").asInt());
+
+        JsonNode int32_t = platformTypeInfo.get("int32");
+        tsBuilder.setInt32Size(int32_t.get("size").asInt());
+        tsBuilder.setInt32Alignment(int32_t.get("align").asInt());
+
+        JsonNode int64_t = platformTypeInfo.get("int64");
+        tsBuilder.setInt64Size(int64_t.get("size").asInt());
+        tsBuilder.setInt64Alignment(int64_t.get("align").asInt());
+
+        JsonNode float32_t = platformTypeInfo.get("float32");
+        tsBuilder.setFloat32Size(float32_t.get("size").asInt());
+        tsBuilder.setFloat32Alignment(float32_t.get("align").asInt());
+
+        JsonNode float64_t = platformTypeInfo.get("float64");
+        tsBuilder.setFloat64Size(float64_t.get("size").asInt());
+        tsBuilder.setFloat64Alignment(float64_t.get("align").asInt());
+
+        JsonNode pointer_t = platformTypeInfo.get("pointer");
+        tsBuilder.setPointerSize(pointer_t.get("size").asInt());
+        tsBuilder.setPointerAlignment(pointer_t.get("align").asInt());
+
+        tsBuilder.setMaxAlignment(platformTypeInfo.get("max-alignment").asInt());
+        // todo: function alignment probe
+        // for now, references == pointers
+        JsonNode reference_t = platformTypeInfo.get("reference");
+
+        tsBuilder.setReferenceSize(reference_t.get("size").asInt());
+        tsBuilder.setReferenceAlignment(reference_t.get("align").asInt());
+
+        JsonNode type_id_t = smallTypeIds? int16_t : int32_t;
+        tsBuilder.setTypeIdSize(type_id_t.get("size").asInt());
+        tsBuilder.setTypeIdAlignment(type_id_t.get("align").asInt());
+
+        tsBuilder.setEndianness(endianness(platformTypeInfo.get("endian").asText()));
+
+        if (nogc) {
+            new NoGcTypeSystemConfigurator().accept(tsBuilder);
+        }
+
+        return tsBuilder.build();
+    }
+
+    ByteOrder endianness(String endianness) {
+        return switch (endianness) {
+            case "little" -> ByteOrder.LITTLE_ENDIAN;
+            case "big" -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IllegalArgumentException(endianness);
+        };
+    }
+}
+

--- a/main/src/main/resources/bundles/wasm32-wasi-unknown-wasm/platform-type-info.yaml
+++ b/main/src/main/resources/bundles/wasm32-wasi-unknown-wasm/platform-type-info.yaml
@@ -6,9 +6,6 @@ platform-type-info:
     pointer:
         size: 4
         align: 4
-    reference:
-        size: 4
-        align: 4
     boolean:
         size: 1
         align: 1

--- a/main/src/main/resources/bundles/wasm32-wasi-unknown-wasm/platform-type-info.yaml
+++ b/main/src/main/resources/bundles/wasm32-wasi-unknown-wasm/platform-type-info.yaml
@@ -1,0 +1,33 @@
+platform-type-info:
+    byte-bits: 8
+    endian: little
+    signed-char: true
+    max-alignment: 8
+    pointer:
+        size: 4
+        align: 4
+    reference:
+        size: 4
+        align: 4
+    boolean:
+        size: 1
+        align: 1
+    int8:
+        size: 1
+        align: 1
+    int16:
+        size: 2
+        align: 2
+    int32:
+        size: 4
+        align: 4
+    int64:
+        size: 8
+        align: 8
+    float32:
+        size: 4
+        align: 4
+    float64:
+        size: 8
+        align: 8
+

--- a/main/src/main/resources/bundles/x86_64-darwin-unknown-macho/platform-type-info.yaml
+++ b/main/src/main/resources/bundles/x86_64-darwin-unknown-macho/platform-type-info.yaml
@@ -1,0 +1,33 @@
+platform-type-info:
+    byte-bits: 8
+    endian: little
+    signed-char: true
+    max-alignment: 16
+    pointer:
+        size: 8
+        align: 8
+    reference:
+        size: 8
+        align: 8
+    boolean:
+        size: 1
+        align: 1
+    int8:
+        size: 1
+        align: 1
+    int16:
+        size: 2
+        align: 2
+    int32:
+        size: 4
+        align: 4
+    int64:
+        size: 8
+        align: 8
+    float32:
+        size: 4
+        align: 4
+    float64:
+        size: 8
+        align: 8
+

--- a/main/src/main/resources/bundles/x86_64-darwin-unknown-macho/platform-type-info.yaml
+++ b/main/src/main/resources/bundles/x86_64-darwin-unknown-macho/platform-type-info.yaml
@@ -6,9 +6,6 @@ platform-type-info:
     pointer:
         size: 8
         align: 8
-    reference:
-        size: 8
-        align: 8
     boolean:
         size: 1
         align: 1

--- a/main/src/main/resources/bundles/x86_64-linux-gnu-elf/platform-type-info.yaml
+++ b/main/src/main/resources/bundles/x86_64-linux-gnu-elf/platform-type-info.yaml
@@ -1,0 +1,33 @@
+platform-type-info:
+    byte-bits: 8
+    endian: little
+    signed-char: true
+    max-alignment: 16
+    pointer:
+        size: 8
+        align: 8
+    reference:
+        size: 8
+        align: 8
+    boolean:
+        size: 1
+        align: 1
+    int8:
+        size: 1
+        align: 1
+    int16:
+        size: 2
+        align: 2
+    int32:
+        size: 4
+        align: 4
+    int64:
+        size: 8
+        align: 8
+    float32:
+        size: 4
+        align: 4
+    float64:
+        size: 8
+        align: 8
+

--- a/main/src/main/resources/bundles/x86_64-linux-gnu-elf/platform-type-info.yaml
+++ b/main/src/main/resources/bundles/x86_64-linux-gnu-elf/platform-type-info.yaml
@@ -6,9 +6,6 @@ platform-type-info:
     pointer:
         size: 8
         align: 8
-    reference:
-        size: 8
-        align: 8
     boolean:
         size: 1
         align: 1


### PR DESCRIPTION
Add a `PlatformTypeSystemLoader` on `Main`. It looks for a `bundles/${platform}/platform-type-info.yaml` config. 
If missing, it will try to synthesize it using CProbes.

First attempt at doing this. Layout and position of the files may vary.
Other probes are a little more scattered, so I will do a separate PR for them. 
In the meantime we can get right the first few details here.

(follow up to the experiments in https://github.com/qbicc/qbicc/pull/1499, addresses part of #1493)