### PR TITLE
Limit errors from `llc` to 1536 characters, and cap errors and warnings by default

### DIFF
--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/process/LimitedAppendable.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/process/LimitedAppendable.java
@@ -1,0 +1,49 @@
+package org.qbicc.machine.tool.process;
+
+import java.io.IOException;
+
+/**
+ * A limited-size appendable.
+ */
+public final class LimitedAppendable implements Appendable {
+    final Appendable delegate;
+    final int limit;
+    int size;
+
+    public LimitedAppendable(Appendable delegate, int limit) {
+        this.delegate = delegate;
+        this.limit = limit;
+    }
+
+    @Override
+    public Appendable append(CharSequence csq) throws IOException {
+        return append(csq, 0, csq.length());
+    }
+
+    @Override
+    public Appendable append(CharSequence csq, int start, int end) throws IOException {
+        if (start > end || start < 0) {
+            throw new IllegalArgumentException();
+        }
+        int amt = end - start;
+        if (amt > 0) {
+            final int rem = limit - size;
+            if (amt < rem) {
+                size += amt;
+                delegate.append(csq, start, end);
+            } else if (rem > 0) {
+                size += rem;
+                delegate.append(csq, start, start + rem);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public Appendable append(char c) throws IOException {
+        if (size < limit) {
+            delegate.append(c);
+        }
+        return this;
+    }
+}

--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/AbstractLlvmInvoker.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/AbstractLlvmInvoker.java
@@ -9,6 +9,7 @@ import java.util.List;
 import io.smallrye.common.constraint.Assert;
 import org.qbicc.machine.tool.ToolMessageHandler;
 import org.qbicc.machine.tool.process.InputSource;
+import org.qbicc.machine.tool.process.LimitedAppendable;
 import org.qbicc.machine.tool.process.OutputDestination;
 
 /**
@@ -61,7 +62,7 @@ abstract class AbstractLlvmInvoker implements LlvmInvoker {
 
     public OutputDestination invokerAsDestination() {
         StringBuilder b = new StringBuilder();
-        OutputDestination errorHandler = OutputDestination.of(b, StandardCharsets.UTF_8);
+        OutputDestination errorHandler = OutputDestination.of(new LimitedAppendable(b, 1536), StandardCharsets.UTF_8);
         List<String> cmd = new ArrayList<>();
         cmd.add(execPath.toString());
         addArguments(cmd);


### PR DESCRIPTION
It's just fixed at 100 for now, we can make it an option later though.