### PR TITLE
simplify CompoundType.hashCode to support linked structs

### DIFF
--- a/compiler/src/main/java/org/qbicc/type/CompoundType.java
+++ b/compiler/src/main/java/org/qbicc/type/CompoundType.java
@@ -34,11 +34,9 @@ public final class CompoundType extends ValueType {
     private volatile List<Member> members;
     private volatile List<Member> paddedMembers;
     private volatile Map<String, Member> membersByName;
-    // late-computed hash code
-    private int hashCode;
 
     CompoundType(final TypeSystem typeSystem, final Tag tag, final String name, final Supplier<List<Member>> membersResolver, final long size, final int overallAlign) {
-        super(typeSystem, 0);
+        super(typeSystem, CompoundType.class.hashCode());
         // name/tag do not contribute to hash or equality
         this.tag = tag;
         this.name = name;
@@ -51,8 +49,8 @@ public final class CompoundType extends ValueType {
     }
 
     CompoundType(final TypeSystem typeSystem, final Tag tag, final String name, final Supplier<List<Member>> membersResolver) {
-        super(typeSystem, 0);
-        // name/tag do not contribute to hash or equality
+        super(typeSystem, CompoundType.class.hashCode());
+        // tag does not contribute to hash or equality
         this.tag = tag;
         this.name = name;
         this.size = -1;
@@ -62,7 +60,7 @@ public final class CompoundType extends ValueType {
     }
 
     CompoundType(final TypeSystem typeSystem, final Tag tag, final String name) {
-        super(typeSystem, 0);
+        super(typeSystem, CompoundType.class.hashCode());
         this.tag = tag;
         this.name = name;
         this.size = 0;
@@ -351,19 +349,6 @@ public final class CompoundType extends ValueType {
 
     public boolean equals(final CompoundType other) {
         return this == other || super.equals(other) && Objects.equals(name, other.name) && size == other.size && align == other.align && getMembers().equals(other.getMembers());
-    }
-
-    @Override
-    public int hashCode() {
-        int hashCode = this.hashCode;
-        if (hashCode == 0) {
-            hashCode = (int) (((getSize() * 19) + getAlign()) * 19 + getMembers().hashCode());
-            if (hashCode == 0) {
-                hashCode |= 1 << 31;
-            }
-            this.hashCode = hashCode;
-        }
-        return hashCode;
     }
 
     public StringBuilder toString(final StringBuilder b) {

--- a/compiler/src/main/java/org/qbicc/type/CompoundType.java
+++ b/compiler/src/main/java/org/qbicc/type/CompoundType.java
@@ -36,8 +36,8 @@ public final class CompoundType extends ValueType {
     private volatile Map<String, Member> membersByName;
 
     CompoundType(final TypeSystem typeSystem, final Tag tag, final String name, final Supplier<List<Member>> membersResolver, final long size, final int overallAlign) {
-        super(typeSystem, CompoundType.class.hashCode());
-        // name/tag do not contribute to hash or equality
+        super(typeSystem, Objects.hash(CompoundType.class, name, size, overallAlign));
+        // tag does not contribute to hash or equality
         this.tag = tag;
         this.name = name;
         // todo: assert size ≥ end of last member w/alignment etc.
@@ -49,7 +49,7 @@ public final class CompoundType extends ValueType {
     }
 
     CompoundType(final TypeSystem typeSystem, final Tag tag, final String name, final Supplier<List<Member>> membersResolver) {
-        super(typeSystem, CompoundType.class.hashCode());
+        super(typeSystem, Objects.hash(CompoundType.class, name, -1, -1));
         // tag does not contribute to hash or equality
         this.tag = tag;
         this.name = name;
@@ -60,7 +60,8 @@ public final class CompoundType extends ValueType {
     }
 
     CompoundType(final TypeSystem typeSystem, final Tag tag, final String name) {
-        super(typeSystem, CompoundType.class.hashCode());
+        super(typeSystem, Objects.hash(CompoundType.class, name, 0, 1));
+        // tag does not contribute to hash or equality
         this.tag = tag;
         this.name = name;
         this.size = 0;

--- a/runtime/bsd/src/main/java/org/qbicc/runtime/bsd/Ifaddrs.java
+++ b/runtime/bsd/src/main/java/org/qbicc/runtime/bsd/Ifaddrs.java
@@ -6,7 +6,7 @@ import static org.qbicc.runtime.posix.SysSocket.*;
 @include("<ifaddrs.h>")
 public class Ifaddrs {
     public static class struct_ifaddrs extends object {
-        public void_ptr /* struct_ifaddrs_ptr */ ifa_next;  // TODO: void_ptr is a hack; struct_ifaddrs_ptr causes a StackOverflowException in qbicc
+        public ptr<struct_ifaddrs> ifa_next;
         public char_ptr ifa_name;
         public unsigned_int ifa_flags;
         public struct_sockaddr_ptr ifa_addr;


### PR DESCRIPTION
Avoid requiring the hashCode of all members to be computed as part of computing the hashCode of a CompoundType.  This avoids an infinite recursion when the CompoundType is a C-struct that contains an member which is a pointer to the same type, the default idiom for defining linked data structures in C.