### PR TITLE
GC: Add is-safepoint tracking to lowered functions

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/Call.java
+++ b/compiler/src/main/java/org/qbicc/graph/Call.java
@@ -71,7 +71,7 @@ public final class Call extends AbstractValue implements OrderedNode {
 
     @Override
     public boolean maySafePoint() {
-        return ! target.isNoSafepoint();
+        return ! target.isNoSafePoints();
     }
 
     public InvokableType getCalleeType() {

--- a/compiler/src/main/java/org/qbicc/graph/CallNoReturn.java
+++ b/compiler/src/main/java/org/qbicc/graph/CallNoReturn.java
@@ -72,7 +72,7 @@ public final class CallNoReturn extends AbstractTerminator {
 
     @Override
     public boolean maySafePoint() {
-        return ! target.isNoSafepoint();
+        return ! target.isNoSafePoints();
     }
 
     public InvokableType getCalleeType() {

--- a/compiler/src/main/java/org/qbicc/graph/Executable.java
+++ b/compiler/src/main/java/org/qbicc/graph/Executable.java
@@ -57,7 +57,7 @@ public abstract class Executable extends AbstractValueHandle {
     }
 
     @Override
-    public boolean isNoSafepoint() {
+    public boolean isNoSafePoints() {
         return executable.hasAllModifiersOf(ClassFile.I_ACC_NO_SAFEPOINTS);
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/Invoke.java
+++ b/compiler/src/main/java/org/qbicc/graph/Invoke.java
@@ -83,7 +83,7 @@ public final class Invoke extends AbstractTerminator implements Resume {
 
     @Override
     public boolean maySafePoint() {
-        return ! target.isNoSafepoint();
+        return ! target.isNoSafePoints();
     }
 
     public InvokableType getCalleeType() {

--- a/compiler/src/main/java/org/qbicc/graph/InvokeNoReturn.java
+++ b/compiler/src/main/java/org/qbicc/graph/InvokeNoReturn.java
@@ -75,7 +75,7 @@ public final class InvokeNoReturn extends AbstractTerminator {
 
     @Override
     public boolean maySafePoint() {
-        return ! target.isNoSafepoint();
+        return ! target.isNoSafePoints();
     }
 
     public InvokableType getCalleeType() {

--- a/compiler/src/main/java/org/qbicc/graph/PointerHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/PointerHandle.java
@@ -62,6 +62,15 @@ public final class PointerHandle extends AbstractValueHandle {
     }
 
     @Override
+    public boolean isNoSafePoints() {
+        return pointerValue instanceof PointerLiteral pl
+            && pl.getPointer() instanceof ProgramObjectPointer pop
+            && pop.getProgramObject() instanceof Function fn
+            && fn.isNoSafePoints()
+            || super.isNoSafePoints();
+    }
+
+    @Override
     public boolean isConstantLocation() {
         return pointerValue.isConstant() && offsetValue.isConstant();
     }

--- a/compiler/src/main/java/org/qbicc/graph/TailCall.java
+++ b/compiler/src/main/java/org/qbicc/graph/TailCall.java
@@ -74,7 +74,7 @@ public final class TailCall extends AbstractTerminator {
     }
 
     public boolean maySafePoint() {
-        return ! target.isNoSafepoint();
+        return ! target.isNoSafePoints();
     }
 
     public InvokableType getCalleeType() {

--- a/compiler/src/main/java/org/qbicc/graph/ValueHandle.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueHandle.java
@@ -67,7 +67,7 @@ public interface ValueHandle extends Unschedulable {
      *
      * @return {@code true} if the handle referee can never safepoint, or {@code false} otherwise
      */
-    default boolean isNoSafepoint() {
+    default boolean isNoSafePoints() {
         return false;
     }
 

--- a/compiler/src/main/java/org/qbicc/object/Function.java
+++ b/compiler/src/main/java/org/qbicc/object/Function.java
@@ -11,6 +11,7 @@ import org.qbicc.type.definition.element.ExecutableElement;
 public final class Function extends SectionObject {
     public static final int FN_NO_RETURN = 1 << 0;
     public static final int FN_NO_SIDE_EFFECTS = 1 << 1;
+    public static final int FN_NO_SAFEPOINTS = 1 << 2;
 
     private final int fnFlags;
     private volatile MethodBody body;
@@ -49,6 +50,10 @@ public final class Function extends SectionObject {
         return (fnFlags & FN_NO_SIDE_EFFECTS) != 0;
     }
 
+    public boolean isNoSafePoints() {
+        return (fnFlags & FN_NO_SAFEPOINTS) != 0;
+    }
+
     public FunctionDeclaration getDeclaration() {
         FunctionDeclaration declaration = this.declaration;
         if (declaration == null) {
@@ -72,6 +77,8 @@ public final class Function extends SectionObject {
             flags |= Function.FN_NO_SIDE_EFFECTS;
         } else if (element.hasAllModifiersOf(ClassFile.I_ACC_NO_RETURN)) {
             flags |= Function.FN_NO_RETURN;
+        } else if (element.hasAllModifiersOf(ClassFile.I_ACC_NO_SAFEPOINTS)) {
+            flags |= Function.FN_NO_SAFEPOINTS;
         }
         return flags;
     }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -930,7 +930,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail();
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafepoint()) {
+        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafePoints()) {
             call.attribute(FunctionAttributes.gcLeafFunction);
         } else {
             addStatepointId(call, node);
@@ -951,7 +951,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail();
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafepoint()) {
+        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafePoints()) {
             call.attribute(FunctionAttributes.gcLeafFunction);
         } else {
             addStatepointId(call, node);
@@ -972,7 +972,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).noTail().attribute(FunctionAttributes.noreturn);
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafepoint()) {
+        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafePoints()) {
             call.attribute(FunctionAttributes.gcLeafFunction);
         } else {
             addStatepointId(call, node);
@@ -994,7 +994,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         Call call = builder.call(llType, llTarget).tail(); // hint only
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
-        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafepoint()) {
+        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafePoints()) {
             call.attribute(FunctionAttributes.gcLeafFunction);
         } else {
             addStatepointId(call, node);
@@ -1041,7 +1041,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
         addPersonalityIfNeeded();
-        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafepoint()) {
+        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafePoints()) {
             call.attribute(FunctionAttributes.gcLeafFunction);
         } else {
             addStatepointId(call, node);
@@ -1072,7 +1072,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Void, LLValue, Instruction, I
         setCallArguments(call, arguments);
         setCallReturnValue(call, functionType);
         addPersonalityIfNeeded();
-        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafepoint()) {
+        if (functionType.isVariadic() || valueHandle instanceof AsmHandle || valueHandle.isNoSafePoints()) {
             call.attribute(FunctionAttributes.gcLeafFunction);
         } else {
             addStatepointId(call, node);


### PR DESCRIPTION
This is needed so that we know whether we have to create live value operand bundles for LLVM (and thereby add calls within such functions to the stack map file).