### PR TITLE
improve serialization of Throwable instances

### DIFF
--- a/compiler/src/main/java/org/qbicc/interpreter/VmThrowable.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/VmThrowable.java
@@ -11,4 +11,6 @@ public interface VmThrowable extends VmObject {
     VmThrowable getCause();
 
     StackTraceElement[] getStackTrace();
+
+    void prepareForSerialization();
 }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableClassImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmThrowableClassImpl.java
@@ -21,7 +21,7 @@ class VmThrowableClassImpl extends VmClassImpl implements VmThrowableClass {
     @Override
     VmThrowableImpl newInstance() {
         VmThrowableImpl throwable = new VmThrowableImpl(this);
-        throwable.initializeDepth();
+        throwable.captureBacktrace();
         return throwable;
     }
 
@@ -30,7 +30,7 @@ class VmThrowableClassImpl extends VmClassImpl implements VmThrowableClass {
         VmThrowableImpl throwable = new VmThrowableImpl(this);
         VmImpl vm = getVm();
         vm.manuallyInitialize(throwable);
-        throwable.initializeDepth();
+        throwable.captureBacktrace();
         LoadedTypeDefinition typeDefinition = getTypeDefinition();
         ClassContext context = typeDefinition.getContext();
         ClassTypeDescriptor jls = ClassTypeDescriptor.synthesize(context, "java/lang/String");
@@ -47,7 +47,7 @@ class VmThrowableClassImpl extends VmClassImpl implements VmThrowableClass {
         VmThrowableImpl throwable = new VmThrowableImpl(this);
         VmImpl vm = getVm();
         vm.manuallyInitialize(throwable);
-        throwable.initializeDepth();
+        throwable.captureBacktrace();
         LoadedTypeDefinition typeDefinition = getTypeDefinition();
         ClassContext context = typeDefinition.getContext();
         ClassTypeDescriptor jlt = ClassTypeDescriptor.synthesize(context, "java/lang/Throwable");
@@ -64,7 +64,7 @@ class VmThrowableClassImpl extends VmClassImpl implements VmThrowableClass {
         VmThrowableImpl throwable = new VmThrowableImpl(this);
         VmImpl vm = getVm();
         vm.manuallyInitialize(throwable);
-        throwable.initializeDepth();
+        throwable.captureBacktrace();
         LoadedTypeDefinition typeDefinition = getTypeDefinition();
         ClassContext context = typeDefinition.getContext();
         ClassTypeDescriptor jls = ClassTypeDescriptor.synthesize(context, "java/lang/String");

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -15,6 +15,7 @@ import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmReferenceArray;
 import org.qbicc.interpreter.VmStaticFieldBaseObject;
 import org.qbicc.interpreter.VmString;
+import org.qbicc.interpreter.VmThrowable;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.pointer.ConstructorPointer;
@@ -86,6 +87,10 @@ class BuildtimeHeapAnalyzer {
             if (cur instanceof VmStaticFieldBaseObject) {
                 // skip
                 continue;
+            }
+
+            if (cur instanceof VmThrowable t) {
+                t.prepareForSerialization();
             }
 
             PhysicalObjectType ot = cur.getObjectType();


### PR DESCRIPTION
Add a hook to the BuildTimeHeapAnalyzer to ensure that the stackTrace field of each reachable Throwable instances is fully constructed at build time from its interpreter backtrace.  This enables inspection of the StackTraceElements of build time exceptions at runtime.