### PR TITLE
Add support for resource loading from any class loader

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/CompilationContext.java
+++ b/compiler/src/main/java/org/qbicc/context/CompilationContext.java
@@ -18,10 +18,9 @@ import org.qbicc.interpreter.Vm;
 import org.qbicc.interpreter.VmClassLoader;
 import org.qbicc.machine.arch.Platform;
 import org.qbicc.object.Function;
-import org.qbicc.object.ProgramModule;
 import org.qbicc.object.ModuleSection;
+import org.qbicc.object.ProgramModule;
 import org.qbicc.object.Section;
-import org.qbicc.object.Segment;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.InvokableType;
 import org.qbicc.type.TypeSystem;
@@ -55,6 +54,8 @@ public interface CompilationContext extends DiagnosticContext {
     ClassContext constructClassContext(VmClassLoader classLoaderObject);
 
     ClassContext constructAppClassLoaderClassContext(VmClassLoader appClassLoaderObject);
+
+    ClassContext constructPlatformClassContext(VmClassLoader platformClassLoaderObject);
 
     <T> void submitTask(T item, Consumer<T> itemConsumer);
 

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -74,6 +74,10 @@ public class TestClassContext implements ClassContext {
             return null;
         }
 
+        public ClassContext constructPlatformClassContext(final VmClassLoader platformClassLoaderObject) {
+            return null;
+        }
+
         public <T> void submitTask(T item, Consumer<T> itemConsumer) {
         }
 

--- a/driver/src/main/java/org/qbicc/driver/Driver.java
+++ b/driver/src/main/java/org/qbicc/driver/Driver.java
@@ -160,7 +160,28 @@ public class Driver implements Closeable {
         java.util.function.Function<CompilationContext, Vm> vmFactory = Assert.checkNotNullParam("builder.vmFactory", builder.vmFactory);
         NativeMethodConfigurator nativeMethodConfigurator = constructNativeMethodConfigurator(builder);
         Scheduler scheduler = new Scheduler(Scheduler.Mode.EARLY);
-        compilationContext = new CompilationContextImpl(initialContext, builder.targetPlatform, typeSystem, literalFactory, scheduler, this::defaultFinder, this::defaultResourceFinder, this::defaultResourcesFinder, this::appFinder, this::appResourceFinder, this::appResourcesFinder, vmFactory, outputDir, resolverFactories, typeBuilderFactories, nativeMethodConfigurator, classContextListener);
+        CompilationContextImpl.Builder ctxtBuilder = CompilationContextImpl.builder()
+            .setBaseDiagnosticContext(initialContext)
+            .setPlatform(builder.targetPlatform)
+            .setTypeSystem(typeSystem)
+            .setLiteralFactory(literalFactory)
+            .setScheduler(scheduler)
+            .setBootstrapFinder(this::defaultFinder)
+            .setBootstrapResourceFinder(this::defaultResourceFinder)
+            .setBootstrapResourcesFinder(this::defaultResourcesFinder)
+            .setAppFinder(this::appFinder)
+            .setAppResourceFinder(this::appResourceFinder)
+            .setAppResourcesFinder(this::appResourcesFinder)
+            .setPlatformFinder(this::platFinder)
+            .setPlatformResourceFinder(this::platResourceFinder)
+            .setPlatformResourcesFinder(this::platResourcesFinder)
+            .setVmFactory(vmFactory)
+            .setOutputDir(outputDir)
+            .setResolverFactories(resolverFactories)
+            .setTypeBuilderFactories(typeBuilderFactories)
+            .setNativeMethodConfigurator(nativeMethodConfigurator)
+            .setClassContextListener(classContextListener);
+        compilationContext = ctxtBuilder.build();
         // start with ADD
         compilationContext.setBlockFactory(addBuilderFactory);
 
@@ -277,6 +298,25 @@ public class Driver implements Closeable {
 
     private List<byte[]> appResourcesFinder(final ClassContext classContext, final String name) {
         return findResources(classContext, name, appClassPath);
+    }
+
+    private DefinedTypeDefinition platFinder(ClassContext classContext, String name) {
+        DefinedTypeDefinition found;
+        found = getCompilationContext().getBootstrapClassContext().findDefinedType(name);
+        if (found == null) {
+            // todo: search platform class loader
+        }
+        return found;
+    }
+
+    private byte[] platResourceFinder(ClassContext classContext, String name) {
+        // todo: search platform class loader
+        return null;
+    }
+
+    private List<byte[]> platResourcesFinder(final ClassContext classContext, final String name) {
+        // todo: search platform class loader
+        return List.of();
     }
 
     private DefinedTypeDefinition findClassDefinition(final ClassContext classContext, final String name, final List<ClassPathItem> classPath) {


### PR DESCRIPTION
* Change `CompilationContextImpl` to use a builder since the argument list is so long
* Add initial support for the platform class loader
* Handle all "special" class loaders identically