### PR TITLE
use relative paths for input files to linker command

### DIFF
--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/LinkerInvoker.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/LinkerInvoker.java
@@ -33,8 +33,9 @@ public interface LinkerInvoker extends MessagingToolInvoker {
     void addObjectFile(Path path);
 
     default void addObjectFiles(Iterable<Path> paths) {
+        Path wd = getWorkingDirectory();
         for (Path path : paths) {
-            addObjectFile(path);
+            addObjectFile(wd ==  null ? path : wd.relativize(path));
         }
     }
 

--- a/machine/tool/api/src/main/java/org/qbicc/machine/tool/ToolInvoker.java
+++ b/machine/tool/api/src/main/java/org/qbicc/machine/tool/ToolInvoker.java
@@ -22,6 +22,16 @@ public interface ToolInvoker {
     Path getPath();
 
     /**
+     * Get the program's working directory (null means use the same directory as the parent process)
+     */
+    Path getWorkingDirectory();
+
+    /**
+     * Set the program's working directory
+     */
+    void setWorkingDirectory(Path path);
+
+    /**
      * Invoke the program.
      *
      * @throws IOException if program invocation failed for some reason

--- a/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/AbstractClangInvoker.java
+++ b/machine/tool/clang/src/main/java/org/qbicc/machine/tool/clang/AbstractClangInvoker.java
@@ -24,6 +24,7 @@ abstract class AbstractClangInvoker implements MessagingToolInvoker {
 
     private final ClangToolChainImpl tool;
     private ToolMessageHandler messageHandler = ToolMessageHandler.DISCARDING;
+    private Path workingDirectory;
 
     AbstractClangInvoker(final ClangToolChainImpl tool) {
         this.tool = tool;
@@ -44,6 +45,14 @@ abstract class AbstractClangInvoker implements MessagingToolInvoker {
     public Path getPath() {
         // only one executable for now
         return tool.getExecutablePath();
+    }
+
+    public Path getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public void setWorkingDirectory(Path workingDirectory) {
+        this.workingDirectory = workingDirectory;
     }
 
     static final Pattern DIAG_PATTERN = Pattern.compile(
@@ -96,6 +105,9 @@ abstract class AbstractClangInvoker implements MessagingToolInvoker {
         addArguments(cmd);
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(cmd);
+        if (getWorkingDirectory() != null) {
+            pb.directory(getWorkingDirectory().toFile());
+        }
         pb.environment().put("LC_ALL", "C");
         pb.environment().put("LANG", "C");
         getSource().transferTo(OutputDestination.of(pb, errorHandler, OutputDestination.discarding(), p -> {

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/AbstractEmscriptenInvoker.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/AbstractEmscriptenInvoker.java
@@ -26,6 +26,7 @@ abstract class AbstractEmscriptenInvoker implements MessagingToolInvoker {
 
     private final EmscriptenToolChainImpl tool;
     private ToolMessageHandler messageHandler = ToolMessageHandler.DISCARDING;
+    private Path workingDirectory;
 
     AbstractEmscriptenInvoker(final EmscriptenToolChainImpl tool) {
         this.tool = tool;
@@ -46,6 +47,14 @@ abstract class AbstractEmscriptenInvoker implements MessagingToolInvoker {
     public Path getPath() {
         // only one executable for now
         return tool.getExecutablePath();
+    }
+
+    public Path getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public void setWorkingDirectory(Path workingDirectory) {
+        this.workingDirectory = workingDirectory;
     }
 
     static final Pattern DIAG_PATTERN = Pattern.compile(
@@ -98,6 +107,9 @@ abstract class AbstractEmscriptenInvoker implements MessagingToolInvoker {
         addArguments(cmd);
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(cmd);
+        if (getWorkingDirectory() != null) {
+            pb.directory(getWorkingDirectory().toFile());
+        }
         pb.environment().put("LC_ALL", "C");
         pb.environment().put("LANG", "C");
         LOGGER.info(String.join(" ", cmd));

--- a/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
+++ b/machine/tool/emscripten/src/main/java/org/qbicc/machine/tool/emscripten/EmscriptenLinkerInvokerImpl.java
@@ -15,6 +15,7 @@ final class EmscriptenLinkerInvokerImpl extends AbstractEmscriptenInvoker implem
     private final List<String> libraries = new ArrayList<>(4);
     private final List<Path> objectFiles = new ArrayList<>(4);
     private Path outputPath = TMP.resolve("qbicc-output-image");
+    private Path workingDirectory;
     private boolean isPie = false;
 
     EmscriptenLinkerInvokerImpl(final EmscriptenToolChainImpl tool) {

--- a/machine/tool/gnu/src/main/java/org/qbicc/machine/tool/gnu/AbstractGccInvoker.java
+++ b/machine/tool/gnu/src/main/java/org/qbicc/machine/tool/gnu/AbstractGccInvoker.java
@@ -23,6 +23,7 @@ abstract class AbstractGccInvoker implements MessagingToolInvoker {
 
     private final GccToolChainImpl tool;
     private ToolMessageHandler messageHandler = ToolMessageHandler.DISCARDING;
+    private Path workingDirectory;
 
     AbstractGccInvoker(final GccToolChainImpl tool) {
         this.tool = tool;
@@ -43,6 +44,14 @@ abstract class AbstractGccInvoker implements MessagingToolInvoker {
     public Path getPath() {
         // only one executable for now
         return tool.getExecutablePath();
+    }
+
+    public Path getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public void setWorkingDirectory(Path workingDirectory) {
+        this.workingDirectory = workingDirectory;
     }
 
     static final Pattern DIAG_PATTERN = Pattern.compile("([^:]+):(?:(\\d+):(?:(\\d+):)?)? (?:((?:fatal )?error|warning|note): )?(.*)(?: \\[-[^]]+])?");
@@ -99,6 +108,9 @@ abstract class AbstractGccInvoker implements MessagingToolInvoker {
         addArguments(cmd);
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(cmd);
+        if (getWorkingDirectory() != null) {
+            pb.directory(getWorkingDirectory().toFile());
+        }
         pb.environment().put("LC_ALL", "C");
         pb.environment().put("LANG", "C");
         getSource().transferTo(OutputDestination.of(pb, errorHandler, OutputDestination.discarding(), p -> {

--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/AbstractLlvmInvoker.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/AbstractLlvmInvoker.java
@@ -18,6 +18,7 @@ import org.qbicc.machine.tool.process.OutputDestination;
 abstract class AbstractLlvmInvoker implements LlvmInvoker {
     private static final String LEVEL_PATTERN = "(?i:error|warning|note)";
     protected final LlvmToolChainImpl tool;
+    private Path workingDirectory;
     private final Path execPath;
     private InputSource source = InputSource.empty();
     private ToolMessageHandler messageHandler = ToolMessageHandler.DISCARDING;
@@ -60,6 +61,14 @@ abstract class AbstractLlvmInvoker implements LlvmInvoker {
         return destination;
     }
 
+    public Path getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public void setWorkingDirectory(Path workingDirectory) {
+        this.workingDirectory = workingDirectory;
+    }
+
     public OutputDestination invokerAsDestination() {
         StringBuilder b = new StringBuilder();
         OutputDestination errorHandler = OutputDestination.of(new LimitedAppendable(b, 1536), StandardCharsets.UTF_8);
@@ -68,6 +77,9 @@ abstract class AbstractLlvmInvoker implements LlvmInvoker {
         addArguments(cmd);
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(cmd);
+        if (getWorkingDirectory() != null) {
+            pb.directory(getWorkingDirectory().toFile());
+        }
         pb.environment().put("LC_ALL", "C");
         pb.environment().put("LANG", "C");
         return OutputDestination.of(pb, errorHandler, destination, p -> {

--- a/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmObjCopyInvokerImpl.java
+++ b/machine/tool/llvm/src/main/java/org/qbicc/tool/llvm/LlvmObjCopyInvokerImpl.java
@@ -21,6 +21,7 @@ public final class LlvmObjCopyInvokerImpl implements LlvmObjCopyInvoker {
     private Path objectFilePath;
     private ToolMessageHandler messageHandler = ToolMessageHandler.DISCARDING;
     private OutputDestination destination = OutputDestination.discarding();
+    private Path workingDirectory;
 
     LlvmObjCopyInvokerImpl(LlvmToolChain toolChain, Path execPath) {
         this.toolChain = toolChain;
@@ -37,6 +38,14 @@ public final class LlvmObjCopyInvokerImpl implements LlvmObjCopyInvoker {
 
     public Path getPath() {
         return execPath;
+    }
+
+    public Path getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public void setWorkingDirectory(Path workingDirectory) {
+        this.workingDirectory = workingDirectory;
     }
 
     public void invoke() throws IOException {
@@ -60,6 +69,9 @@ public final class LlvmObjCopyInvokerImpl implements LlvmObjCopyInvoker {
         cmd.add(objectFilePath.toString());
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(cmd);
+        if (getWorkingDirectory() != null) {
+            pb.directory(getWorkingDirectory().toFile());
+        }
         pb.environment().put("LC_ALL", "C");
         pb.environment().put("LANG", "C");
         return OutputDestination.of(pb, errorHandler, destination, p -> {

--- a/plugins/linker/src/main/java/org/qbicc/plugin/linker/LinkStage.java
+++ b/plugins/linker/src/main/java/org/qbicc/plugin/linker/LinkStage.java
@@ -33,6 +33,7 @@ public class LinkStage implements Consumer<CompilationContext> {
         }
         LinkerInvoker linkerInvoker = cToolChain.newLinkerInvoker();
         Linker linker = Linker.get(context);
+        linkerInvoker.setWorkingDirectory(context.getOutputDirectory());
         linkerInvoker.addObjectFiles(linker.getObjectFilePathsInLinkOrder());
         linkerInvoker.addLibraries(linker.getLibraries());
         linkerInvoker.addLibraryPaths(librarySearchPaths);


### PR DESCRIPTION
Workaround problems with long linker command lines by using paths relative to the tool's working directory for the input object files.