### PR TITLE
bug fix: must defer loading defined type to a separate task

### DIFF
--- a/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureTypeBuilder.java
+++ b/plugins/initialization-control/src/main/java/org/qbicc/plugin/initializationcontrol/QbiccFeatureTypeBuilder.java
@@ -137,7 +137,10 @@ public class QbiccFeatureTypeBuilder implements DefinedTypeDefinition.Builder.De
     public DefinedTypeDefinition build() {
         DefinedTypeDefinition result = delegate.build();
         if (reflectiveClass) {
-            ReachabilityRoots.get(classContext.getCompilationContext()).registerReflectiveClass(result.load());
+            ReachabilityRoots rr = ReachabilityRoots.get(classContext.getCompilationContext());
+            classContext.getCompilationContext().submitTask(result, dtd -> {
+                rr.registerReflectiveClass(dtd.load());
+            });
         }
         return result;
     }


### PR DESCRIPTION
Eager loading here violates the protocol used by qbicc to deal with cyclic type references.