### PR TITLE
Fix wrong var signature issue

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BlockParameter.java
+++ b/compiler/src/main/java/org/qbicc/graph/BlockParameter.java
@@ -16,8 +16,8 @@ public final class BlockParameter extends AbstractValue implements PinnedNode {
     private final BlockLabel blockLabel;
     private final Slot slot;
 
-    BlockParameter(Node callSite, ExecutableElement element, ValueType type, boolean nullable, BlockLabel blockLabel, Slot slot) {
-        super(callSite, element, 0, -1);
+    BlockParameter(Node callSite, ExecutableElement element, int line, int bci, ValueType type, boolean nullable, BlockLabel blockLabel, Slot slot) {
+        super(callSite, element, line, bci);
         this.type = type;
         this.nullable = nullable;
         this.blockLabel = blockLabel;

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -80,7 +80,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder {
         if (nullable && ! (type instanceof NullableType)) {
             throw new IllegalArgumentException("Parameter can only be nullable if its type is nullable");
         }
-        parameter = new BlockParameter(callSite, element, type, nullable, owner, slot);
+        parameter = new BlockParameter(callSite, element, line, bci, type, nullable, owner, slot);
         subMap.put(slot, parameter);
         return parameter;
     }

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassMethodInfo.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/ClassMethodInfo.java
@@ -282,7 +282,7 @@ final class ClassMethodInfo {
                                 // already have an entry for it
                                 throw new InvalidLocalVariableIndexException();
                             }
-                            array[lvt ? 3 : 4] = (short) typeIdx;
+                            array[base + (lvt ? 3 : 4)] = (short) typeIdx;
                         } else {
                             // insert
                             idx = -idx - 1;


### PR DESCRIPTION
When merging LVT entries, we were always applying signatures to the first entry instead of the corresponding entry.

Also, let's tag `BlockParamater` with line & bci info.