### PR TITLE
Ensure integer types are truncated when returned from boolean functions

### DIFF
--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
@@ -8,13 +8,17 @@ import org.qbicc.graph.Load;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.NodeVisitor;
 import org.qbicc.graph.ReadModifyWrite;
+import org.qbicc.graph.Return;
 import org.qbicc.graph.Store;
+import org.qbicc.graph.TerminatorVisitor;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.ValueHandle;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.CompoundType;
 import org.qbicc.type.IntegerType;
+import org.qbicc.type.ValueType;
+import org.qbicc.type.VoidType;
 
 /**
  *
@@ -97,6 +101,19 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
             return b.truncate(b.readModifyWrite(copyHandle, op, b.extend(copiedUpdate, it), node.getReadAccessMode(), node.getWriteAccessMode()), bt);
         } else {
             return b.readModifyWrite(copyHandle, op, copiedUpdate, node.getReadAccessMode(), node.getWriteAccessMode());
+        }
+    }
+
+    @Override
+    public BasicBlock visit(Node.Copier param, Return node) {
+        BasicBlockBuilder b = param.getBlockBuilder();
+        param.copyNode(node.getDependency());
+        Value copiedReturnValue = param.copyValue(node.getReturnValue());
+
+        if (node.getElement().getType().getReturnType() instanceof BooleanType bt   && copiedReturnValue.getType() instanceof IntegerType) {
+            return b.return_(b.truncate(copiedReturnValue, bt));
+        } else {
+            return b.return_(copiedReturnValue);
         }
     }
 }


### PR DESCRIPTION
Addresses a build issue on Wasm:

```
[ERROR] <stdin>:398: error: /usr/local/bin/emcc: value doesn't match function result type 'i1'
[ERROR] : error: /usr/local/bin/emcc:   ret i8 %L4, !dbg !816 ; null:0 bci@-1
[ERROR] : error: /usr/local/bin/emcc:       ^
[ERROR] : error: /usr/local/bin/emcc: 1 error generated.
[ERROR] emcc: error: /usr/local/bin/emcc: '/usr/local/Cellar/emscripten/3.1.21/libexec/llvm/bin/clang++ -target wasm32-unknown-emscripten -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -DEMSCRIPTEN -D__EMSCRIPTEN_major__=3 -D__EMSCRIPTEN_minor__=1 -D__EMSCRIPTEN_tiny__=21 -I/usr/local/Cellar/emscripten/3.1.21/libexec/cache/sysroot/include/SDL --sysroot=/usr/local/Cellar/emscripten/3.1.21/libexec/cache/sysroot -Xclang -iwithsysroot/include/compat -pipe -fexceptions -Wno-override-module -mbulk-memory -g3 -c -x ir - -o /Users/evacchi/Devel/rh/fun/qbicc/integration-tests/target/native/boot/jdk/internal/misc/Unsafe.o' failed (returned 1)
```
