### PR TITLE
Make annotations available at runtime for reflective classes

### DIFF
--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/FeaturePatcher.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/FeaturePatcher.java
@@ -54,6 +54,10 @@ public class FeaturePatcher {
         }
     }
 
+    public boolean isReflectiveClass(String internalName) {
+        return reflectiveClasses.containsKey(internalName);
+    }
+
     public void addReflectiveConstructor(String className, String[] parameterTypes) {
         reflectiveConstructors.computeIfAbsent(className, k -> ConcurrentHashMap.newKeySet()).add(encodeArguments(parameterTypes));
     }
@@ -127,14 +131,14 @@ public class FeaturePatcher {
         if (args == null || args.length == 0) {
             return "";
         }
-        if (args.length == 1 && args.equals("*")) {
+        if (args.length == 1 && args[0].equals("*")) {
             return "*"; // wildcard -- matches all args
         }
-        String ans = toDescriptorString(args[0]);
+        StringBuilder ans = new StringBuilder(toDescriptorString(args[0]));
         for (int i = 1; i<args.length; i++) {
-            ans = ans + "," + toDescriptorString(args[i]);
+            ans.append(",").append(toDescriptorString(args[i]));
         }
-        return ans;
+        return ans.toString();
     }
 
     private String toDescriptorString(String t) {

--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureTypeBuilder.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureTypeBuilder.java
@@ -20,6 +20,7 @@ public class QbiccFeatureTypeBuilder implements DefinedTypeDefinition.Builder.De
     private final DefinedTypeDefinition.Builder delegate;
     private final ClassContext classContext;
     private boolean runtimeInitialized;
+    private boolean reflectiveClass;
     private boolean reflectiveFields;
     private boolean reflectiveConstructors;
     private boolean reflectiveMethods;
@@ -41,6 +42,9 @@ public class QbiccFeatureTypeBuilder implements DefinedTypeDefinition.Builder.De
         FeaturePatcher fp = FeaturePatcher.get(classContext.getCompilationContext());
         if (fp.isRuntimeInitializedClass(internalName)) {
             runtimeInitialized = true;
+        }
+        if (fp.isReflectiveClass(internalName)) {
+            reflectiveClass = true;
         }
         if (fp.hasReflectiveConstructors(internalName)) {
             reflectiveConstructors = true;
@@ -127,6 +131,15 @@ public class QbiccFeatureTypeBuilder implements DefinedTypeDefinition.Builder.De
         } else {
             delegate.addField(resolver, index, name, descriptor);
         }
+    }
+
+    @Override
+    public DefinedTypeDefinition build() {
+        DefinedTypeDefinition result = delegate.build();
+        if (reflectiveClass) {
+            ReachabilityRoots.get(classContext.getCompilationContext()).registerReflectiveClass(result.load());
+        }
+        return result;
     }
 
     static class RuntimeInitFieldResolver implements FieldResolver {

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityRoots.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/ReachabilityRoots.java
@@ -104,7 +104,6 @@ public class ReachabilityRoots {
             info.processRootReachableElement(e);
         }
         for (LoadedTypeDefinition ltd : roots.reflectiveClasses) {
-            ReachabilityInfo.LOGGER.debugf("Reflectively accessed type %s made reachable", ltd.toString());
             info.getAnalysis().processReachableType(ltd, null);
         }
         for (ExecutableElement e : roots.reflectiveMethods) {
@@ -135,6 +134,10 @@ public class ReachabilityRoots {
         for (ExecutableElement e : roots.dispatchTableMethods) {
             ctxt.enqueue(e);
         }
+    }
+
+    public boolean isReflectiveClass(LoadedTypeDefinition ltd) {
+        return reflectiveClasses.contains(ltd);
     }
 
     public Set<LoadedTypeDefinition> getReflectiveClasses() {

--- a/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/Reflection.java
+++ b/plugins/reflection/src/main/java/org/qbicc/plugin/reflection/Reflection.java
@@ -370,7 +370,9 @@ public final class Reflection {
     }
 
     public void generateReflectiveData(LoadedTypeDefinition ltd) {
-        if (!ltd.getVisibleAnnotations().isEmpty() || (!ltd.isInterface() && hasInheritedAnnotations(ltd))) {
+        if (!ltd.getVisibleAnnotations().isEmpty()
+            || (!ltd.isInterface() && hasInheritedAnnotations(ltd))
+            || ReachabilityRoots.get(ctxt).isReflectiveClass(ltd)) {
             MethodElement annotationData = classClass.getTypeDefinition().requireSingleMethod("annotationData");
             vm.invokeExact(annotationData, ltd.getVmClass(), List.of());
         }


### PR DESCRIPTION
If a class has been registered for some reflective operations, then ensure its annotationData is generated at build time so that we can support runtime reflection over its annotations.