### PR TITLE
qbicc-side of runtime resource support

### DIFF
--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -50,6 +50,7 @@ import org.qbicc.driver.ElementVisitorAdapter;
 import org.qbicc.driver.GraphGenConfig;
 import org.qbicc.driver.Phase;
 import org.qbicc.driver.plugin.DriverPlugin;
+import org.qbicc.plugin.initializationcontrol.RuntimeResourceManager;
 import org.qbicc.plugin.reachability.ReachabilityFactsSetup;
 import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmThread;
@@ -492,6 +493,12 @@ public class Main implements Callable<DiagnosticContext> {
                                     Vm vm = ctxt.getVm();
                                     vm.doAttached(vm.newThread("ServiceProvider Serialization", vm.getMainThreadGroup(), false, Thread.currentThread().getPriority()), () -> {
                                         ServiceLoaderAnalyzer.get(ctxt).serializeProviderConfig();
+                                    });
+                                });
+                                builder.addPostHook(Phase.ADD, ctxt -> {
+                                    Vm vm = ctxt.getVm();
+                                    vm.doAttached(vm.newThread("Resource Serialization", vm.getMainThreadGroup(), false, Thread.currentThread().getPriority()), () -> {
+                                        RuntimeResourceManager.get(ctxt).findAndSerializeResources();
                                     });
                                 });
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::reportStats);

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeature.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeature.java
@@ -2,4 +2,6 @@ package org.qbicc.plugin.initializationcontrol;
 
 final class QbiccFeature {
     String[] initializeAtRuntime;
+    String[] runtimeResource;  // ClassLoader.findResource
+    String[] runtimeResources; // ClassLoader.findResources
 }

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureProcessor.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureProcessor.java
@@ -19,11 +19,14 @@ public class QbiccFeatureProcessor {
         if (features.isEmpty()) {
             return;
         }
+        FeaturePatcher fp = FeaturePatcher.get(ctxt);
+        RuntimeResourceManager rm = RuntimeResourceManager.get(ctxt);
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
 
         for (Path feature: features) {
             QbiccFeature qf;
@@ -39,9 +42,21 @@ public class QbiccFeatureProcessor {
             }
 
             ctxt.info("Processing build feature %s", feature);
-            for (String className: qf.initializeAtRuntime) {
-                String internalName = className.replace('.', '/');
-                FeaturePatcher.get(ctxt).addRuntimeInitializedClass(internalName);
+            if (qf.initializeAtRuntime != null) {
+                for (String className : qf.initializeAtRuntime) {
+                    String internalName = className.replace('.', '/');
+                    fp.addRuntimeInitializedClass(internalName);
+                }
+            }
+            if (qf.runtimeResource != null) {
+                for (String name : qf.runtimeResource) {
+                    rm.addResource(name);
+                }
+            }
+            if (qf.runtimeResources != null) {
+                for (String name : qf.runtimeResources) {
+                    rm.addResources(name);
+                }
             }
         }
     }

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/RuntimeResourceManager.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/RuntimeResourceManager.java
@@ -1,0 +1,72 @@
+package org.qbicc.plugin.initializationcontrol;
+
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.interpreter.Vm;
+import org.qbicc.interpreter.VmArray;
+import org.qbicc.interpreter.VmClassLoader;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.plugin.apploader.AppClassLoader;
+import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.element.MethodElement;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RuntimeResourceManager {
+    private static final AttachmentKey<RuntimeResourceManager> KEY = new AttachmentKey<>();
+
+    private final CompilationContext ctxt;
+    private final Set<String> runtimeResource = ConcurrentHashMap.newKeySet();
+    private final Set<String> runtimeResources = ConcurrentHashMap.newKeySet();
+
+    RuntimeResourceManager(CompilationContext ctxt) {
+        this.ctxt = ctxt;
+    }
+
+    public static RuntimeResourceManager get(CompilationContext ctxt) {
+        RuntimeResourceManager patcher = ctxt.getAttachment(KEY);
+        if (patcher == null) {
+            patcher = new RuntimeResourceManager(ctxt);
+            RuntimeResourceManager appearing = ctxt.putAttachmentIfAbsent(KEY, patcher);
+            if (appearing != null) {
+                patcher = appearing;
+            }
+        }
+        return patcher;
+    }
+
+    public void addResource(String name) {
+        runtimeResource.add(name);
+    }
+
+    public void addResources(String name) {
+        runtimeResources.add(name);
+    }
+
+    public void findAndSerializeResources() {
+        if (runtimeResource.isEmpty() && runtimeResources.isEmpty()) {
+            return;
+        }
+        VmClassLoader appCl = AppClassLoader.get(ctxt).getAppClassLoader();
+        ClassContext appContext = appCl.getClassContext();
+        LoadedTypeDefinition nir = appContext.findDefinedType("jdk/internal/loader/NativeImageResources").load();
+        MethodElement addResource = nir.requireSingleMethod("addResource");
+        Vm vm = appContext.getCompilationContext().getVm();
+        for (String name: runtimeResource) {
+            byte[] bytes = appContext.getResource(name);
+            if (bytes != null) {
+                vm.invokeExact(addResource, null, List.of(appCl, name, vm.newByteArray(bytes)));
+            }
+        }
+        for (String name: runtimeResources) {
+            List<byte[]> bytes = appContext.getResources(name);
+            for (byte[] b: bytes) {
+                vm.invokeExact(addResource, null, List.of(appCl, name, vm.newByteArray(b)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Needs https://github.com/qbicc/qbicc-class-library/pull/305 to actually work, but should be harmless to merge independently since the code that needs the library support is only active if we feed the compiler a `qbicc-feature.yaml` that defines `runtimeResource` or `runtimeResources`.

I'll extend the ResourceLoading test snippet to include tests for this functionality after we merge both sides and get a classlib release.