### PR TITLE
Tidy up `toString` for values

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/AbstractValue.java
+++ b/compiler/src/main/java/org/qbicc/graph/AbstractValue.java
@@ -46,6 +46,6 @@ abstract class AbstractValue extends AbstractNode implements Value {
 
     @Override
     public StringBuilder toReferenceString(StringBuilder b) {
-        return toLValueString(b).append('<').append(getNodeName()).append('>');
+        return toLValueString(b);
     }
 }


### PR DESCRIPTION
Having the node name on the output is often distracting and makes things harder to read, not easier.