### PR TITLE
Introduce switchable safepoint strategy

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFile.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassFile.java
@@ -92,6 +92,12 @@ public interface ClassFile extends FieldResolver,
      */
     int I_ACC_PRIMITIVE = 1 << 17;
     /**
+     * For methods which cannot be interrupted with a safepoint.
+     * Such methods should only call other methods that are not interruptible.
+     * Methods which are uninterruptible must be {@code final} or {@code static}.
+     */
+    int I_ACC_NO_SAFEPOINTS = 1 << 17;
+    /**
      * On methods, hide from stack traces.  On classes, defined as a JEP 371 "hidden class".
      */
     int I_ACC_HIDDEN = 1 << 18;

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -77,6 +77,8 @@ import org.qbicc.plugin.dispatch.DispatchTableEmitter;
 import org.qbicc.plugin.dot.DotGenerator;
 import org.qbicc.plugin.gc.common.GcCommon;
 import org.qbicc.plugin.gc.common.MultiNewArrayExpansionBasicBlockBuilder;
+import org.qbicc.plugin.gc.common.safepoint.SafePointPlacementBasicBlockBuilder;
+import org.qbicc.plugin.gc.common.safepoint.SafePoints;
 import org.qbicc.plugin.gc.nogc.NoGcBasicBlockBuilder;
 import org.qbicc.plugin.gc.nogc.NoGcSetupHook;
 import org.qbicc.plugin.initializationcontrol.QbiccFeatureProcessor;
@@ -411,9 +413,11 @@ public class Main implements Callable<DiagnosticContext> {
                                     vm.doAttached(vm.newThread(Thread.currentThread().getName(), vm.getMainThreadGroup(), false, Thread.currentThread().getPriority()), () -> wrapper.accept(ctxt));
                                 });
                                 builder.addPreHook(Phase.ADD, ReachabilityFactsSetup::setupAdd);
+                                builder.addPreHook(Phase.ADD, ctxt -> SafePoints.selectStrategy(ctxt, SafePoints.Strategy.GLOBAL_FLAG));
                                 if (llvm) {
                                     builder.addPreHook(Phase.ADD, LLVMIntrinsics::register);
                                 }
+                                builder.addPreHook(Phase.ADD, SafePoints::enqueueMethods);
                                 builder.addPreHook(Phase.ADD, CoreIntrinsics::register);
                                 builder.addPreHook(Phase.ADD, CoreClasses::get);
                                 builder.addPreHook(Phase.ADD, ReflectionIntrinsics::register);
@@ -498,6 +502,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPostHook(Phase.ADD, ReachabilityInfo::clear);
 
                                 builder.addPreHook(Phase.ANALYZE, ReachabilityFactsSetup::setupAnalyze);
+                                builder.addPreHook(Phase.ANALYZE, SafePoints::enqueueMethods);
                                 builder.addPreHook(Phase.ANALYZE, new VMHelpersSetupHook());
                                 builder.addPreHook(Phase.ANALYZE, ReachabilityInfo::forceCoreClassesReachable);
                                 builder.addPreHook(Phase.ANALYZE, ReachabilityRoots::processRootsForAnalyze);
@@ -541,6 +546,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addPostHook(Phase.ANALYZE, new SupersDisplayBuilder());
 
                                 builder.addPreHook(Phase.LOWER, ReachabilityFactsSetup::setupLower);
+                                builder.addPreHook(Phase.LOWER, SafePoints::enqueueMethods);
                                 builder.addPreHook(Phase.LOWER, ReachabilityRoots::processRootsForLower);
                                 builder.addPreHook(Phase.LOWER, new ClassObjectSerializer());
                                 if (optEscapeAnalysis) {
@@ -558,6 +564,7 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addCopyFactory(Phase.LOWER, MemberPointerCopier::new);
                                 builder.addCopyFactory(Phase.LOWER, ObjectLiteralSerializingVisitor::new);
 
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, SafePointPlacementBasicBlockBuilder::createIfNeeded);
                                 if (isWasm) {
                                     builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, AbortingThrowLoweringBasicBlockBuilder::new);
                                 } else {
@@ -578,13 +585,14 @@ public class Main implements Callable<DiagnosticContext> {
                                 if (llvm) {
                                     builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LLVMCompatibleBasicBlockBuilder::new);
                                 }
-                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.OPTIMIZE, SimpleOptBasicBlockBuilder::new);
                                 if (optMemoryTracking) {
                                     builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, LocalMemoryTrackingBasicBlockBuilder::new);
                                 }
