### PR TITLE
qbicc feature: add reflectiveFields and reflectiveMethods

### DIFF
--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/FeaturePatcher.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/FeaturePatcher.java
@@ -2,7 +2,9 @@ package org.qbicc.plugin.initializationcontrol;
 
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
+import org.qbicc.type.descriptor.MethodDescriptor;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -12,6 +14,8 @@ public class FeaturePatcher {
 
     private final CompilationContext ctxt;
     private final Set<String> runtimeInitializedClasses = ConcurrentHashMap.newKeySet();
+    private final Map<String, Set<String>> reflectiveMethods = new ConcurrentHashMap<>();
+    private final Map<String, Set<String>> reflectiveFields = new ConcurrentHashMap<>();
 
     private FeaturePatcher(CompilationContext ctxt) {
         this.ctxt = ctxt;
@@ -35,5 +39,32 @@ public class FeaturePatcher {
 
     public boolean isRuntimeInitializedClass(String internalName) {
         return runtimeInitializedClasses.contains(internalName);
+    }
+
+    public void addReflectiveMethod(String className, String methodName, String descriptor) {
+        String encodedMethod = methodName+":"+descriptor;
+        reflectiveMethods.computeIfAbsent(className, k -> ConcurrentHashMap.newKeySet()).add(encodedMethod);
+    }
+
+    public boolean hasReflectiveMethods(String className) {
+        return reflectiveMethods.containsKey(className);
+    }
+
+    public boolean isReflectiveMethod(String className, String methodName, MethodDescriptor descriptor) {
+        Set<String> encodedMethods = reflectiveMethods.get(className);
+        return encodedMethods != null && encodedMethods.contains(methodName+":"+descriptor);
+    }
+
+    public void addReflectiveField(String className, String fieldName) {
+        reflectiveFields.computeIfAbsent(className, k -> ConcurrentHashMap.newKeySet()).add(fieldName);
+    }
+
+    public boolean hasReflectiveFields(String className) {
+        return reflectiveFields.containsKey(className);
+    }
+
+    public boolean isReflectiveField(String className, String fieldName) {
+        Set<String> fields = reflectiveFields.get(className);
+        return fields != null && fields.contains(fieldName);
     }
 }

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeature.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeature.java
@@ -4,4 +4,17 @@ final class QbiccFeature {
     String[] initializeAtRuntime;
     String[] runtimeResource;  // ClassLoader.findResource
     String[] runtimeResources; // ClassLoader.findResources
+    Method[] reflectiveMethods;
+    Field[] reflectiveFields;
+
+    static final class Method {
+        String declaringClass;
+        String name;
+        String descriptor;
+    }
+
+    static final class Field {
+        String declaringClass;
+        String name;
+    }
 }

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureProcessor.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureProcessor.java
@@ -58,6 +58,16 @@ public class QbiccFeatureProcessor {
                     rm.addResources(name);
                 }
             }
+            if (qf.reflectiveMethods != null) {
+                for (QbiccFeature.Method meth : qf.reflectiveMethods) {
+                    fp.addReflectiveMethod(meth.declaringClass, meth.name, meth.descriptor);
+                }
+            }
+            if (qf.reflectiveFields != null) {
+                for (QbiccFeature.Field f : qf.reflectiveFields) {
+                    fp.addReflectiveField(f.declaringClass, f.name);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
+ Add the ability to declare that fields and methods are reflectively accessed at runtime to qbicc features.
+ Move initial processing of qbicc feature very early in ADD preHook sequence so that it can apply to classes loaded during initial bootstrapping of the interpreter.
