### PR TITLE
ImageInfo fixes

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/BuildIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/BuildIntrinsics.java
@@ -42,14 +42,6 @@ final class BuildIntrinsics {
         intrinsics.registerIntrinsic(buildDesc, "isJvm", emptyToBool, (builder, targetPtr, arguments) ->
             builder.getLiteralFactory().literalOf(false)
         );
-
-        // TODO: works around direct reference to org.graalvm.nativeimage.ImageInfo in quarkus 2.14
-        //       Once we upgrade quarkus-qbicc to a Quarkus version that includes
-        //       https://github.com/quarkusio/quarkus/pull/29993 we can get rid of this Hook.
-        ClassTypeDescriptor imageInfo = ClassTypeDescriptor.synthesize(classContext, "org/graalvm/nativeimage/ImageInfo");
-        intrinsics.registerIntrinsic(imageInfo, "inImageBuildtimeCode", emptyToBool, (builder, targetPtr, arguments) ->
-            builder.getLiteralFactory().literalOf(true)
-        );
     }
 
     private static void registerHostIntrinsics(final Intrinsics intrinsics, final CompilationContext ctxt) {

--- a/runtime/api/src/main/java/org/graalvm/nativeimage/ImageInfo.java
+++ b/runtime/api/src/main/java/org/graalvm/nativeimage/ImageInfo.java
@@ -1,8 +1,15 @@
 package org.graalvm.nativeimage;
 
+import org.qbicc.runtime.Build;
+
 // TODO: works around direct reference to org.graalvm.nativeimage.ImageInfo in quarkus 2.14
 //       Once we upgrade quarkus-qbicc to a Quarkus version that includes
 //       https://github.com/quarkusio/quarkus/pull/29993 we can get rid of this Hook.
 public class ImageInfo {
-    public static native boolean inImageBuildtimeCode();
+    public static boolean inImageBuildtimeCode() {
+        return Build.isHost();
+    }
+    public static boolean inImageRuntimeCode() {
+        return Build.isTarget();
+    }
 }


### PR DESCRIPTION
1. Quarkus also expects inImageRuntimeCore
2. Simplify implementation by using Build.isHost/isTarget