-                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, LowerVerificationBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, SafePoints::createBasicBlockBuilder);
                                 // To avoid serializing Strings we won't need, MethodDataStringsSerializer should be the last "real" BBB
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.TRANSFORM, MethodDataStringsSerializer::new);
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.OPTIMIZE, SimpleOptBasicBlockBuilder::new);
+                                builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, LowerVerificationBasicBlockBuilder::new);
                                 builder.addBuilderFactory(Phase.LOWER, BuilderStage.INTEGRITY, StaticChecksBasicBlockBuilder::new);
                                 builder.addPostHook(Phase.LOWER, NativeXtorLoweringHook::process);
                                 builder.addPostHook(Phase.LOWER, BuildtimeHeap::reportStats);

--- a/plugins/core/src/main/java/org/qbicc/plugin/core/CoreAnnotationTypeBuilder.java
+++ b/plugins/core/src/main/java/org/qbicc/plugin/core/CoreAnnotationTypeBuilder.java
@@ -27,6 +27,7 @@ public final class CoreAnnotationTypeBuilder implements DefinedTypeDefinition.Bu
     private final ClassTypeDescriptor jdkHidden;
     private final ClassTypeDescriptor noReflect;
     private final ClassTypeDescriptor noReturn;
+    private final ClassTypeDescriptor noSafePoint;
     private final ClassTypeDescriptor noThrow;
     private final ClassTypeDescriptor inline;
     private final ClassTypeDescriptor fold;
@@ -40,6 +41,7 @@ public final class CoreAnnotationTypeBuilder implements DefinedTypeDefinition.Bu
         jdkHidden = ClassTypeDescriptor.synthesize(classCtxt, "jdk/internal/vm/annotation/Hidden");
         noReflect = ClassTypeDescriptor.synthesize(classCtxt, "org/qbicc/runtime/NoReflect");
         noReturn = ClassTypeDescriptor.synthesize(classCtxt, "org/qbicc/runtime/NoReturn");
+        noSafePoint = ClassTypeDescriptor.synthesize(classCtxt, "org/qbicc/runtime/NoSafePoint");
         noThrow = ClassTypeDescriptor.synthesize(classCtxt, "org/qbicc/runtime/NoThrow");
         inline = ClassTypeDescriptor.synthesize(classCtxt, "org/qbicc/runtime/Inline");
         fold = ClassTypeDescriptor.synthesize(classCtxt, "org/qbicc/runtime/Fold");
