### PR TITLE
bug fix in lazy resolution of deref in call argument list

### DIFF
--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/DeferenceBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/DeferenceBasicBlockBuilder.java
@@ -588,7 +588,7 @@ public final class DeferenceBasicBlockBuilder extends DelegatingBasicBlockBuilde
     private List<Value> rhs(final List<Value> vals) {
         for (Value val : vals) {
             if (val instanceof Dereference) {
-                List<Value> newVals = new ArrayList<>(vals);
+                List<Value> newVals = new ArrayList<>();
                 for (Value value : vals) {
                     newVals.add(rhs(value));
                 }


### PR DESCRIPTION
The code was mistakenly appending the resolved dereference codes to a copy of the original argument array, thus in effect rewriting the call to take 2x as many arguments!