### PR TITLE
Deprecate pointer-form classes and methods; introduce non-generic pthread start function interface

### DIFF
--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/FunctionTypeResolver.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/FunctionTypeResolver.java
@@ -48,8 +48,7 @@ public class FunctionTypeResolver implements DescriptorTypeResolver.Delegating {
                     FunctionType functionType;
                     // check the signature
                     TypeSystem ts = ctxt.getTypeSystem();
-                    if (signature instanceof ClassTypeSignature) {
-                        ClassTypeSignature sig = (ClassTypeSignature) signature;
+                    if (signature instanceof ClassTypeSignature sig) {
                         if (! sig.getIdentifier().equals(Native.FUNCTION)) {
                             ctxt.warning("Incorrect generic signature (expected a %s but got \"%s\")", function.class, sig);
                             break out;
@@ -62,58 +61,53 @@ public class FunctionTypeResolver implements DescriptorTypeResolver.Delegating {
                         TypeArgument typeArgument = args.get(0);
                         if (typeArgument instanceof AnyTypeArgument) {
                             ctxt.error("Function types cannot be open-ended");
-                            functionType = ts.getFunctionType(ts.getVoidType());
+                            return ts.getFunctionType(ts.getVoidType(), List.of());
                         } else {
                             assert typeArgument instanceof BoundTypeArgument;
                             BoundTypeArgument bound = (BoundTypeArgument) typeArgument;
                             if (bound.getVariance() != Variance.INVARIANT) {
                                 ctxt.error("Function types cannot be open-ended");
+                                return ts.getFunctionType(ts.getVoidType(), List.of());
                             }
                             // looks right, get the proper pointee type
                             ReferenceTypeSignature pointeeSig = bound.getBound();
-                            // todo: use context to resolve type variable bounds
-                            TypeDescriptor pointeeDesc = pointeeSig.asDescriptor(classCtxt);
-                            if (pointeeDesc instanceof ClassTypeDescriptor) {
-                                ClassTypeDescriptor classDesc = (ClassTypeDescriptor) pointeeDesc;
-                                final String name;
-                                if (classDesc.getPackageName().isEmpty()) {
-                                    name = classDesc.getClassName();
-                                } else {
-                                    name = classDesc.getPackageName() + '/' + classDesc.getClassName();
-                                }
-                                if (name.equals("java/lang/Object")) {
-                                    // special case: it's really an "any" pointer with extra front-end guards on it
-                                    return ts.getVoidType().getPointer();
-                                }
-                                DefinedTypeDefinition definedType = classCtxt.findDefinedType(name);
-                                if (definedType == null) {
-                                    ctxt.error("Function interface type \"%s\" is missing", name);
-                                    functionType = ts.getFunctionType(ts.getVoidType());
-                                } else {
-                                    if (definedType.isInterface()) {
-                                        List<TypeArgument> functionalInterfaceArguments = ((ClassTypeSignature)bound.getBound()).getTypeArguments();
-                                        return NativeInfo.get(ctxt).getTypeOfFunctionalInterface(definedType, functionalInterfaceArguments);
-                                    } else {
-                                        ctxt.error("Function interface type \"%s\" is not an interface", name);
-                                        functionType = ts.getFunctionType(ts.getVoidType());
-                                    }
-                                }
-                            } else {
+                            if (! (pointeeSig instanceof ClassTypeSignature ctsBound)) {
                                 ctxt.error("Function pointee must be a functional interface");
-                                functionType = ts.getFunctionType(ts.getVoidType());
+                                return ts.getFunctionType(ts.getVoidType(), List.of());
+                            }
+                            // todo: use context to resolve type variable bounds
+                            ClassTypeDescriptor classDesc = ctsBound.asDescriptor(classCtxt);
+                            final String name;
+                            if (classDesc.getPackageName().isEmpty()) {
+                                name = classDesc.getClassName();
+                            } else {
+                                name = classDesc.getPackageName() + '/' + classDesc.getClassName();
+                            }
+                            if (name.equals("java/lang/Object")) {
+                                // special case: it's really an "any" pointer with extra front-end guards on it
+                                ctxt.error("Function types cannot be open-ended");
+                                return ts.getFunctionType(ts.getVoidType(), List.of());
+                            }
+                            DefinedTypeDefinition definedType = classCtxt.findDefinedType(name);
+                            if (definedType == null) {
+                                ctxt.error("Function interface type \"%s\" is missing", name);
+                                return ts.getFunctionType(ts.getVoidType(), List.of());
+                            } else {
+                                if (definedType.isInterface()) {
+                                    return NativeInfo.get(ctxt).getTypeOfFunctionalInterface(definedType, ctsBound);
+                                } else {
+                                    ctxt.error("Function interface type \"%s\" is not an interface", name);
+                                    return ts.getFunctionType(ts.getVoidType(), List.of());
+                                }
                             }
                         }
                     } else {
                         // todo: how can we cleanly get the location from here?
                         ctxt.warning("Generic signature type mismatch (expected a %s but got a %s)", ClassTypeSignature.class, signature.getClass());
-                        functionType = ts.getFunctionType(ts.getVoidType());
+                        functionType = ts.getFunctionType(ts.getVoidType(), List.of());
                     }
                     return functionType;
-                } else {
-                    break out;
                 }
-            } else {
-                break out;
             }
         }
         return getDelegate().resolveTypeFromDescriptor(descriptor, paramCtxt, signature);

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -402,6 +402,10 @@ final class NativeInfo {
 
     private ValueType decodePointerType(final DefinedTypeDefinition definedType) {
         TypeSystem ts = ctxt.getTypeSystem();
+        if (definedType.internalNameEquals("org/qbicc/runtime/CNative$function_ptr")) {
+            // xxx - this type will be removed in the future
+            return ts.getFunctionType(ts.getVoidType(), List.of()).getPointer();
+        }
         Signature signature = definedType.getSignature();
         ClassTypeSignature superClassSignature = signature instanceof ClassSignature cs ? cs.getSuperClassSignature() : null;
         List<TypeArgument> typeArguments = superClassSignature == null ? List.of() : superClassSignature.getTypeArguments();

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -5,7 +5,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -23,6 +22,7 @@ import org.qbicc.machine.probe.Qualifier;
 import org.qbicc.plugin.core.ConditionEvaluation;
 import org.qbicc.plugin.linker.Linker;
 import org.qbicc.type.CompoundType;
+import org.qbicc.type.InstanceMethodType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.annotation.Annotation;
@@ -37,6 +37,7 @@ import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.FieldElement;
 import org.qbicc.type.definition.element.FunctionElement;
 import org.qbicc.type.definition.element.InitializerElement;
+import org.qbicc.type.definition.element.InstanceMethodElement;
 import org.qbicc.type.definition.element.MethodElement;
 import org.qbicc.type.descriptor.ClassTypeDescriptor;
 import org.qbicc.type.descriptor.MethodDescriptor;
@@ -45,14 +46,11 @@ import org.qbicc.type.generic.AnyTypeArgument;
 import org.qbicc.type.generic.BoundTypeArgument;
 import org.qbicc.type.generic.ClassSignature;
 import org.qbicc.type.generic.ClassTypeSignature;
-import org.qbicc.type.generic.MethodSignature;
 import org.qbicc.type.generic.ReferenceTypeSignature;
 import org.qbicc.type.generic.Signature;
 import org.qbicc.type.generic.TopLevelClassTypeSignature;
 import org.qbicc.type.generic.TypeArgument;
-import org.qbicc.type.generic.TypeParameter;
 import org.qbicc.type.generic.TypeSignature;
-import org.qbicc.type.generic.TypeVariableSignature;
 import org.qbicc.type.generic.Variance;
 
 /**
@@ -74,7 +72,7 @@ final class NativeInfo {
     final Map<TypeDescriptor, Map<String, NativeDataInfo>> nativeFields = new ConcurrentHashMap<>();
     final Map<DefinedTypeDefinition, AtomicReference<ValueType>> nativeTypes = new ConcurrentHashMap<>();
     final Map<DefinedTypeDefinition, AtomicReference<ValueType>> internalNativeTypes = new ConcurrentHashMap<>();
-    final Map<DefinedTypeDefinition, FunctionalInterfaceData> functionalInterfaceMethods = new ConcurrentHashMap<>();
+    final Map<DefinedTypeDefinition, InstanceMethodElement> functionalInterfaceMethods = new ConcurrentHashMap<>();
     final Set<InitializerElement> initializers = ConcurrentHashMap.newKeySet();
     final Map<DefinedTypeDefinition, List<FunctionAndPriority>> globalCtors = new ConcurrentHashMap<>();
     final Map<DefinedTypeDefinition, List<FunctionAndPriority>> globalDtors = new ConcurrentHashMap<>();
@@ -456,86 +454,27 @@ final class NativeInfo {
         return nativeTypes.containsKey(enclosingType);
     }
 
-    static final class FunctionalInterfaceData {
-        MethodElement me;
-        ClassTypeSignature signature;
-
-        FunctionalInterfaceData(MethodElement me, ClassTypeSignature signature) {
-            this.me = me;
-            this.signature = signature;
+    public ValueType getTypeOfFunctionalInterface(final DefinedTypeDefinition definedType, final ClassTypeSignature sig) {
+        InstanceMethodElement method = getFunctionalInterfaceMethod(definedType);
+        if (method == null) {
+            ctxt.error("No functional interface method on \"%s\"", definedType);
+            return ctxt.getTypeSystem().getFunctionType(ctxt.getTypeSystem().getVoidType(), List.of());
         }
-
-        public ClassTypeSignature getClassTypeSignature() {
-            return signature;
-        }
-
-        public MethodElement getMethodElement() {
-            return me;
-        }
+        // the method type is the invocation type
+        return ctxt.getTypeSystem().getFunctionType(method.getType().getReturnType(), method.getType().getParameterTypes());
     }
 
-    public ValueType getTypeOfFunctionalInterface(final DefinedTypeDefinition definedType, final List<TypeArgument> arguments) {
-        FunctionalInterfaceData fiData = getFunctionalInterfaceMethod(definedType);
-        if (fiData == null) {
-            return ctxt.getTypeSystem().getFunctionType(ctxt.getTypeSystem().getVoidType());
-        }
-
-        HashMap<String, ValueType> genericTypeMap = new HashMap();
-        MethodElement method = fiData.getMethodElement();
-
-        /* Map generic types to the ValueTypes they represent */
-        List<TypeParameter> genericTypeParameters = definedType.getSignature() instanceof ClassSignature cs ? cs.getTypeParameters() : List.of();
-        for (int i = 0; i < arguments.size(); i++) {
-            String genericTypeId = genericTypeParameters.get(i).getIdentifier();
-            BoundTypeArgument argument = (BoundTypeArgument) arguments.get(i);
-            TopLevelClassTypeSignature argumentTypeSignature = (TopLevelClassTypeSignature)argument.getBound();
-            ValueType argumentValue = ctxt.getBootstrapClassContext().resolveTypeFromClassName(argumentTypeSignature.getPackageName(), argumentTypeSignature.getIdentifier());
-            genericTypeMap.put(genericTypeId, argumentValue);
-        }
-
-        /* compare class signature with method's class signature and make sure all generics have the correct assigned types.
-        * The MethodElement's types may have been overridden if its from a super interface. For example:
-        *   UnaryOperator extends Function<T, T>, but the class Function has generic names of Function<T, R>.
-        *   In this case R should be mapped to the same ValueType as T.
-        */
-        List<TypeArgument> classTypeParameters = fiData.getClassTypeSignature().getTypeArguments();
-        List<TypeParameter> methodsTypeParameters = method.getEnclosingType().getSignature() instanceof ClassSignature cs ? cs.getTypeParameters() : List.of();
-        for (int i = 0; i < classTypeParameters.size(); i++) {
-            TypeParameter methodParam = methodsTypeParameters.get(i);
-            ValueType existingArgument = genericTypeMap.get(methodParam.getIdentifier());
-            if (existingArgument == null) {
-                BoundTypeArgument overridingType = (BoundTypeArgument) classTypeParameters.get(i);
-                String identifier = ((TypeVariableSignature)overridingType.getBound()).getIdentifier();
-                ValueType mapsTo = genericTypeMap.get(identifier);
-                genericTypeMap.put(methodParam.getIdentifier(), mapsTo);
-            }
-        }
-
-        /* Create the function type. */
-        MethodSignature methodSignature = method.getSignature();
-        List<TypeSignature> parameterTypeSignatures = methodSignature.getParameterTypes();
-        ValueType returnType = genericTypeMap.get(((TypeVariableSignature)methodSignature.getReturnTypeSignature()).getIdentifier());
-        ValueType[] parameterTypes = new ValueType[parameterTypeSignatures.size()];
-        for (int i = 0; i < parameterTypeSignatures.size(); i++) {
-            TypeVariableSignature sig = (TypeVariableSignature)parameterTypeSignatures.get(i);
-            ValueType iou = genericTypeMap.get(sig.getIdentifier());
-            parameterTypes[i] = iou;
-        }
-        ValueType functionType = ctxt.getTypeSystem().getFunctionType(returnType, parameterTypes);
-        return functionType;
-    }
-
-    public FunctionalInterfaceData getFunctionalInterfaceMethod(final DefinedTypeDefinition definedType) {
-        FunctionalInterfaceData fiData = functionalInterfaceMethods.get(definedType);
+    public InstanceMethodElement getFunctionalInterfaceMethod(final DefinedTypeDefinition definedType) {
+        InstanceMethodElement fiData = functionalInterfaceMethods.get(definedType);
         if (fiData != null) {
             return fiData;
         }
         try {
-            fiData = computeFunctionalInterfaceMethod(definedType.load(), definedType.getSignature(), new HashSet<>(), null);
+            fiData = computeFunctionalInterfaceMethod(definedType.load(), new HashSet<>(), null);
         } catch (IllegalArgumentException ignored) {
         }
         if (fiData != null) {
-            FunctionalInterfaceData appearing = functionalInterfaceMethods.putIfAbsent(definedType, fiData);
+            InstanceMethodElement appearing = functionalInterfaceMethods.putIfAbsent(definedType, fiData);
             if (appearing != null) {
                 return appearing;
             }
@@ -545,22 +484,26 @@ final class NativeInfo {
         return fiData;
     }
 
-    private FunctionalInterfaceData computeFunctionalInterfaceMethod(final LoadedTypeDefinition type, final Signature signature, final HashSet<LoadedTypeDefinition> visited, FunctionalInterfaceData found) {
+    private InstanceMethodElement computeFunctionalInterfaceMethod(final LoadedTypeDefinition type, final HashSet<LoadedTypeDefinition> visited, InstanceMethodElement found) {
         if (visited.add(type)) {
             int methodCount = type.getMethodCount();
             for (int i = 0; i < methodCount; i ++) {
                 MethodElement method = type.getMethod(i);
-                if (method.isAbstract() && method.isPublic()) {
+                if (method.isAbstract() && method.isPublic() && method instanceof InstanceMethodElement ime) {
+                    InstanceMethodType methodType = ime.getType();
                     if (found == null) {
-                        found = new FunctionalInterfaceData(method, (ClassTypeSignature) signature);
+                        found = ime;
                     } else {
-                        throw new IllegalArgumentException();
+                        InstanceMethodType foundType = found.getType();
+                        if (! foundType.getReturnType().equals(methodType.getReturnType()) || ! foundType.getParameterTypes().equals(methodType.getParameterTypes())) {
+                            throw new IllegalArgumentException();
+                        }
                     }
                 }
             }
             int intCnt = type.getInterfaceCount();
             for (int i = 0; i < intCnt; i ++) {
-                found = computeFunctionalInterfaceMethod(type.getInterface(i), ((ClassSignature)signature).getInterfaceSignatures().get(i), visited, found);
+                found = computeFunctionalInterfaceMethod(type.getInterface(i), visited, found);
             }
         }
         return found;

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -12,7 +12,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BooleanSupplier;
-import java.util.function.UnaryOperator;
 
 import org.qbicc.runtime.stdc.Stdlib;
 
@@ -1214,7 +1213,10 @@ public final class CNative {
         public static native <F> function<F> of(F invokable);
     }
 
-    public static final class void_ptr_unaryoperator_function_ptr extends ptr<function<UnaryOperator<void_ptr>>> {}
+    @Deprecated public interface void_ptr_to_void_ptr {
+        void_ptr run(void_ptr arg);
+    }
+    @Deprecated public static final class void_ptr_unaryoperator_function_ptr extends ptr<function<void_ptr_to_void_ptr>> {}
     public static final class function_ptr<F> extends ptr<function<F>> {}
 
     // floating point

--- a/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/main/CompilerIntrinsics.java
@@ -3,7 +3,6 @@ package org.qbicc.runtime.main;
 import org.qbicc.runtime.CNative.*;
 import org.qbicc.runtime.Hidden;
 import org.qbicc.runtime.NoSafePoint;
-import org.qbicc.runtime.posix.PThread;
 import org.qbicc.runtime.stdc.Stdint.*;
 
 /**

--- a/runtime/posix/src/main/java/org/qbicc/runtime/posix/PThread.java
+++ b/runtime/posix/src/main/java/org/qbicc/runtime/posix/PThread.java
@@ -18,67 +18,25 @@ public final class PThread {
     public static final c_int PTHREAD_MUTEX_RECURSIVE = constant();
 
     public static class pthread_t extends word {}
-
-    public static final class pthread_t_ptr extends ptr<pthread_t> {}
-    public static final class const_pthread_t_ptr extends ptr<@c_const pthread_t> {}
-    public static final class pthread_t_ptr_ptr extends ptr<pthread_t_ptr> {}
-    public static final class const_pthread_t_ptr_ptr extends ptr<const_pthread_t_ptr> {}
-    public static final class pthread_t_ptr_const_ptr extends ptr<@c_const pthread_t_ptr> {}
-    public static final class const_pthread_t_ptr_const_ptr extends ptr<@c_const const_pthread_t_ptr> {}
-
     public static class pthread_attr_t extends word {}
-
-    public static final class pthread_attr_t_ptr extends ptr<pthread_attr_t> {}
-    public static final class const_pthread_attr_t_ptr extends ptr<@c_const pthread_attr_t> {}
-    public static final class pthread_attr_t_ptr_ptr extends ptr<pthread_attr_t_ptr> {}
-    public static final class const_pthread_attr_t_ptr_ptr extends ptr<const_pthread_attr_t_ptr> {}
-    public static final class pthread_attr_t_ptr_const_ptr extends ptr<@c_const pthread_attr_t_ptr> {}
-    public static final class const_pthread_attr_t_ptr_const_ptr extends ptr<@c_const const_pthread_attr_t_ptr> {}
-
     public static class pthread_mutex_t extends word {}
-
-    public static final class pthread_mutex_t_ptr extends ptr<pthread_mutex_t> {}
-    public static final class const_pthread_mutex_t_ptr extends ptr<@c_const pthread_mutex_t> {}
-    public static final class pthread_mutex_t_ptr_ptr extends ptr<pthread_mutex_t_ptr> {}
-    public static final class const_pthread_mutex_t_ptr_ptr extends ptr<const_pthread_mutex_t_ptr> {}
-    public static final class pthread_mutex_t_ptr_const_ptr extends ptr<@c_const pthread_mutex_t_ptr> {}
-    public static final class const_pthread_mutex_t_ptr_const_ptr extends ptr<@c_const const_pthread_mutex_t_ptr> {}
-
     public static class pthread_mutexattr_t extends word {}
-
-    public static final class pthread_mutexattr_t_ptr extends ptr<pthread_mutexattr_t> {}
-    public static final class const_pthread_mutexattr_t_ptr extends ptr<@c_const pthread_mutexattr_t> {}
-    public static final class pthread_mutexattr_t_ptr_ptr extends ptr<pthread_mutexattr_t_ptr> {}
-    public static final class const_pthread_mutexattr_t_ptr_ptr extends ptr<const_pthread_mutexattr_t_ptr> {}
-    public static final class pthread_mutexattr_t_ptr_const_ptr extends ptr<@c_const pthread_mutexattr_t_ptr> {}
-    public static final class const_pthread_mutexattr_t_ptr_const_ptr extends ptr<@c_const const_pthread_mutexattr_t_ptr> {}
-
     public static class pthread_cond_t extends word {}
-
-    public static final class pthread_cond_t_ptr extends ptr<pthread_cond_t> {}
-    public static final class const_pthread_cond_t_ptr extends ptr<@c_const pthread_cond_t> {}
-    public static final class pthread_cond_t_ptr_ptr extends ptr<pthread_cond_t_ptr> {}
-    public static final class const_pthread_cond_t_ptr_ptr extends ptr<const_pthread_cond_t_ptr> {}
-    public static final class pthread_cond_t_ptr_const_ptr extends ptr<@c_const pthread_cond_t_ptr> {}
-    public static final class const_pthread_cond_t_ptr_const_ptr extends ptr<@c_const const_pthread_cond_t_ptr> {}
-
     public static class pthread_condattr_t extends word {}
 
-    public static final class pthread_condattr_t_ptr extends ptr<pthread_condattr_t> {}
-    public static final class const_pthread_condattr_t_ptr extends ptr<@c_const pthread_condattr_t> {}
-    public static final class pthread_condattr_t_ptr_ptr extends ptr<pthread_condattr_t_ptr> {}
-    public static final class const_pthread_condattr_t_ptr_ptr extends ptr<const_pthread_condattr_t_ptr> {}
-    public static final class pthread_condattr_t_ptr_const_ptr extends ptr<@c_const pthread_condattr_t_ptr> {}
-    public static final class const_pthread_condattr_t_ptr_const_ptr extends ptr<@c_const const_pthread_condattr_t_ptr> {}
+    public static native c_int pthread_attr_init(ptr<pthread_attr_t> attr);
+    public static native c_int pthread_attr_destroy(ptr<pthread_attr_t> attr);
 
-    public static native c_int pthread_attr_init(pthread_attr_t_ptr attr);
-    public static native c_int pthread_attr_destroy(pthread_attr_t_ptr attr);
+    public static native c_int pthread_attr_getstack(ptr<@c_const pthread_attr_t> attr, ptr<ptr<?>> stackAddr, ptr<size_t> stackSize);
+    public static native c_int pthread_attr_setstack(ptr<pthread_attr_t> attr, ptr<?> stackAddr, size_t stackSize);
 
-    public static native c_int pthread_attr_getstack(const_pthread_attr_t_ptr attr, void_ptr_ptr stackAddr, size_t_ptr stackSize);
-    public static native c_int pthread_attr_setstack(pthread_attr_t_ptr attr, void_ptr stackAddr, size_t stackSize);
+    public static native c_int pthread_create(ptr<pthread_t> thread, ptr<@c_const pthread_attr_t> attr,
+                                              ptr<function<pthread_run>> start_routine, void_ptr arg);
 
-    public static native c_int pthread_create(pthread_t_ptr thread, const_pthread_attr_t_ptr attr,
-                                              void_ptr_unaryoperator_function_ptr start_routine, void_ptr arg);
+    @FunctionalInterface
+    public interface pthread_run {
+        void_ptr run(void_ptr arg);
+    }
 
     public static native pthread_t pthread_self();
 
@@ -89,24 +47,93 @@ public final class PThread {
 
     public static native c_int pthread_kill(pthread_t thread, c_int signal);
 
-    public static native c_int pthread_sigmask(c_int how, const_sigset_t_ptr set, sigset_t_ptr oldSet);
+    public static native c_int pthread_sigmask(c_int how, ptr<@c_const sigset_t> set, ptr<sigset_t> oldSet);
 
-    public static native c_int pthread_mutex_init(pthread_mutex_t_ptr mutex, const_pthread_mutexattr_t_ptr attr);
-    public static native c_int pthread_mutex_lock(pthread_mutex_t_ptr mutex);
-    public static native c_int pthread_mutex_unlock(pthread_mutex_t_ptr mutex);
-    public static native c_int pthread_mutex_destroy(pthread_mutex_t_ptr mutex);
+    public static native c_int pthread_mutex_init(ptr<pthread_mutex_t> mutex, ptr<@c_const pthread_mutexattr_t> attr);
+    public static native c_int pthread_mutex_lock(ptr<pthread_mutex_t> mutex);
+    public static native c_int pthread_mutex_unlock(ptr<pthread_mutex_t> mutex);
+    public static native c_int pthread_mutex_destroy(ptr<pthread_mutex_t> mutex);
 
-    public static native c_int pthread_mutexattr_init(pthread_mutexattr_t_ptr attr);
-    public static native c_int pthread_mutexattr_settype(pthread_mutexattr_t_ptr attr, c_int type);
-    public static native c_int pthread_mutexattr_destroy(pthread_mutexattr_t_ptr attr);
+    public static native c_int pthread_mutexattr_init(ptr<pthread_mutexattr_t> attr);
+    public static native c_int pthread_mutexattr_settype(ptr<pthread_mutexattr_t> attr, c_int type);
+    public static native c_int pthread_mutexattr_destroy(ptr<pthread_mutexattr_t> attr);
 
-    public static native c_int pthread_cond_init(pthread_cond_t_ptr cond, pthread_condattr_t_ptr attr);
-    public static native c_int pthread_cond_destroy(pthread_cond_t_ptr cond);
-    public static native c_int pthread_cond_signal(pthread_cond_t_ptr cond);
-    public static native c_int pthread_cond_broadcast(pthread_cond_t_ptr cond);
-    public static native c_int pthread_cond_wait(pthread_cond_t_ptr cond, pthread_mutex_t_ptr mutex);
-    public static native c_int pthread_cond_timedwait(pthread_cond_t_ptr cond, pthread_mutex_t_ptr mutex, const_struct_timespec_ptr abstime);
+    public static native c_int pthread_cond_init(ptr<pthread_cond_t> cond, ptr<pthread_condattr_t> attr);
+    public static native c_int pthread_cond_destroy(ptr<pthread_cond_t> cond);
+    public static native c_int pthread_cond_signal(ptr<pthread_cond_t> cond);
+    public static native c_int pthread_cond_broadcast(ptr<pthread_cond_t> cond);
+    public static native c_int pthread_cond_wait(ptr<pthread_cond_t> cond, ptr<pthread_mutex_t> mutex);
+    public static native c_int pthread_cond_timedwait(ptr<pthread_cond_t> cond, ptr<pthread_mutex_t> mutex, ptr<@c_const struct_timespec> abstime);
 
-    public static native c_int pthread_condattr_init(pthread_condattr_t_ptr attr);
-    public static native c_int pthread_condattr_destroy(pthread_condattr_t_ptr attr);
+    public static native c_int pthread_condattr_init(ptr<pthread_condattr_t> attr);
+    public static native c_int pthread_condattr_destroy(ptr<pthread_condattr_t> attr);
+
+    // Deprecated things
+
+    @Deprecated public static final class pthread_t_ptr extends ptr<pthread_t> {}
+    @Deprecated public static final class const_pthread_t_ptr extends ptr<@c_const pthread_t> {}
+    @Deprecated public static final class pthread_t_ptr_ptr extends ptr<pthread_t_ptr> {}
+    @Deprecated public static final class const_pthread_t_ptr_ptr extends ptr<const_pthread_t_ptr> {}
+    @Deprecated public static final class pthread_t_ptr_const_ptr extends ptr<@c_const pthread_t_ptr> {}
+    @Deprecated public static final class const_pthread_t_ptr_const_ptr extends ptr<@c_const const_pthread_t_ptr> {}
+
+    @Deprecated public static final class pthread_attr_t_ptr extends ptr<pthread_attr_t> {}
+    @Deprecated public static final class const_pthread_attr_t_ptr extends ptr<@c_const pthread_attr_t> {}
+    @Deprecated public static final class pthread_attr_t_ptr_ptr extends ptr<pthread_attr_t_ptr> {}
+    @Deprecated public static final class const_pthread_attr_t_ptr_ptr extends ptr<const_pthread_attr_t_ptr> {}
+    @Deprecated public static final class pthread_attr_t_ptr_const_ptr extends ptr<@c_const pthread_attr_t_ptr> {}
+    @Deprecated public static final class const_pthread_attr_t_ptr_const_ptr extends ptr<@c_const const_pthread_attr_t_ptr> {}
+
+    @Deprecated public static final class pthread_mutex_t_ptr extends ptr<pthread_mutex_t> {}
+    @Deprecated public static final class const_pthread_mutex_t_ptr extends ptr<@c_const pthread_mutex_t> {}
+    @Deprecated public static final class pthread_mutex_t_ptr_ptr extends ptr<pthread_mutex_t_ptr> {}
+    @Deprecated public static final class const_pthread_mutex_t_ptr_ptr extends ptr<const_pthread_mutex_t_ptr> {}
+    @Deprecated public static final class pthread_mutex_t_ptr_const_ptr extends ptr<@c_const pthread_mutex_t_ptr> {}
+    @Deprecated public static final class const_pthread_mutex_t_ptr_const_ptr extends ptr<@c_const const_pthread_mutex_t_ptr> {}
+
+    @Deprecated public static final class pthread_mutexattr_t_ptr extends ptr<pthread_mutexattr_t> {}
+    @Deprecated public static final class const_pthread_mutexattr_t_ptr extends ptr<@c_const pthread_mutexattr_t> {}
+    @Deprecated public static final class pthread_mutexattr_t_ptr_ptr extends ptr<pthread_mutexattr_t_ptr> {}
+    @Deprecated public static final class const_pthread_mutexattr_t_ptr_ptr extends ptr<const_pthread_mutexattr_t_ptr> {}
+    @Deprecated public static final class pthread_mutexattr_t_ptr_const_ptr extends ptr<@c_const pthread_mutexattr_t_ptr> {}
+    @Deprecated public static final class const_pthread_mutexattr_t_ptr_const_ptr extends ptr<@c_const const_pthread_mutexattr_t_ptr> {}
+
+    @Deprecated public static final class pthread_cond_t_ptr extends ptr<pthread_cond_t> {}
+    @Deprecated public static final class const_pthread_cond_t_ptr extends ptr<@c_const pthread_cond_t> {}
+    @Deprecated public static final class pthread_cond_t_ptr_ptr extends ptr<pthread_cond_t_ptr> {}
+    @Deprecated public static final class const_pthread_cond_t_ptr_ptr extends ptr<const_pthread_cond_t_ptr> {}
+    @Deprecated public static final class pthread_cond_t_ptr_const_ptr extends ptr<@c_const pthread_cond_t_ptr> {}
+    @Deprecated public static final class const_pthread_cond_t_ptr_const_ptr extends ptr<@c_const const_pthread_cond_t_ptr> {}
+
+    @Deprecated public static final class pthread_condattr_t_ptr extends ptr<pthread_condattr_t> {}
+    @Deprecated public static final class const_pthread_condattr_t_ptr extends ptr<@c_const pthread_condattr_t> {}
+    @Deprecated public static final class pthread_condattr_t_ptr_ptr extends ptr<pthread_condattr_t_ptr> {}
+    @Deprecated public static final class const_pthread_condattr_t_ptr_ptr extends ptr<const_pthread_condattr_t_ptr> {}
+    @Deprecated public static final class pthread_condattr_t_ptr_const_ptr extends ptr<@c_const pthread_condattr_t_ptr> {}
+    @Deprecated public static final class const_pthread_condattr_t_ptr_const_ptr extends ptr<@c_const const_pthread_condattr_t_ptr> {}
+
+    @Deprecated public static native c_int pthread_attr_init(pthread_attr_t_ptr attr);
+    @Deprecated public static native c_int pthread_attr_destroy(pthread_attr_t_ptr attr);
+    @Deprecated public static native c_int pthread_attr_getstack(const_pthread_attr_t_ptr attr, void_ptr_ptr stackAddr, size_t_ptr stackSize);
+    @Deprecated public static native c_int pthread_attr_setstack(pthread_attr_t_ptr attr, void_ptr stackAddr, size_t stackSize);
+    @Deprecated public static native c_int pthread_create(pthread_t_ptr thread, const_pthread_attr_t_ptr attr,
+                                              void_ptr_unaryoperator_function_ptr start_routine, void_ptr arg);
+    @Deprecated public static native c_int pthread_sigmask(c_int how, const_sigset_t_ptr set, sigset_t_ptr oldSet);
+    @Deprecated public static native c_int pthread_mutex_init(pthread_mutex_t_ptr mutex, const_pthread_mutexattr_t_ptr attr);
+    @Deprecated public static native c_int pthread_mutex_lock(pthread_mutex_t_ptr mutex);
+    @Deprecated public static native c_int pthread_mutex_unlock(pthread_mutex_t_ptr mutex);
+    @Deprecated public static native c_int pthread_mutex_destroy(pthread_mutex_t_ptr mutex);
+    @Deprecated public static native c_int pthread_mutexattr_init(pthread_mutexattr_t_ptr attr);
+    @Deprecated public static native c_int pthread_mutexattr_settype(pthread_mutexattr_t_ptr attr, c_int type);
+    @Deprecated public static native c_int pthread_mutexattr_destroy(pthread_mutexattr_t_ptr attr);
+
+    @Deprecated public static native c_int pthread_cond_init(pthread_cond_t_ptr cond, pthread_condattr_t_ptr attr);
+    @Deprecated public static native c_int pthread_cond_destroy(pthread_cond_t_ptr cond);
+    @Deprecated public static native c_int pthread_cond_signal(pthread_cond_t_ptr cond);
+    @Deprecated public static native c_int pthread_cond_broadcast(pthread_cond_t_ptr cond);
+    @Deprecated public static native c_int pthread_cond_wait(pthread_cond_t_ptr cond, pthread_mutex_t_ptr mutex);
+    @Deprecated public static native c_int pthread_cond_timedwait(pthread_cond_t_ptr cond, pthread_mutex_t_ptr mutex, const_struct_timespec_ptr abstime);
+
+    @Deprecated public static native c_int pthread_condattr_init(pthread_condattr_t_ptr attr);
+    @Deprecated public static native c_int pthread_condattr_destroy(pthread_condattr_t_ptr attr);
 }


### PR DESCRIPTION
Generic type inference of functional interfaces for function pointers is still a bit screwy. We can reduce complexity by just removing support for generic function invocation interfaces.

Also, deprecate all of the special pointer-form methods and classes from `Pthread`, replacing them with `ptr`-based methods.