@@ -66,6 +68,8 @@ public final class CoreAnnotationTypeBuilder implements DefinedTypeDefinition.Bu
                         methodElement.setModifierFlags(ClassFile.I_ACC_NO_RETURN);
                     } else if (annotation.getDescriptor().equals(noReflect)) {
                         methodElement.setModifierFlags(ClassFile.I_ACC_NO_REFLECT);
+                    } else if (annotation.getDescriptor().equals(noSafePoint)) {
+                        methodElement.setModifierFlags(ClassFile.I_ACC_NO_SAFEPOINTS);
                     } else if (annotation.getDescriptor().equals(noThrow)) {
                         methodElement.setModifierFlags(ClassFile.I_ACC_NO_THROW);
                     } else if (annotation.getDescriptor().equals(inline)) {

--- a/plugins/gc/common/pom.xml
+++ b/plugins/gc/common/pom.xml
@@ -29,5 +29,9 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-plugin-layout</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>qbicc-plugin-patcher</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/AbstractMethodBasedSafePointStrategy.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/AbstractMethodBasedSafePointStrategy.java
@@ -1,0 +1,48 @@
+package org.qbicc.plugin.gc.common.safepoint;
+
+import static org.qbicc.type.descriptor.MethodDescriptor.VOID_METHOD_DESCRIPTOR;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.qbicc.context.ClassContext;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.plugin.patcher.Patcher;
+import org.qbicc.type.definition.element.StaticMethodElement;
+
+/**
+ * The base class for safepoint strategies which use a method call to poll for a safepoint.
+ */
+public abstract class AbstractMethodBasedSafePointStrategy extends AbstractSafePointStrategy {
+
+    private static final String POLL_SAFE_POINT = "pollSafePoint";
+
+    /**
+     * Construct a new instance.
+     * The constructor should inject any additional fields or methods needed to implement the strategy.
+     *
+     * @param ctxt the compilation context
+     */
+    protected AbstractMethodBasedSafePointStrategy(CompilationContext ctxt) {
+        super(ctxt);
+        final Patcher patcher = Patcher.get(ctxt);
+        patcher.replaceMethodBody(ctxt.getBootstrapClassContext(), SAFE_POINT_INT_NAME, POLL_SAFE_POINT, VOID_METHOD_DESCRIPTOR, adapt(this::implementPollSafePoint), 0);
+    }
+
+    @Override
+    protected void forEachSafePointMethod(Consumer<String> consumer) {
+        super.forEachSafePointMethod(consumer);
+        consumer.accept(POLL_SAFE_POINT);
+    }
+
+    @Override
+    public void safePoint(BasicBlockBuilder bbb) {
+        final ClassContext bcc = bbb.getContext().getBootstrapClassContext();
+        final StaticMethodElement pollSafePoint = (StaticMethodElement) bcc.findDefinedType(SAFE_POINT_INT_NAME).load().requireSingleMethod(POLL_SAFE_POINT);
+        bbb.call(bbb.staticMethod(pollSafePoint), List.of());
+    }
+
+    public abstract void implementPollSafePoint(BasicBlockBuilder bbb);
+
+}

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/AbstractSafePointStrategy.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/AbstractSafePointStrategy.java
@@ -1,0 +1,89 @@
+package org.qbicc.plugin.gc.common.safepoint;
+
+import static org.qbicc.type.descriptor.MethodDescriptor.VOID_METHOD_DESCRIPTOR;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.ParameterValue;
+import org.qbicc.graph.schedule.Schedule;
+import org.qbicc.plugin.patcher.Patcher;
+import org.qbicc.type.definition.LoadedTypeDefinition;
+import org.qbicc.type.definition.MethodBody;
+import org.qbicc.type.definition.MethodBodyFactory;
+
+/**
+ * The base class for safe point polling strategy implementation.
+ */
+public abstract class AbstractSafePointStrategy {
+    static final String SAFE_POINT_INT_NAME = "org/qbicc/runtime/main/SafePoint";
+
+    private static final String ENTER_SAFE_POINT = "enterSafePoint";
+    private static final String REQUEST_GLOBAL_SAFE_POINT = "requestGlobalSafePoint";
+    private static final String CLEAR_GLOBAL_SAFE_POINT = "clearGlobalSafePoint";
+
+    protected final CompilationContext ctxt;
+
+    /**
+     * Construct a new instance.
+     * The constructor should inject any additional fields or methods needed to implement the strategy.
+     *
+     * @param ctxt the compilation context
+     */
+    protected AbstractSafePointStrategy(CompilationContext ctxt) {
+        this.ctxt = ctxt;
+        final Patcher patcher = Patcher.get(ctxt);
+        patcher.replaceMethodBody(ctxt.getBootstrapClassContext(), SAFE_POINT_INT_NAME, REQUEST_GLOBAL_SAFE_POINT, VOID_METHOD_DESCRIPTOR, adapt(this::implementRequestGlobalSafePoint), 0);
+        patcher.replaceMethodBody(ctxt.getBootstrapClassContext(), SAFE_POINT_INT_NAME, CLEAR_GLOBAL_SAFE_POINT, VOID_METHOD_DESCRIPTOR, adapt(this::implementClearGlobalSafePoint), 0);
+    }
+
+    static MethodBodyFactory adapt(Consumer<BasicBlockBuilder> consumer) {
+        return (index, element) -> {
+            BasicBlockBuilder bbb = element.getEnclosingType().getContext().newBasicBlockBuilder(element);
+            final List<ParameterValue> params = List.of();
+            bbb.startMethod(params);
+            consumer.accept(bbb);
+            bbb.finish();
+            final BasicBlock entry = bbb.getFirstBlock();
+            return MethodBody.of(entry, Schedule.forMethod(entry), null, params);
+        };
+    }
+
+    public final void registerReachableMethods(CompilationContext ctxt) {
+        final LoadedTypeDefinition safePointClass = ctxt.getBootstrapClassContext().findDefinedType(SAFE_POINT_INT_NAME).load();
+        forEachSafePointMethod(name -> ctxt.enqueue(safePointClass.requireSingleMethod(name)));
+    }
+
+    protected void forEachSafePointMethod(Consumer<String> consumer) {
+        consumer.accept(ENTER_SAFE_POINT);
+        consumer.accept(REQUEST_GLOBAL_SAFE_POINT);
+        consumer.accept(CLEAR_GLOBAL_SAFE_POINT);
+    }
+
+    /**
+     * Implement the {@code SafePoint} node.
+     * This method is called during lowering to implement the actual action of a safepoint poll.
+     *
+     * @param bbb the block builder (not {@code null})
+     */
+    public abstract void safePoint(BasicBlockBuilder bbb);
+
+    /**
+     * Implement the method which requests a global safepoint.
+     * The implementation must not throw any exception, poll for a safepoint, or call any method that may do either.
+     *
+     * @param bbb the block builder (not {@code null})
+     */
+    public abstract void implementRequestGlobalSafePoint(BasicBlockBuilder bbb);
+
+    /**
+     * Implement the method which clears a global safepoint request.
+     * The implementation must not throw any exception, poll for a safepoint, or call any method that may do either.
+     *
+     * @param bbb the block builder (not {@code null})
+     */
+    public abstract void implementClearGlobalSafePoint(BasicBlockBuilder bbb);
+}

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/GlobalFlagSafePointStrategy.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/GlobalFlagSafePointStrategy.java
@@ -1,0 +1,80 @@
+package org.qbicc.plugin.gc.common.safepoint;
+
+import static org.qbicc.graph.atomic.AccessModes.SingleAcquire;
+import static org.qbicc.graph.atomic.AccessModes.SingleRelease;
+
+import java.util.List;
+import java.util.Map;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.BlockEarlyTermination;
+import org.qbicc.graph.BlockLabel;
+import org.qbicc.graph.Value;
+import org.qbicc.graph.literal.LiteralFactory;
+import org.qbicc.plugin.patcher.Patcher;
+import org.qbicc.type.definition.FieldResolver;
+import org.qbicc.type.definition.classfile.ClassFile;
+import org.qbicc.type.definition.element.FieldElement;
+import org.qbicc.type.definition.element.StaticMethodElement;
+import org.qbicc.type.descriptor.BaseTypeDescriptor;
+import org.qbicc.type.generic.TypeSignature;
+
+/**
+ * A safepoint polling strategy which uses a single global flag field to indicate that a safepoint should be entered.
+ */
+public final class GlobalFlagSafePointStrategy extends AbstractMethodBasedSafePointStrategy {
+
+    private static final String REQUEST_SAFE_POINT_FIELD = "requestSafePoint";
+
+    public GlobalFlagSafePointStrategy(CompilationContext ctxt) {
+        super(ctxt);
+        final Patcher patcher = Patcher.get(ctxt);
+        FieldResolver requestSafePointResolver = (index, enclosing, builder) -> {
+            builder.setModifiers(ClassFile.ACC_PRIVATE | ClassFile.ACC_STATIC | ClassFile.I_ACC_NO_REFLECT);
+            builder.setEnclosingType(enclosing);
+            builder.setSignature(TypeSignature.synthesize(enclosing.getContext(), builder.getDescriptor()));
+            return builder.build();
+        };
+        patcher.addField(ctxt.getBootstrapClassContext(), SAFE_POINT_INT_NAME, REQUEST_SAFE_POINT_FIELD, BaseTypeDescriptor.Z, requestSafePointResolver, 0, 0);
+    }
+
+    private FieldElement getField() {
+        return ctxt.getBootstrapClassContext().findDefinedType(SAFE_POINT_INT_NAME).load().resolveField(BaseTypeDescriptor.Z, REQUEST_SAFE_POINT_FIELD);
+    }
+
+    @Override
+    public void implementRequestGlobalSafePoint(BasicBlockBuilder bbb) {
+        final LiteralFactory lf = bbb.getLiteralFactory();
+        bbb.begin(new BlockLabel());
+        bbb.store(bbb.staticField(getField()), lf.literalOf(true), SingleRelease);
+        bbb.return_();
+    }
+
+    @Override
+    public void implementClearGlobalSafePoint(BasicBlockBuilder bbb) {
+        final LiteralFactory lf = bbb.getLiteralFactory();
+        bbb.begin(new BlockLabel());
+        bbb.store(bbb.staticField(getField()), lf.literalOf(false), SingleRelease);
+        bbb.return_();
+    }
+
+    @Override
+    public void implementPollSafePoint(BasicBlockBuilder bbb) {
+        bbb.begin(new BlockLabel());
+        final Value flag = bbb.load(bbb.staticField(getField()), SingleAcquire);
+        BlockLabel enterSafePoint = new BlockLabel();
+        BlockLabel resume = new BlockLabel();
+        bbb.if_(flag, enterSafePoint, resume, Map.of());
+        try {
+            bbb.begin(enterSafePoint);
+            final StaticMethodElement enterSafePointMethod = (StaticMethodElement) bbb.getContext().getBootstrapClassContext().findDefinedType(SAFE_POINT_INT_NAME).load().requireSingleMethod("enterSafePoint");
+            // directly enter the safe point work method
+            bbb.tailCall(bbb.staticMethod(enterSafePointMethod), List.of());
+        } catch (BlockEarlyTermination ignored) {}
+        try {
+            bbb.begin(resume);
+            bbb.return_();
+        } catch (BlockEarlyTermination ignored) {}
+    }
+}

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/NoSafePointStrategy.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/NoSafePointStrategy.java
@@ -1,0 +1,34 @@
+package org.qbicc.plugin.gc.common.safepoint;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+
+/**
+ * A safepoint strategy where no safepoints may be entered.
+ */
+public final class NoSafePointStrategy extends AbstractSafePointStrategy {
+
+    /**
+     * Construct a new instance.
+     *
+     * @param ctxt the compilation context
+     */
+    public NoSafePointStrategy(CompilationContext ctxt) {
+        super(ctxt);
+    }
+
+    @Override
+    public void safePoint(BasicBlockBuilder bbb) {
+        // no operation
+    }
+
+    @Override
+    public void implementRequestGlobalSafePoint(BasicBlockBuilder bbb) {
+        // no operation
+    }
+
+    @Override
+    public void implementClearGlobalSafePoint(BasicBlockBuilder bbb) {
+        // no operation
+    }
+}

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/SafePointPlacementBasicBlockBuilder.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/SafePointPlacementBasicBlockBuilder.java
@@ -1,0 +1,34 @@
+package org.qbicc.plugin.gc.common.safepoint;
+
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlock;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Value;
+import org.qbicc.type.definition.classfile.ClassFile;
+
+/**
+ * Block builder which places safepoint polls.
+ */
+public final class SafePointPlacementBasicBlockBuilder extends DelegatingBasicBlockBuilder {
+    private SafePointPlacementBasicBlockBuilder(BasicBlockBuilder delegate) {
+        super(delegate);
+    }
+
+    public static BasicBlockBuilder createIfNeeded(CompilationContext ctxt, BasicBlockBuilder delegate) {
+        final boolean noSafePoints = delegate.getCurrentElement().hasAllModifiersOf(ClassFile.I_ACC_NO_SAFEPOINTS);
+        return noSafePoints ? delegate : new SafePointPlacementBasicBlockBuilder(delegate);
+    }
+
+    @Override
+    public BasicBlock return_(Value value) {
+        safePoint();
+        return super.return_(value);
+    }
+
+    @Override
+    public BasicBlock throw_(Value value) {
+        safePoint();
+        return super.throw_(value);
+    }
+}

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/SafePoints.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/safepoint/SafePoints.java
@@ -1,0 +1,63 @@
+package org.qbicc.plugin.gc.common.safepoint;
+
+import org.qbicc.context.AttachmentKey;
+import org.qbicc.context.CompilationContext;
+import org.qbicc.graph.BasicBlockBuilder;
+import org.qbicc.graph.DelegatingBasicBlockBuilder;
+import org.qbicc.graph.Node;
+
+/**
+ *
+ */
+public final class SafePoints {
+    private static final AttachmentKey<AbstractSafePointStrategy> IMPL_KEY = new AttachmentKey<>();
+
+    private SafePoints() {}
+
+    public static void selectStrategy(CompilationContext ctxt, Strategy strategy) {
+        final AbstractSafePointStrategy existing = ctxt.putAttachmentIfAbsent(IMPL_KEY, strategy.create(ctxt));
+        if (existing != null) {
+            throw new IllegalStateException("Already installed");
+        }
+    }
+
+    public static void enqueueMethods(CompilationContext ctxt) {
+        ctxt.getAttachment(IMPL_KEY).registerReachableMethods(ctxt);
+    }
+
+    /**
+     * Create the basic block builder for the selected strategy.
+     *
+     * @param ctxt the compilation context (must not be {@code null})
+     * @param delegate the delegate basic block builder (must not be {@code null})
+     * @return the basic block builder (not {@code null})
+     */
+    public static BasicBlockBuilder createBasicBlockBuilder(CompilationContext ctxt, BasicBlockBuilder delegate) {
+        final AbstractSafePointStrategy strategy = ctxt.getAttachment(IMPL_KEY);
+        return new DelegatingBasicBlockBuilder(delegate) {
+            @Override
+            public Node safePoint() {
+                strategy.safePoint(getFirstBuilder());
+                return nop();
+            }
+        };
+    }
+
+    public enum Strategy {
+        NONE {
+            @Override
+            AbstractSafePointStrategy create(CompilationContext ctxt) {
+                return new NoSafePointStrategy(ctxt);
+            }
+        },
+        GLOBAL_FLAG {
+            @Override
+            AbstractSafePointStrategy create(CompilationContext ctxt) {
+                return new GlobalFlagSafePointStrategy(ctxt);
+            }
+        },
+        ;
+
+        abstract AbstractSafePointStrategy create(CompilationContext ctxt);
+    }
+}

--- a/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
+++ b/plugins/gc/nogc/src/main/java/org/qbicc/plugin/gc/nogc/NoGcBasicBlockBuilder.java
@@ -82,11 +82,6 @@ public class NoGcBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         return oop;
     }
 
