### PR TITLE
Add `reference`, a word-view of an object reference

### DIFF
--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -79,6 +79,7 @@ final class CNativeIntrinsics {
 
         ClassTypeDescriptor cNativeDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/CNative");
         ClassTypeDescriptor typeIdDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/CNative$type_id");
+        ClassTypeDescriptor referenceDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/CNative$reference");
         ClassTypeDescriptor objDesc = ClassTypeDescriptor.synthesize(classContext, "java/lang/Object");
         ArrayTypeDescriptor objArrayDesc = ArrayTypeDescriptor.of(classContext, objDesc);
         ClassTypeDescriptor nObjDesc = ClassTypeDescriptor.synthesize(classContext, "org/qbicc/runtime/CNative$object");
@@ -106,6 +107,12 @@ final class CNativeIntrinsics {
 
         MethodDescriptor objTypeIdDesc = MethodDescriptor.synthesize(classContext, typeIdDesc, List.of(objDesc));
         MethodDescriptor objArrayTypeIdDesc = MethodDescriptor.synthesize(classContext, typeIdDesc, List.of(objArrayDesc));
+
+        MethodDescriptor objToReference = MethodDescriptor.synthesize(classContext, referenceDesc, List.of(objDesc));
+        MethodDescriptor toObject = MethodDescriptor.synthesize(classContext, objDesc, List.of());
+
+        intrinsics.registerIntrinsic(referenceDesc, "of", objToReference, (builder, targetPtr, arguments) -> arguments.get(0));
+        intrinsics.registerIntrinsic(referenceDesc, "toObject", toObject, (builder, instance, targetPtr, arguments) -> instance);
 
         StaticIntrinsic typeOf = (builder, target, arguments) ->
             builder.loadTypeId(arguments.get(0));

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
@@ -44,6 +44,8 @@ final class Native {
     static final String TYPE_ID_INT_NAME = intName(type_id.class);
     static final String TYPE_ID = className(type_id.class);
     static final String HEADER_TYPE = className(header_type.class);
+    static final String REFERENCE_INT_NAME = intName(reference.class);
+    static final String REFERENCE = className(reference.class);
     static final String VOID = className(c_void.class);
     static final String PTR = className(ptr.class);
     static final String WORD = className(word.class);

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeResolver.java
@@ -1,11 +1,24 @@
 package org.qbicc.plugin.native_;
 
+import java.util.List;
+
+import org.qbicc.context.ClassContext;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.plugin.coreclasses.HeaderBits;
+import org.qbicc.type.ReferenceType;
 import org.qbicc.type.ValueType;
-import org.qbicc.context.ClassContext;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.DescriptorTypeResolver;
+import org.qbicc.type.descriptor.ClassTypeDescriptor;
+import org.qbicc.type.descriptor.TypeDescriptor;
+import org.qbicc.type.generic.BoundTypeArgument;
+import org.qbicc.type.generic.NestedClassTypeSignature;
+import org.qbicc.type.generic.ReferenceTypeSignature;
+import org.qbicc.type.generic.TopLevelClassTypeSignature;
+import org.qbicc.type.generic.TypeArgument;
+import org.qbicc.type.generic.TypeParameterContext;
+import org.qbicc.type.generic.TypeSignature;
+import org.qbicc.type.generic.Variance;
 
 /**
  * This type resolver is responsible for translating Java reference types such as {@code CNative.c_int} into the
@@ -33,6 +46,9 @@ public class NativeTypeResolver implements DescriptorTypeResolver.Delegating {
                 return classCtxt.findDefinedType("java/lang/Object").load().getClassType().getReference().getTypeType();
             } else if (rewrittenName.equals(Native.HEADER_TYPE)) {
                 return HeaderBits.get(ctxt).getHeaderType();
+            } else if (rewrittenName.equals(Native.REFERENCE)) {
+                // normally we'd handle this with generics, but a raw reference is OK too
+                return classCtxt.resolveTypeFromClassName("java/lang", "Object");
             } else if (rewrittenName.equals(Native.VOID)) {
                 return ctxt.getTypeSystem().getVoidType();
             } else if (rewrittenName.equals(Native.OBJECT)) {
@@ -48,5 +64,39 @@ public class NativeTypeResolver implements DescriptorTypeResolver.Delegating {
         }
         ValueType valueType = nativeInfo.resolveNativeType(definedType);
         return valueType == null ? delegate.resolveTypeFromClassName(packageName, rewrittenName) : valueType;
+    }
+
+    @Override
+    public ValueType resolveTypeFromDescriptor(TypeDescriptor descriptor, TypeParameterContext paramCtxt, TypeSignature signature) {
+        if (descriptor instanceof ClassTypeDescriptor ctd && ctd.packageAndClassNameEquals(Native.NATIVE_PKG, Native.REFERENCE_INT_NAME)) {
+            // try to access the generic type
+            if (signature instanceof NestedClassTypeSignature nc && nc.getIdentifier().equals(Native.REFERENCE)) {
+                // check the outer class
+                if (nc.getEnclosing() instanceof TopLevelClassTypeSignature cts && cts.getPackageName().equals(Native.NATIVE_PKG) && cts.getIdentifier().equals(Native.C_NATIVE)) {
+                    // OK, now look into the type arguments
+                    List<TypeArgument> typeArguments = nc.getTypeArguments();
+                    if (typeArguments.size() == 1) {
+                        TypeArgument typeArgument = typeArguments.get(0);
+                        if (typeArgument instanceof BoundTypeArgument bta) {
+                            Variance variance = bta.getVariance();
+                            if (variance == Variance.COVARIANT || variance == Variance.INVARIANT) {
+                                // either is acceptable
+                                ReferenceTypeSignature bound = bta.getBound();
+                                TypeDescriptor boundDesc = bound.asDescriptor(classCtxt);
+                                ValueType nestedType = classCtxt.resolveTypeFromDescriptor(boundDesc, paramCtxt, bound);
+                                if (nestedType instanceof ReferenceType rt) {
+                                    return rt;
+                                } else {
+                                    ctxt.error("Cannot convert %s into a reference type", nestedType);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // in some way it wasn't parseable
+            return classCtxt.resolveTypeFromClassName("java/lang", "Object");
+        }
+        return delegate.resolveTypeFromDescriptor(descriptor, paramCtxt, signature);
     }
 }

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -752,6 +752,29 @@ public final class CNative {
     public static final class header_type extends word {
     }
 
+    /**
+     * The special type which corresponds to a bitwise representation of an object reference.
+     *
+     * @param <B> the upper bounds
+     */
+    public static final class reference<B> extends word {
+        /**
+         * Get a {@code reference} for the given object reference.
+         *
+         * @param ref the object reference or {@code null}
+         * @return the {@code reference} or {@code null}
+         * @param <B> the upper bounds
+         */
+        public static native <B> reference<B> of(B ref);
+
+        /**
+         * Get an object reference for a {@code reference}.
+         *
+         * @return the object reference
+         */
+        public native B toObject();
+    }
+
     // basic types
 
     @name("char")


### PR DESCRIPTION
Allows an easier way to cast between references and other word types for GC code.