### PR TITLE
disable alignment checking for C-probed members

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -230,6 +230,12 @@ public final class TypeSystem {
         return referenceArrayDefinition;
     }
 
+    public CompoundType.Member getProbedCompoundTypeMember(String name, ValueType type, int offset) {
+        Assert.checkNotNullParam("name", name);
+        Assert.checkMinimumParameter("offset", 0, offset);
+        return new CompoundType.Member(name, type, offset, 1);
+    }
+
     public CompoundType.Member getCompoundTypeMember(String name, ValueType type, int offset, int align) {
         Assert.checkNotNullParam("name", name);
         TypeUtil.checkAlignmentParameter("align", align);

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -365,7 +365,7 @@ final class NativeInfo {
                                                     // compound type
                                                     String name = field.getName();
                                                     CProbe.Type.Info member = result.getTypeInfoOfMember(probeType, name);
-                                                    list.add(ts.getCompoundTypeMember(name, type, (int) member.getOffset(), 1));
+                                                    list.add(ts.getProbedCompoundTypeMember(name, type, (int) member.getOffset()));
                                                 }
                                             }
                                             list.sort(Comparator.naturalOrder());


### PR DESCRIPTION
Fixes a problem with a C probed struct where `pragma(pack)` changes the struct layout algorithm. 