### PR TITLE
use ptr<_Float64> instead of _Float64[] to avoid bug

### DIFF
--- a/runtime/linux/src/main/java/org/qbicc/runtime/linux/Stdlib.java
+++ b/runtime/linux/src/main/java/org/qbicc/runtime/linux/Stdlib.java
@@ -8,7 +8,6 @@ import static org.qbicc.runtime.CNative.*;
 @include("<stdlib.h>")
 @define(value = "_DEFAULT_SOURCE")
 public final class Stdlib {
-    // heap
 
-    public static native c_int getloadavg(_Float64[] loadavg, c_int nelem);
+    public static native c_int getloadavg(ptr<_Float64> loadavg, c_int nelem);
 }


### PR DESCRIPTION
Works around what appears to be a codegen bug where it appears the stack-allocated _Float[64] array whish is the argument is being exploded at the callsite causing a mismatch in function type.