-    public Node safePoint() {
-        // No safepoints in NoGC
-        return nop();
-    }
-
     private Value allocateArray(CompoundType compoundType, Value size, long elementSize) {
         NoGc noGc = NoGc.get(ctxt);
         LiteralFactory lf = ctxt.getLiteralFactory();

--- a/runtime/api/src/main/java/org/qbicc/runtime/NoSafePoint.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/NoSafePoint.java
@@ -1,0 +1,15 @@
+package org.qbicc.runtime;
+
+import static java.lang.annotation.ElementType.*;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicate that a method cannot be interrupted by a safepoint poll.
+ */
+@Target({ METHOD, CONSTRUCTOR })
+@Retention(RetentionPolicy.CLASS)
+public @interface NoSafePoint {
+}

--- a/runtime/api/src/main/java/org/qbicc/runtime/NoThrow.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/NoThrow.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * Indicate that a method does not throw any exception - not even {@link StackOverflowError} or {@link OutOfMemoryError}.
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.CLASS)
 public @interface NoThrow {
 }

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/SafePoint.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/SafePoint.java
@@ -1,0 +1,62 @@
+package org.qbicc.runtime.main;
+
+import org.qbicc.runtime.Hidden;
+import org.qbicc.runtime.NoReflect;
+import org.qbicc.runtime.NoSafePoint;
+import org.qbicc.runtime.NoThrow;
+
+/**
+ * Methods which facilitate the handling and implementation of safe points.
+ */
+public final class SafePoint {
+    private SafePoint() {}
+
+    /**
+     * Perform safe point work.
+     * <p>
+     * The actual safepoint tasks are registered by plugins.
+     */
+    @NoSafePoint
+    @NoThrow
+    @NoReflect
+    @Hidden
+    static native void enterSafePoint();
+
+    /**
+     * Request a global safepoint.
+     * Returns immediately.
+     * <p>
+     * The actual implementation depends on the selected safepoint strategy.
+     */
+    @NoSafePoint
+    @NoThrow
+    @NoReflect
+    @Hidden
+    public static native void requestGlobalSafePoint();
+
+    /**
+     * Clear the global safepoint request.
+     * Returns immediately.
+     * This should only be called from within the safepoint handler mechanism.
+     * <p>
+     * The actual implementation depends on the selected safepoint strategy.
+     */
+    @NoSafePoint
+    @NoThrow
+    @NoReflect
+    @Hidden
+    public static native void clearGlobalSafePoint();
+
+    /**
+     * Poll for a safepoint.
+     * <p>
+     * The actual implementation (if any) depends on the selected safepoint strategy.
+     * This method exists as a placeholder for safepoint strategies that rely on a method call
+     * so that they do not have to inject a method for that purpose.
+     */
+    @NoReflect
+    @Hidden
+    @NoSafePoint
+    @NoThrow
+    static native void pollSafePoint();
+}

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/JavaStackWalker.java
@@ -2,6 +2,8 @@ package org.qbicc.runtime.stackwalk;
 
 import org.qbicc.runtime.AutoQueued;
 import org.qbicc.runtime.Hidden;
