### PR TITLE
add some posix networking-related native APIs

### DIFF
--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/ProbeUtils.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/ProbeUtils.java
@@ -111,7 +111,11 @@ final class ProbeUtils {
             for (Annotation define : defines) {
                 String str = ((StringAnnotationValue) define.getValue("value")).getString();
                 if (ConditionEvaluation.get(classContext.getCompilationContext()).evaluateConditions(classContext, locatable, define)) {
-                    builder.define(str);
+                    if (define.getValue("as") instanceof StringAnnotationValue asStr) {
+                        builder.define(str, asStr.getString());
+                    } else {
+                        builder.define(str);
+                    }
                 }
             }
             for (Annotation undef : undefs) {

--- a/runtime/api/src/main/java/org/qbicc/runtime/stdc/String.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/stdc/String.java
@@ -23,4 +23,6 @@ public class String {
     public static native c_int strcmp(const_char_ptr src1, const_char_ptr src2);
 
     public static native c_int strncmp(const_char_ptr src1, const_char_ptr src2, size_t len);
+
+    public static native c_int strncpy(char_ptr dst, const_char_ptr src, size_t len);
 }

--- a/runtime/bsd/src/main/java/org/qbicc/runtime/bsd/Ifaddrs.java
+++ b/runtime/bsd/src/main/java/org/qbicc/runtime/bsd/Ifaddrs.java
@@ -1,0 +1,23 @@
+package org.qbicc.runtime.bsd;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.posix.SysSocket.*;
+
+@include("<ifaddrs.h>")
+public class Ifaddrs {
+    public static class struct_ifaddrs extends object {
+        public void_ptr /* struct_ifaddrs_ptr */ ifa_next;  // TODO: void_ptr is a hack; struct_ifaddrs_ptr causes a StackOverflowException in qbicc
+        public char_ptr ifa_name;
+        public unsigned_int ifa_flags;
+        public struct_sockaddr_ptr ifa_addr;
+        public struct_sockaddr_ptr ifa_netmask;
+        public struct_sockaddr_ptr ifa_dstaddr;
+        public void_ptr ifa_data;
+    }
+
+    public static class struct_ifaddrs_ptr extends ptr<struct_ifaddrs> {}
+    public static class struct_ifaddrs_ptr_ptr extends ptr<struct_ifaddrs_ptr> {}
+
+    public static native c_int getifaddrs(struct_ifaddrs_ptr_ptr x);
+    public static native void freeifaddrs(struct_ifaddrs_ptr x);
+}

--- a/runtime/bsd/src/main/java/org/qbicc/runtime/bsd/NetIf.java
+++ b/runtime/bsd/src/main/java/org/qbicc/runtime/bsd/NetIf.java
@@ -1,0 +1,8 @@
+package org.qbicc.runtime.bsd;
+
+import static org.qbicc.runtime.CNative.*;
+
+@include("<net/if.h>")
+public class NetIf {
+    public static native unsigned_int if_nametoindex(const_char_ptr ifname);
+}

--- a/runtime/linux/src/main/java/org/qbicc/runtime/linux/NetIf.java
+++ b/runtime/linux/src/main/java/org/qbicc/runtime/linux/NetIf.java
@@ -1,0 +1,8 @@
+package org.qbicc.runtime.linux;
+
+import static org.qbicc.runtime.CNative.*;
+
+@include("<net/if.h>")
+public class NetIf {
+    public static final unsigned_long SIOCGIFINDEX = constant();
+}

--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/ArpaInet.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/ArpaInet.java
@@ -1,0 +1,16 @@
+package org.qbicc.runtime.posix;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.stdc.Stdint.*;
+
+@define(value = "_POSIX_C_SOURCE", as = "200809L")
+@include("<arpa/inet.h>")
+public class ArpaInet {
+    public static native uint64_t htonll(uint64_t hostlonglong);
+    public static native uint32_t htonl(uint32_t hostlong);
+    public static native uint16_t hton2(uint16_t hostshort);
+
+    public static native uint64_t ntohll(uint64_t netlonglong);
+    public static native uint32_t ntohl(uint32_t netlong);
+    public static native uint16_t ntohs(uint16_t netshort);
+}

--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/NetIf.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/NetIf.java
@@ -1,0 +1,79 @@
+package org.qbicc.runtime.posix;
+
+import org.qbicc.runtime.Build;
+
+import static org.qbicc.runtime.CNative.*;
+
+@define(value = "_POSIX_C_SOURCE", as = "200809L")
+@define(value = "_DARWIN_C_SOURCE", when = Build.Target.IsApple.class)
+@include("<net/if.h>")
+public class NetIf {
+
+    public static final c_int IF_NAMESIZE = constant();
+
+    public static final class struct_ifreq extends object {
+        public c_char[] ifr_name;
+        public void_ptr ifr_ifru; // This is actually a horrific 16-way union.
+    }
+    public static final class struct_ifreq_ptr extends ptr<struct_ifreq> {}
+
+    public static final class struct_ifconf extends object {
+        public c_int ifc_len;
+        public void_ptr ifc_ifcu; // This is a 2-way union
+    }
+    public static final class struct_ifconf_ptr extends ptr<struct_ifconf> {}
+
+    public static final c_short IFF_UP = constant();
+    public static final c_short IFF_BROADCAST = constant();
+    public static final c_short IFF_DEBUG = constant();
+    public static final c_short IFF_LOOPBACK = constant();
+    public static final c_short IFF_POINTOPOINT = constant();
+    public static final c_short IFF_NOTRAILERS = constant();
+    public static final c_short IFF_RUNNING = constant();
+    public static final c_short IFF_NOARP = constant();
+    public static final c_short IFF_PROMISC = constant();
+    public static final c_short IFF_ALLMULTI = constant();
+    public static final c_short IFF_OACTIVE = constant();
+    public static final c_short IFF_SIMPLEX = constant();
+    public static final c_short IFF_LINK0 = constant();
+    public static final c_short IFF_LINK1 = constant();
+    public static final c_short IFF_LINK2 = constant();
+    public static final c_short IFF_ALTPHYS = constant();
+    public static final c_short IFF_MULTICAST = constant();
+
+    public static final unsigned_long SIOCSHIWAT = constant();
+    public static final unsigned_long SIOCGHIWAT = constant();
+    public static final unsigned_long SIOCSLOWAT = constant();
+    public static final unsigned_long SIOCGLOWAT = constant();
+    public static final unsigned_long SIOCATMARK = constant();
+    public static final unsigned_long SIOCSPGRP = constant();
+    public static final unsigned_long SIOCGPGRP = constant();
+
+    public static final unsigned_long SIOCSIFADDR = constant();
+    public static final unsigned_long SIOCSIFDSTADDR = constant();
+    public static final unsigned_long SIOCSIFFLAGS = constant();
+    public static final unsigned_long SIOCGIFFLAGS = constant();
+    public static final unsigned_long SIOCSIFBRDADDR = constant();
+    public static final unsigned_long SIOCSIFNETMASK = constant();
+    public static final unsigned_long SIOCGIFMETRIC = constant();
+    public static final unsigned_long SIOCSIFMETRIC = constant();
+    public static final unsigned_long SIOCDIFADDR = constant();
+    public static final unsigned_long SIOCAIFADDR = constant();
+
+    public static final unsigned_long SIOCGIFADDR = constant();
+    public static final unsigned_long SIOCGIFDSTADDR = constant();
+    public static final unsigned_long SIOCGIFBRDADDR = constant();
+    public static final unsigned_long SIOCGIFCONF = constant();
+    public static final unsigned_long SIOCGIFNETMASK = constant();
+    public static final unsigned_long SIOCAUTOADDR = constant();
+    public static final unsigned_long SIOCAUTONETMASK = constant();
+    public static final unsigned_long SIOCARPIPLL = constant();
+
+    public static final unsigned_long SIOCADDMULTI = constant();
+    public static final unsigned_long SIOCDELMULTI = constant();
+    public static final unsigned_long SIOCGIFMTU = constant();
+    public static final unsigned_long SIOCSIFMTU = constant();
+    public static final unsigned_long SIOCGIFPHYS = constant();
+    public static final unsigned_long SIOCSIFPHYS = constant();
+    public static final unsigned_long SIOCSIFMEDIA = constant();
+}

--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/NetinetIn.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/NetinetIn.java
@@ -17,16 +17,19 @@ public final class NetinetIn {
     public static final class struct_in_addr extends object {
         public in_addr_t s_addr;
     }
+    public static final class struct_in_addr_ptr extends ptr<struct_in_addr> {}
 
     public static final class struct_sockaddr_in extends object {
         public sa_family_t sin_family;
         public in_port_t sin_port;
         public struct_in_addr sin_addr;
     }
+    public static final class struct_sockaddr_in_ptr extends ptr<struct_sockaddr_in> {}
 
     public static final class struct_in6_addr extends object {
         public uint8_t @array_size(16)[] s6_addr;
     }
+    public static final class struct_in6_addr_ptr extends ptr<struct_in6_addr> {}
 
     public static final class struct_sockaddr_in6 extends object {
         public sa_family_t sin6_family;
@@ -35,6 +38,7 @@ public final class NetinetIn {
         public struct_in6_addr sin6_addr;
         public uint32_t sin6_scope_id;
     }
+    public static final class struct_sockaddr_in6_ptr extends ptr<struct_sockaddr_in6> {}
 
     @extern
     public static @c_const struct_in6_addr in6addr_any;
@@ -45,6 +49,7 @@ public final class NetinetIn {
         public struct_in6_addr ipv6mr_multiaddr;
         public unsigned_int ipv6mr_interface;
     }
+    public static final class struct_ipv6_mreq_ptr extends ptr<struct_ipv6_mreq> {}
 
     public static final c_int IPPROTO_IP = constant();
     public static final c_int IPPROTO_IPV6 = constant();

--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysIoctl.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/SysIoctl.java
@@ -1,0 +1,10 @@
+package org.qbicc.runtime.posix;
+
+import static org.qbicc.runtime.CNative.*;
+
+@SuppressWarnings("SpellCheckingInspection")
+@include("<sys/ioctl.h>")
+public class SysIoctl {
+
+    public static native c_int ioctl(c_int fd, unsigned_long request, object... more);
+}


### PR DESCRIPTION
This is enough to get the IPv4 subset of the native code for java.net.NetworkInterface.getAll() working on MacOS.
