### PR TITLE
Correctly handle LLVM pointer-backed references

### DIFF
--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
@@ -73,19 +73,22 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder {
 
     @Override
     public Value decodeReference(Value reference, PointerType pointerType) {
-        // convert reference to pointer with lower type
-        Layout layout = Layout.get(ctxt);
-        ReferenceType referenceType = (ReferenceType) reference.getType();
-        ObjectType upperBound = referenceType.getUpperBound();
-        LayoutInfo info;
-        if (upperBound instanceof ReferenceArrayObjectType raot) {
-            info = layout.getArrayLayoutInfo(CoreClasses.get(ctxt).getArrayContentField(upperBound).getEnclosingType(), raot.getElementObjectType());
-        } else if (upperBound instanceof ArrayObjectType) {
-            info = layout.getInstanceLayoutInfo(CoreClasses.get(ctxt).getArrayContentField(upperBound).getEnclosingType());
+        if (reference.getType() instanceof ReferenceType referenceType) {
+            // convert reference to pointer with lower type
+            Layout layout = Layout.get(ctxt);
+            ObjectType upperBound = referenceType.getUpperBound();
+            LayoutInfo info;
+            if (upperBound instanceof ReferenceArrayObjectType raot) {
+                info = layout.getArrayLayoutInfo(CoreClasses.get(ctxt).getArrayContentField(upperBound).getEnclosingType(), raot.getElementObjectType());
+            } else if (upperBound instanceof ArrayObjectType) {
+                info = layout.getInstanceLayoutInfo(CoreClasses.get(ctxt).getArrayContentField(upperBound).getEnclosingType());
+            } else {
+                info = layout.getInstanceLayoutInfo(upperBound.getDefinition());
+            }
+            return super.decodeReference(reference, info.getCompoundType().getPointer());
         } else {
-            info = layout.getInstanceLayoutInfo(upperBound.getDefinition());
+            return super.decodeReference(reference, pointerType);
         }
-        return super.decodeReference(reference, info.getCompoundType().getPointer());
     }
 
     @Override

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -59,17 +59,13 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
 
     @Override
     public Value decodeReference(Value refVal, PointerType pointerType) {
-        if (config.getReferenceStrategy() == ReferenceStrategy.POINTER) {
-            return refVal;
-        }
+        // this won't be scheduled by the LLVM backend when pointer strategy is in use
         return super.decodeReference(refVal, pointerType);
     }
 
     @Override
     public Value valueConvert(Value value, WordType toType) {
-        if (toType instanceof ReferenceType && value.getType() instanceof PointerType && config.getReferenceStrategy() == ReferenceStrategy.POINTER) {
-            return value;
-        }
+        // this won't be scheduled by the LLVM backend when pointer strategy is in use
         return super.valueConvert(value, toType);
     }
 

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -278,12 +278,12 @@ final class LLVMModuleNodeVisitor implements LiteralVisitor<Void, LLValue> {
             return Values.ptrtointConstant(input, fromType, toType);
         } else if (inputType instanceof ReferenceType && outputType instanceof PointerType) {
             return switch (config.getReferenceStrategy()) {
-                case POINTER -> throw new IllegalStateException("Cast found with pointer ref strategy");
+                case POINTER -> input;
                 case POINTER_AS1 -> Values.addrspacecastConstant(input, fromType, toType);
             };
         } else if (inputType instanceof PointerType && outputType instanceof ReferenceType) {
             return switch (config.getReferenceStrategy()) {
-                case POINTER -> throw new IllegalStateException("Cast found with pointer ref strategy");
+                case POINTER -> input;
                 case POINTER_AS1 -> Values.addrspacecastConstant(input, fromType, toType);
             };
         }


### PR DESCRIPTION
The difference is mostly whitespace so [ignore whitespace](https://github.com/qbicc/qbicc/pull/1685/files?diff=unified&w=1) for an easier review.