### PR TITLE
Use a Maven-friendly logging handler by default

### DIFF
--- a/main/src/main/java/org/qbicc/main/MavenFriendlyConsoleHandler.java
+++ b/main/src/main/java/org/qbicc/main/MavenFriendlyConsoleHandler.java
@@ -1,0 +1,57 @@
+package org.qbicc.main;
+
+import java.io.Writer;
+import java.util.Arrays;
+
+import org.jboss.logmanager.handlers.WriterHandler;
+
+/**
+ * A logging handler that does not upset Maven's test harness.
+ */
+public class MavenFriendlyConsoleHandler extends WriterHandler {
+
+    public MavenFriendlyConsoleHandler() {
+        setWriter(new Writer() {
+            @Override
+            public void write(int c) {
+                System.out.write(c);
+            }
+
+            @Override
+            public void write(char[] cbuf) {
+                System.out.print(cbuf);
+            }
+
+            @Override
+            public void write(String str) {
+                System.out.print(str);
+            }
+
+            @Override
+            public void write(String str, int off, int len) {
+                System.out.append(str, off, len);
+            }
+
+            @Override
+            public Writer append(char c) {
+                System.out.write(c);
+                return this;
+            }
+
+            @Override
+            public void write(char[] cbuf, int off, int len) {
+                System.out.print(Arrays.copyOfRange(cbuf, off, off + len));
+            }
+
+            @Override
+            public void flush() {
+                System.out.flush();
+            }
+
+            @Override
+            public void close() {
+                flush();
+            }
+        });
+    }
+}

--- a/main/src/main/resources/logging.properties
+++ b/main/src/main/resources/logging.properties
@@ -23,7 +23,7 @@ logger.org.qbicc.plugin.stringpool.stats.level=INFO
 
 
 # A handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE=org.qbicc.main.MavenFriendlyConsoleHandler
 handler.CONSOLE.level=DEBUG
 handler.CONSOLE.formatter=PATTERN
 handler.CONSOLE.properties=autoFlush,enabled


### PR DESCRIPTION
Gets rid of the warnings that Maven prints about overwriting the native output streams.