+import org.qbicc.runtime.NoSafePoint;
+import org.qbicc.runtime.NoThrow;
 import org.qbicc.runtime.StackObject;
 
 public final class JavaStackWalker extends StackObject {
@@ -12,10 +14,14 @@ public final class JavaStackWalker extends StackObject {
     private int sourceIndex = -1;
     private int methodInfoIdx = -1;
 
+    @NoSafePoint
+    @NoThrow
     public JavaStackWalker(boolean skipHidden) {
         this.skipHidden = skipHidden;
     }
 
+    @NoSafePoint
+    @NoThrow
     public JavaStackWalker(JavaStackWalker original) {
         skipHidden = original.skipHidden;
         index = original.index;
@@ -23,6 +29,8 @@ public final class JavaStackWalker extends StackObject {
         methodInfoIdx = original.methodInfoIdx;
     }
 
+    @NoSafePoint
+    @NoThrow
     public boolean next(StackWalker stackWalker) {
         for (;;) {
             for (;;) {
@@ -55,6 +63,8 @@ public final class JavaStackWalker extends StackObject {
 
     @Hidden
     @AutoQueued
+    @NoSafePoint
+    @NoThrow
     public static int getFrameCount(Throwable exceptionObject) {
         StackWalker sw = new StackWalker();
         JavaStackWalker javaStackWalker = new JavaStackWalker(true);
@@ -74,6 +84,8 @@ public final class JavaStackWalker extends StackObject {
      * @return the number of matching frames
      */
     @Hidden
+    @NoSafePoint
+    @NoThrow
     public static int getFrameCount(int skipRawFrames, int skipJavaFrames, boolean skipHidden) {
         StackWalker sw = new StackWalker();
         for (int i = 0; i < skipRawFrames; i ++) {
@@ -100,6 +112,8 @@ public final class JavaStackWalker extends StackObject {
         }
     }
 
+    @NoSafePoint
+    @NoThrow
     public int getIndex() {
         return index;
     }
@@ -134,14 +148,20 @@ public final class JavaStackWalker extends StackObject {
         return MethodData.getBytecodeIndex(sourceIndex);
     }
 
+    @NoSafePoint
+    @NoThrow
     public int getSourceIndex() {
         return sourceIndex;
     }
 
+    @NoSafePoint
+    @NoThrow
     public int getMethodInfoIdx() {
         return methodInfoIdx;
     }
 
+    @NoSafePoint
+    @NoThrow
     public void reset() {
         methodInfoIdx = -1;
         sourceIndex = -1;

--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
@@ -1,6 +1,8 @@
 package org.qbicc.runtime.stackwalk;
 
 import org.qbicc.runtime.Build;
+import org.qbicc.runtime.NoSafePoint;
+import org.qbicc.runtime.NoThrow;
 import org.qbicc.runtime.StackObject;
 import org.qbicc.runtime.stdc.Stdint.uint64_t_ptr;
 
@@ -16,6 +18,8 @@ public final class StackWalker extends StackObject {
     int index = -1;
     boolean ready;
 
+    @NoSafePoint
+    @NoThrow
     public StackWalker() {
         unw_context_t_ptr context_ptr = addr_of(refToPtr(this).sel().context);
         if (Build.Target.isAarch64() && ! Build.Target.isMacOs()) {
@@ -47,12 +51,17 @@ public final class StackWalker extends StackObject {
         unw_init_local(addr_of(refToPtr(this).sel().cursor), context_ptr);
     }
 
+    @NoSafePoint
+    @NoThrow
     public StackWalker(StackWalker orig) {
+        memcpy(addr_of(refToPtr(this).sel().context).cast(), addr_of(refToPtr(orig).sel().context).cast(), sizeof(unw_context_t.class));
         memcpy(addr_of(refToPtr(this).sel().cursor).cast(), addr_of(refToPtr(orig).sel().cursor).cast(), sizeof(unw_cursor_t.class));
         index = orig.index;
         ready = orig.ready;
     }
 
+    @NoSafePoint
+    @NoThrow
     public boolean next() {
         if (unw_step(addr_of(refToPtr(this).sel().cursor)).isGt(zero())) {
             index++;
@@ -61,8 +70,10 @@ public final class StackWalker extends StackObject {
         return ready = false;
     }
 
+    @NoSafePoint
+    @NoThrow
     public void_ptr getIp() {
-        if (! ready) throw new IllegalStateException();
+        if (! ready) return zero();
         unw_word_t ip = auto();
         unw_get_reg(addr_of(refToPtr(this).sel().cursor), UNW_REG_IP, addr_of(ip));
         if (Build.Target.isAarch64() && Build.Target.isMacOs()) {
@@ -73,8 +84,10 @@ public final class StackWalker extends StackObject {
         return ip.cast();
     }
 
+    @NoSafePoint
+    @NoThrow
     public void_ptr getSp() {
-        if (! ready) throw new IllegalStateException();
+        if (! ready) return zero();
         unw_word_t sp = auto();
         unw_get_reg(addr_of(refToPtr(this).sel().cursor), UNW_REG_SP, addr_of(sp));
         return sp.cast();
@@ -86,6 +99,8 @@ public final class StackWalker extends StackObject {
      *
      * @param ptr a pointer to the new cursor value (must not be {@code null})
      */
+    @NoSafePoint
+    @NoThrow
     public void setCursor(ptr<@c_const unw_cursor_t> ptr) {
         memcpy(addr_of(refToPtr(this).sel().cursor).cast(), ptr.cast(), sizeof(unw_cursor_t.class));
     }
@@ -96,10 +111,14 @@ public final class StackWalker extends StackObject {
      *
      * @param ptr a pointer to memory into which the copy should be stored (must not be {@code null})
      */
+    @NoSafePoint
+    @NoThrow
     public void getCursor(ptr<unw_cursor_t> ptr) {
         memcpy(ptr.cast(), addr_of(refToPtr(this).sel().cursor).cast(), sizeof(unw_cursor_t.class));
     }
 
+    @NoSafePoint
+    @NoThrow
     public int getIndex() {
         return index;
     }


### PR DESCRIPTION
This introduces an API and implementation for implementing actual safepoint probes. The simple implementation uses a single static boolean field to request a safepoint.

The actual body of the safepoint is not yet implemented.

The next step is to implement an API which allows plugins to register safepoint steps (for example, marking the thread stack for GC, or synchronizing all threads to perform a sweep/compact operation).