### PR TITLE
Annotate a few more runtime methods with @Hidden

### DIFF
--- a/runtime/main/src/main/java/org/qbicc/runtime/main/Once.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/Once.java
@@ -1,6 +1,7 @@
 package org.qbicc.runtime.main;
 
 import org.qbicc.runtime.AutoQueued;
+import org.qbicc.runtime.Hidden;
 
 import java.util.Objects;
 
@@ -38,6 +39,7 @@ public final class Once {
      */
     @SuppressWarnings("unused")
     @AutoQueued
+    @Hidden
     public void run() throws Throwable {
         boolean done = this.done;
         if (! done) {

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/RuntimeInitializerRunner.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/RuntimeInitializerRunner.java
@@ -1,6 +1,7 @@
 package org.qbicc.runtime.main;
 
 import org.qbicc.runtime.AutoQueued;
+import org.qbicc.runtime.Hidden;
 
 /**
  * Effectively a lambda that will execute a specific runtime initializer.
@@ -25,6 +26,7 @@ public final class RuntimeInitializerRunner implements Runnable {
 
     @Override
     @AutoQueued
+    @Hidden
     public void run() {
         CompilerIntrinsics.callRuntimeInitializer(initID);
     }


### PR DESCRIPTION
Hide the <rtinit> internals so they don't appear in stacktraces.  Two motivations: (a) they are qbicc-internal functions and (b) these classes are not in a module, so StackTraceElement.computeFormat() explodes with a NPE if these methods actually appear in a stack trace we are trying to print.