### PR TITLE
stub out GraalVM's ImageInfo class for Quarkus 2.14

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/BuildIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/BuildIntrinsics.java
@@ -42,6 +42,14 @@ final class BuildIntrinsics {
         intrinsics.registerIntrinsic(buildDesc, "isJvm", emptyToBool, (builder, targetPtr, arguments) ->
             builder.getLiteralFactory().literalOf(false)
         );
+
+        // TODO: works around direct reference to org.graalvm.nativeimage.ImageInfo in quarkus 2.14
+        //       Once we upgrade quarkus-qbicc to a Quarkus version that includes
+        //       https://github.com/quarkusio/quarkus/pull/29993 we can get rid of this Hook.
+        ClassTypeDescriptor imageInfo = ClassTypeDescriptor.synthesize(classContext, "org/graalvm/nativeimage/ImageInfo");
+        intrinsics.registerIntrinsic(imageInfo, "inImageBuildtimeCode", emptyToBool, (builder, targetPtr, arguments) ->
+            builder.getLiteralFactory().literalOf(true)
+        );
     }
 
     private static void registerHostIntrinsics(final Intrinsics intrinsics, final CompilationContext ctxt) {

--- a/runtime/api/src/main/java/org/graalvm/nativeimage/ImageInfo.java
+++ b/runtime/api/src/main/java/org/graalvm/nativeimage/ImageInfo.java
@@ -1,0 +1,8 @@
+package org.graalvm.nativeimage;
+
+// TODO: works around direct reference to org.graalvm.nativeimage.ImageInfo in quarkus 2.14
+//       Once we upgrade quarkus-qbicc to a Quarkus version that includes
+//       https://github.com/quarkusio/quarkus/pull/29993 we can get rid of this Hook.
+public class ImageInfo {
+    public static native boolean inImageBuildtimeCode();
+}


### PR DESCRIPTION
I was hoping to avoid defining the stub class, but we insist on loading it before we see if a static method is an intrinsic.  The alternative would be to put the real Graal jar file in the class path,  but that seems even less desirable than this kludge.
