### PR TITLE
Revert "Statepoint relocations"

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/AbstractNode.java
+++ b/compiler/src/main/java/org/qbicc/graph/AbstractNode.java
@@ -1,7 +1,5 @@
 package org.qbicc.graph;
 
-import java.util.Set;
-
 import org.qbicc.type.definition.element.ExecutableElement;
 
 abstract class AbstractNode implements Node {
@@ -12,8 +10,6 @@ abstract class AbstractNode implements Node {
     private int hashCode;
     private int scheduleIndex = -1;
     private BasicBlock scheduledBlock;
-    private Set<Value> liveIns;
-    private Set<Value> liveOuts;
 
     AbstractNode(final Node callSite, final ExecutableElement element, final int line, final int bci) {
         this.callSite = callSite;
@@ -44,22 +40,6 @@ abstract class AbstractNode implements Node {
 
     public void setScheduleIndex(int index) {
         this.scheduleIndex = index;
-    }
-
-    public Set<Value> getLiveIns() {
-        return liveIns;
-    }
-
-    public void setLiveIns(Set<Value> liveIns) {
-        this.liveIns = liveIns;
-    }
-
-    public Set<Value> getLiveOuts() {
-        return liveOuts;
-    }
-
-    public void setLiveOuts(Set<Value> liveOuts) {
-        this.liveOuts = liveOuts;
     }
 
     public BasicBlock getScheduledBlock() {

--- a/compiler/src/main/java/org/qbicc/graph/BasicBlock.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlock.java
@@ -20,6 +20,7 @@ public final class BasicBlock {
     private Set<BasicBlock> incoming = Set.of();
     private Set<Loop> loops = Set.of();
     private int index;
+    private Set<Value> liveOuts;
     private List<Node> instructions;
     private Map<Slot, BlockParameter> usedParameters;
 
@@ -168,7 +169,16 @@ public final class BasicBlock {
      * @return the (possibly empty) set of live values
      */
     public Set<Value> getLiveOuts() {
-        return terminator.getLiveOuts();
+        return liveOuts;
+    }
+
+    /**
+     * For use by the scheduler.
+     *
+     * @param liveOuts the live outs to add
+     */
+    public void setLiveOuts(Set<Value> liveOuts) {
+        this.liveOuts = liveOuts;
     }
 
     public StringBuilder toString(StringBuilder b) {

--- a/compiler/src/main/java/org/qbicc/graph/Unschedulable.java
+++ b/compiler/src/main/java/org/qbicc/graph/Unschedulable.java
@@ -1,7 +1,5 @@
 package org.qbicc.graph;
 
-import java.util.Set;
-
 /**
  * Represents a node that cannot be scheduled.
  */
@@ -28,26 +26,6 @@ public interface Unschedulable extends Node {
 
     @Override
     default void setScheduledBlock(BasicBlock block) {
-        throw new UnsupportedOperationException("Cannot schedule unschedulable node");
-    }
-
-    @Override
-    default Set<Value> getLiveIns() {
-        return Set.of();
-    }
-
-    @Override
-    default void setLiveIns(Set<Value> live) {
-        throw new UnsupportedOperationException("Cannot schedule unschedulable node");
-    }
-
-    @Override
-    default Set<Value> getLiveOuts() {
-        return Set.of();
-    }
-
-    @Override
-    default void setLiveOuts(Set<Value> live) {
         throw new UnsupportedOperationException("Cannot schedule unschedulable node");
     }
 }

--- a/compiler/src/main/java/org/qbicc/graph/schedule/Scheduler.java
+++ b/compiler/src/main/java/org/qbicc/graph/schedule/Scheduler.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -13,7 +12,6 @@ import io.smallrye.common.constraint.Assert;
 import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.BlockEntry;
 import org.qbicc.graph.BlockParameter;
-import org.qbicc.graph.Invoke;
 import org.qbicc.graph.Node;
 import org.qbicc.graph.OrderedNode;
 import org.qbicc.graph.PinnedNode;
@@ -327,40 +325,9 @@ public final class Scheduler {
             }
             // finally, go back and build the live-out sets
             computeLiveSetsByUse();
-            Set<Value> live = new HashSet<>();
             for (BlockInfo bi : allBlocks) {
                 BasicBlock block = bi.block;
-                live.clear();
-                live.addAll(bi.liveOut);
-                Set<Value> liveOut = Util.getCachedSet(valueSetCache, bi.liveOut);
-                // set the live-in and live-out sets of each node
-                final List<Node> instructions = block.getInstructions();
-                ListIterator<Node> li = instructions.listIterator(instructions.size());
-                while (li.hasPrevious()) {
-                    Node node = li.previous();
-                    node.setLiveOuts(liveOut);
-                    // remove this value if needed
-                    if (node instanceof BlockParameter bp && bp.getPinnedBlock() == block) {
-                        // keep it alive to the start of the block.
-                    } if (node instanceof Value v) {
-                        // this is where it was defined, thus we can remove it from the live set.
-                        live.remove(v);
-                    } else if (node instanceof Invoke inv) {
-                        // special case!
-                        live.remove(inv.getReturnValue());
-                    }
-                    // add any values consumed by this node to the live set
-                    final int cnt = node.getValueDependencyCount();
-                    for (int i = 0; i < cnt; i ++) {
-                        final Value val = node.getValueDependency(i);
-                        if (! (val instanceof Literal)) {
-                            live.add(val);
-                        }
-                    }
-                    // the live-out set of the previous node is the live-in set of this node
-                    liveOut = Util.getCachedSet(valueSetCache, live);
-                    node.setLiveIns(liveOut);
-                }
+                block.setLiveOuts(Util.getCachedSet(valueSetCache, bi.liveOut));
             }
         }
 
@@ -436,7 +403,7 @@ public final class Scheduler {
                     for (Slot slot : successor.getUsedParameterSlots()) {
                         if (! t.isImplicitOutboundArgument(slot, successor)) {
                             final Value out = t.getOutboundArgument(slot);
-                            if (! (out instanceof Literal)) {
+                            if (out.getType() instanceof ReferenceType  && ! (out instanceof Literal)) {
                                 if (bi.liveOut.add(out)) {
                                     upAndMark(b.getIndex(), out);
                                 }
@@ -448,7 +415,7 @@ public final class Scheduler {
                     cnt = node.getValueDependencyCount();
                     for (int i = 0; i < cnt; i ++) {
                         final Value dep = node.getValueDependency(i);
-                        if (! (dep instanceof Literal)) {
+                        if (dep.getType() instanceof ReferenceType  && ! (dep instanceof Literal)) {
                             if (! (dep instanceof BlockParameter) && used.add(dep)) {
                                 upAndMark(b.getIndex(), dep);
                             }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -36,6 +36,7 @@ import org.qbicc.type.FunctionType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.NumericType;
 import org.qbicc.type.PointerType;
+import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.UnsignedIntegerType;

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -87,8 +87,6 @@ final class LLVMModuleNodeVisitor implements LiteralVisitor<Void, LLValue> {
     final Map<String, LLValue> resultDeclsByName = new HashMap<>();
     final Map<ValueType, LLValue> resultDeclTypes = new HashMap<>();
     final LLValue refType;
-    final LLValue relocateDeclType;
-    LLValue relocateDecl;
 
     LLVMModuleNodeVisitor(final LLVMModuleGenerator generator, final Module module, final CompilationContext ctxt, final LLVMConfiguration config) {
         this.generator = generator;
@@ -103,7 +101,6 @@ final class LLVMModuleNodeVisitor implements LiteralVisitor<Void, LLValue> {
             case POINTER -> opaquePointers ? ptr : i8_ptr;
             case POINTER_AS1 -> opaquePointers ? ptr_as1 : i8_ptr_as1;
         }).asTypeRef();
-        relocateDeclType = function(refType, List.of(token, i32, i32), false);
     }
 
     LLValue map(Type type) {
@@ -561,23 +558,5 @@ final class LLVMModuleNodeVisitor implements LiteralVisitor<Void, LLValue> {
             resultDeclTypes.put(returnType, resultDeclType);
         }
         return resultDeclType;
-    }
-
-    public LLValue getRelocateDecl() {
-        LLValue relocateDecl = this.relocateDecl;
-        if (relocateDecl == null) {
-            final Function decl = module.declare("llvm.experimental.gc.relocate");
-            decl.param(token);
-            decl.param(i32);
-            decl.param(i32);
-            decl.attribute(FunctionAttributes.nounwind);
-            decl.returns(refType);
-            relocateDecl = this.relocateDecl = decl.asGlobal();
-        }
-        return relocateDecl;
-    }
-
-    public LLValue getRelocateDeclType() {
-        return relocateDeclType;
     }
 }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -2,7 +2,6 @@ package org.qbicc.plugin.llvm;
 
 import static org.qbicc.graph.atomic.AccessModes.*;
 import static org.qbicc.machine.llvm.Types.*;
-import static org.qbicc.machine.llvm.Types.token;
 import static org.qbicc.machine.llvm.Values.*;
 
 import java.util.ArrayList;
@@ -11,8 +10,8 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -23,6 +22,8 @@ import org.qbicc.context.Location;
 import org.qbicc.graph.Action;
 import org.qbicc.graph.Add;
 import org.qbicc.graph.And;
+import org.qbicc.graph.InvocationNode;
+import org.qbicc.graph.literal.AsmLiteral;
 import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.BitCast;
 import org.qbicc.graph.BlockEntry;
@@ -49,7 +50,6 @@ import org.qbicc.graph.Goto;
 import org.qbicc.graph.If;
 import org.qbicc.graph.InsertElement;
 import org.qbicc.graph.InsertMember;
-import org.qbicc.graph.InvocationNode;
 import org.qbicc.graph.Invoke;
 import org.qbicc.graph.InvokeNoReturn;
 import org.qbicc.graph.IsEq;
@@ -68,6 +68,7 @@ import org.qbicc.graph.NodeVisitor;
 import org.qbicc.graph.NotNull;
 import org.qbicc.graph.OffsetPointer;
 import org.qbicc.graph.Or;
+import org.qbicc.graph.OrderedNode;
 import org.qbicc.graph.Reachable;
 import org.qbicc.graph.ReadModifyWrite;
 import org.qbicc.graph.Ret;
@@ -93,9 +94,9 @@ import org.qbicc.graph.atomic.AccessMode;
 import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
-import org.qbicc.graph.literal.AsmLiteral;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.ProgramObjectLiteral;
+import org.qbicc.graph.schedule.Util;
 import org.qbicc.machine.llvm.AsmFlag;
 import org.qbicc.machine.llvm.FastMathFlag;
 import org.qbicc.machine.llvm.FloatCondition;
@@ -168,6 +169,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
     final Map<LocalVariableElement, DILocalVariable> localVariables = new HashMap<>();
     final List<InvocationNode> invocationNodes = new ArrayList<>();
     final Map<Invoke, Set<Phi>> invokeResultsToMap = new HashMap<>();
+    private final Map<Set<Value>, Set<Value>> cache = new HashMap<>();
     private final boolean opaquePointers;
 
     private boolean personalityAdded;
@@ -959,74 +961,31 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
 
     @Override
     public LLValue visit(Set<Value> liveValues, org.qbicc.graph.Call node) {
-        final StatepointReason sr = getStatepointReason(node.getTarget(), liveValues);
-        if (sr.isNeeded()) {
-            final Call spCall = makeStatepointCall(node, sr, (type, fn) -> builder.call(type, fn).noTail());
-            final int cnt = addLiveValuesToStatepoint(node, spCall);
-            if (node.isVoidCall()) {
-                return makeStatepointRelocs(spCall.setLValue(map(node)), cnt);
-            } else {
-                return makeStatepointResult(node, makeStatepointRelocs(spCall.asLocal(), cnt)).setLValue(map(node));
-            }
-        } else {
-            return makeNonStatepointCall(node, sr, builder::call).setLValue(map(node));
-        }
+        final Call call = setUpCall(liveValues, node, (type, function) -> builder.call(type, function).noTail(), builder::call);
+        return call.setLValue(map(node));
     }
 
     @Override
     public LLValue visit(Set<Value> liveValues, CallNoSideEffects node) {
-        final StatepointReason sr = getStatepointReason(node.getTarget(), liveValues);
-        if (sr.isNeeded()) {
-            final Call spCall = makeStatepointCall(node, sr, (type, fn) -> builder.call(type, fn).noTail());
-            final int cnt = addLiveValuesToStatepoint(node, spCall);
-            if (node.isVoidCall()) {
-                return makeStatepointRelocs(spCall.setLValue(map(node)), cnt);
-            } else {
-                return makeStatepointResult(node, makeStatepointRelocs(spCall.asLocal(), cnt)).setLValue(map(node));
-            }
-        } else {
-            return makeNonStatepointCall(node, sr, builder::call).setLValue(map(node));
-        }
+        final Call call = setUpCall(liveValues, node, (type, function) -> builder.call(type, function).noTail(), builder::call);
+        return call.setLValue(map(node));
     }
 
     @Override
     public Instruction visit(Set<Value> liveValues, CallNoReturn node) {
-        final StatepointReason sr = getStatepointReason(node.getTarget(), liveValues);
-        final BiFunction<LLValue, LLValue, Call> callMaker = (type, fn) -> builder.call(type, fn).attribute(FunctionAttributes.noreturn);
-        if (sr.isNeeded()) {
-            final Call spCall = makeStatepointCall(node, sr, callMaker);
-            final int cnt = addLiveValuesToStatepoint(node, spCall);
-            makeStatepointRelocs(spCall.asLocal(), cnt);
-        } else {
-            makeNonStatepointCall(node, sr, callMaker);
-        }
+        setUpCall(liveValues, node, (type, function) -> builder.call(type, function).attribute(FunctionAttributes.noreturn), null);
         return builder.unreachable();
     }
 
     @Override
     public Instruction visit(Set<Value> liveValues, TailCall node) {
-        final StatepointReason sr = getStatepointReason(node.getTarget(), liveValues);
-        final BiFunction<LLValue, LLValue, Call> callMaker = (type, fn) -> builder.call(type, fn).tail();
+        final Call call = setUpCall(liveValues, node, (type, function) -> builder.call(type, function).tail(), builder::call);
         ValueType returnType = node.getCalleeType().getReturnType();
-        final LLValue result;
-        if (sr.isNeeded()) {
-            final Call spCall = makeStatepointCall(node, sr, callMaker);
-            final int cnt = addLiveValuesToStatepoint(node, spCall);
-            if (returnType instanceof VoidType) {
-                makeStatepointRelocs(spCall.asLocal(), cnt);
-                return builder.ret();
-            } else {
-                result = makeStatepointResult(node, makeStatepointRelocs(spCall.asLocal(), cnt)).asLocal();
-            }
+        if (returnType instanceof VoidType) {
+            return builder.ret();
         } else {
-            if (returnType instanceof VoidType) {
-                makeNonStatepointCall(node, sr, callMaker);
-                return builder.ret();
-            } else {
-                result = makeNonStatepointCall(node, sr, callMaker).asLocal();
-            }
+            return builder.ret(map(returnType), call.asLocal());
         }
-        return builder.ret(map(returnType), result);
     }
 
     @Override
@@ -1035,7 +994,6 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
             // already done
             return null;
         }
-
         LLBasicBlock resume = checkMap(node.getResumeTarget());
         boolean postMapResume = resume == null;
         if (postMapResume) {
@@ -1047,36 +1005,35 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
             catch_ = preMap(node.getCatchBlock());
         }
         LLBasicBlock finalResume = resume;
-
-        final StatepointReason sr = getStatepointReason(node.getTarget(), liveValues);
-        final Call call;
-        if (sr.isNeeded()) {
+        final Call call = setUpCall(liveValues, node, (llType, llTarget) -> {
+            // statepoint
+            if (node.isVoidCall()) {
+                return builder.invoke(llType, llTarget, finalResume, mapCatch(node.getCatchBlock())).noTail();
+            } else {
+                return builder.invoke(llType, llTarget, mapSpResume(node.getTerminatedBlock()), mapCatch(node.getCatchBlock())).noTail();
+            }
+        }, (llType, llTarget) -> {
+            // no statepoint
+            final Call invoke = builder.invoke(llType, llTarget, finalResume, mapCatch(node.getCatchBlock())).noTail();
+            if (! node.isVoidCall()) {
+                invokeResults.put(node, invoke.setLValue(map(node.getReturnValue())));
+            }
+            return invoke;
+        }, (llType, llTarget) -> {
+            // statepoint result
             final LLBasicBlock spResume = mapSpResume(node.getTerminatedBlock());
-            call = makeStatepointCall(node, sr, (llType, llTarget) -> builder.invoke(llType, llTarget, spResume, mapCatch(node.getCatchBlock())).noTail());
-            final LLValue resultToken = call.asLocal();
-            final int cnt = addLiveValuesToStatepoint(node, call);
             final LLBasicBlock old = builder.moveToBlock(spResume);
             try {
-                makeStatepointRelocs(resultToken, cnt);
+                final Call resultCall = builder.call(llType, llTarget);
                 if (! node.isVoidCall()) {
-                    final Call resultCall = makeStatepointResult(node, resultToken);
                     invokeResults.put(node, resultCall.setLValue(map(node.getReturnValue())));
                 }
                 builder.br(finalResume);
+                return resultCall;
             } finally {
                 builder.moveToBlock(old);
             }
-        } else {
-            if (node.isVoidCall()) {
-                call = makeNonStatepointCall(node, sr, (llType, llTarget) -> builder.invoke(llType, llTarget, finalResume, mapCatch(node.getCatchBlock())).noTail());
-            } else {
-                call = makeNonStatepointCall(node, sr, (llType, llTarget) -> {
-                    final Call invoke = builder.invoke(llType, llTarget, finalResume, mapCatch(node.getCatchBlock())).noTail();
-                    invokeResults.put(node, invoke.setLValue(map(node.getReturnValue())));
-                    return invoke;
-                });
-            }
-        }
+        });
         if (postMapResume) {
             postMap(node.getResumeTarget(), resume);
         }
@@ -1084,44 +1041,6 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
             postMap(node.getCatchBlock(), catch_);
         }
         addPersonalityIfNeeded();
-        // all done
-        return call;
-    }
-
-    @Override
-    public Instruction visit(Set<Value> liveValues, InvokeNoReturn node) {
-        LLBasicBlock unreachableTarget = func.createBlock();
-        LLBasicBlock catch_ = checkMap(node.getCatchBlock());
-        boolean postMapCatch = catch_ == null;
-        if (postMapCatch) {
-            catch_ = preMap(node.getCatchBlock());
-        }
-        final StatepointReason sr = getStatepointReason(node.getTarget(), liveValues);
-        final Call call;
-        if (sr.isNeeded()) {
-            call = makeStatepointCall(node, sr, (llType, llTarget) -> builder.invoke(llType, llTarget, unreachableTarget, mapCatch(node.getCatchBlock())).noTail().attribute(FunctionAttributes.noreturn));
-            final LLValue token = call.asLocal();
-            final int cnt = addLiveValuesToStatepoint(node, call);
-            final LLBasicBlock old = builder.moveToBlock(unreachableTarget);
-            try {
-                makeStatepointRelocs(token, cnt);
-            } finally {
-                builder.moveToBlock(old);
-            }
-        } else {
-            call = makeNonStatepointCall(node, sr, (llType, llTarget) -> builder.invoke(llType, llTarget, unreachableTarget, mapCatch(node.getCatchBlock())).noTail().attribute(FunctionAttributes.noreturn));
-        }
-        if (postMapCatch) {
-            postMap(node.getCatchBlock(), catch_);
-        }
-        final LLBasicBlock old = builder.moveToBlock(unreachableTarget);
-        try {
-            builder.unreachable();
-        } finally {
-            builder.moveToBlock(old);
-        }
-        addPersonalityIfNeeded();
-        // all done
         return call;
     }
 
@@ -1136,156 +1055,117 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
         return mapped;
     }
 
-    enum StatepointReason {
-        DISABLED(false, "Statepoint is disabled"),
-        HIDDEN_NO_SP_CALLER(false, "Caller is hidden and calling function is noSafePoints"),
-        HIDDEN_NO_SP_CALLEE(false, "Caller is hidden and callee function is noSafePoints"),
-        HIDDEN_NO_LIVE(false, "Caller is hidden and no live values"),
-        VARIADIC(false, "Statepoint forbidden (variadic)"),
-        EXTERN(false, "Statepoint forbidden (external function"),
-        ASM(false, "Statepoint forbidden (inline assembly"),
-        VISIBLE_STACK(true, "Visible to stack walk (no live GC values)"),
-        VISIBLE_STACK_LIVE(true, "Visible to stack walk, live GC values"),
-        ;
-
-        private final boolean needed;
-        private final String reason;
-
-        StatepointReason(boolean needed, String reason) {
-            this.needed = needed;
-            this.reason = reason;
+    @Override
+    public Instruction visit(Set<Value> liveValues, InvokeNoReturn node) {
+        LLBasicBlock unreachableTarget = func.createBlock();
+        LLVM.newBuilder(unreachableTarget).unreachable();
+        LLBasicBlock catch_ = checkMap(node.getCatchBlock());
+        boolean postMapCatch = catch_ == null;
+        if (postMapCatch) {
+            catch_ = preMap(node.getCatchBlock());
         }
-
-        public boolean isNeeded() {
-            return needed;
+        final Call call = setUpCall(liveValues, node, (llType, llTarget) -> builder.invoke(llType, llTarget, unreachableTarget, mapCatch(node.getCatchBlock())).noTail().attribute(FunctionAttributes.noreturn), null);
+        if (postMapCatch) {
+            postMap(node.getCatchBlock(), catch_);
         }
-
-        public String getReason() {
-            return reason;
-        }
+        addPersonalityIfNeeded();
+        return call;
     }
 
-    private StatepointReason getStatepointReason(Value target, Set<Value> liveValues) {
-        final ExecutableElement origElement = functionObj.getOriginalElement();
-        final boolean noLive = liveValues.stream().noneMatch(v -> v.getType() instanceof ReferenceType && v != target);
-        final boolean callerIsHidden = origElement != null && origElement.hasAllModifiersOf(ClassFile.I_ACC_HIDDEN);
-        if (! moduleVisitor.config.isStatepointEnabled()) {
-            return StatepointReason.DISABLED;
-        } else if (callerIsHidden && functionObj.isNoSafePoints()) {
-            // caller is hidden, caller is noSafePoints, so no stack walker will see this call and no safepoint is possible
-            return StatepointReason.HIDDEN_NO_SP_CALLER;
-        } else if (callerIsHidden && target.isNoSafePoints()) {
-            // caller is hidden, callee is noSafePoints, so no stack walker will see this call and no safepoint is possible
-            return StatepointReason.HIDDEN_NO_SP_CALLEE;
-        } else if (callerIsHidden && noLive) {
-            // caller is hidden; GC can see this call but there are no live values to relocate
-            return StatepointReason.HIDDEN_NO_LIVE;
-        } else if (target.getPointeeType(InvokableType.class).isVariadic()) {
-            return StatepointReason.VARIADIC;
-        } else if (target instanceof ProgramObjectLiteral pol && pol.getProgramObject() instanceof FunctionDeclaration fd && fd.getOriginalElement() == null) {
-            return StatepointReason.EXTERN;
-        } else if (target instanceof AsmLiteral) {
-            return StatepointReason.ASM;
-        } else if (functionObj.isNoSafePoints() || target.isNoSafePoints() || noLive) {
-            // stack walkers can see us but GC is impossible; we do not need live values
-            return StatepointReason.VISIBLE_STACK;
-        } else {
-            // need statepoint with call info *and* live values
-            return StatepointReason.VISIBLE_STACK_LIVE;
-        }
+    private Call setUpCall(Set<Value> liveValues, InvocationNode node, BiFunction<LLValue, LLValue, Call> callMaker, BiFunction<LLValue, LLValue, Call> resultCallMaker) {
+        return setUpCall(liveValues, node, callMaker, callMaker, resultCallMaker);
     }
 
-    private Call makeStatepointCall(InvocationNode node, StatepointReason statepointReason, BiFunction<LLValue, LLValue, Call> spCallMaker) {
-        assert statepointReason.isNeeded();
+    private Call setUpCall(Set<Value> liveValues, InvocationNode node, BiFunction<LLValue, LLValue, Call> spCallMaker, BiFunction<LLValue, LLValue, Call> noSpCallMaker, BiFunction<LLValue, LLValue, Call> spResultCallMaker) {
         FunctionType functionType = (FunctionType) node.getCalleeType();
         List<Value> arguments = node.getArguments();
         // two scans - once to populate the maps, and then once to emit the call in the right order
         preMapArgumentList(arguments);
         Value target = node.getTarget();
         LLValue llTarget = map(target);
-        // wrap call with statepoint
-        LLValue statepointDecl = moduleVisitor.generateStatepointDecl(functionType);
-        LLValue statepointType = moduleVisitor.mapStatepointType(functionType);
-        Call spCall = spCallMaker.apply(statepointType, statepointDecl);
-        spCall.comment(statepointReason.getReason());
-        // record the statepoint so that we can correlate the stack map info back to nodes
-        int statepointId = LLVM.getNextStatepointId();
-        CallSiteInfo.get(ctxt).mapStatepointIdToNode(statepointId, node);
-        invocationNodes.add(node);
-        spCall.arg(i64, intConstant(statepointId));
-        spCall.arg(i32, ZERO);
-        final HasArguments.Argument argument = spCall.arg(map(functionType.getPointer()), llTarget);
-        if (moduleVisitor.generator.getLlvmMajor() >= 15) {
-            // LLVM 15 requires elementtype even without opaque pointers
-            argument.attribute(ParameterAttributes.elementtype(map(functionType)));
+        boolean needsStatepoint;
+        String statepointReason;
+        final ExecutableElement origElement = functionObj.getOriginalElement();
+        final boolean callerIsHidden = origElement != null && origElement.hasAllModifiersOf(ClassFile.I_ACC_HIDDEN);
+        if (! moduleVisitor.config.isStatepointEnabled()) {
+            needsStatepoint = false;
+            statepointReason = "Statepoint is disabled";
+        } else if (callerIsHidden && functionObj.isNoSafePoints()) {
+            // caller is hidden, caller is noSafePoints, so no stack walker will see this call and no safepoint is possible
+            needsStatepoint = false;
+            statepointReason = "Caller is hidden and noSafePoints";
+        } else if (callerIsHidden && target.isNoSafePoints()) {
+            // caller is hidden, callee is noSafePoints, so no stack walker will see this call and no safepoint is possible
+            needsStatepoint = false;
+            statepointReason = "Caller is hidden and callee is noSafePoints";
+        } else if (callerIsHidden && liveValues.isEmpty()) {
+            // caller is hidden; GC can see this call but there are no live values to relocate
+            needsStatepoint = false;
+            statepointReason = "Caller is hidden and no live values";
+        } else if (target.getPointeeType(InvokableType.class).isVariadic()) {
+            // state point is forbidden!
+            needsStatepoint = false;
+            statepointReason = "Statepoint forbidden (variadic)";
+        } else if (target instanceof ProgramObjectLiteral pol && pol.getProgramObject() instanceof FunctionDeclaration fd && fd.getOriginalElement() == null) {
+            needsStatepoint = false;
+            statepointReason = "Statepoint forbidden (external function)";
+        } else if (target instanceof AsmLiteral) {
+            needsStatepoint = false;
+            statepointReason = "Statepoint forbidden (inline assembly)";
+        } else if (functionObj.isNoSafePoints() || target.isNoSafePoints() || liveValues.isEmpty()) {
+            // stack walkers can see us but GC is impossible; we do not need live values
+            liveValues = Set.of();
+            needsStatepoint = true;
+            statepointReason = "Visible to stack walk (no live GC values)";
+        } else {
+            // need statepoint with call info *and* live values
+            needsStatepoint = true;
+            statepointReason = "Visible to stack walk with live GC values";
         }
-        spCall.arg(i32, intConstant(arguments.size()));
-        spCall.arg(i32, ONE);
-        setCallArguments(spCall, arguments);
-        spCall.arg(i64, ZERO);
-        spCall.arg(i64, ZERO);
-        return spCall;
-    }
-
-    private Call makeNonStatepointCall(InvocationNode node, StatepointReason statepointReason, BiFunction<LLValue, LLValue, Call> callMaker) {
-        Value target = node.getTarget();
-        LLValue llTarget = map(target);
-        FunctionType functionType = (FunctionType) node.getCalleeType();
-        // no live values, or a no-safepoints method
-        Call call = callMaker.apply(map(functionType), llTarget);
-        call.comment(statepointReason.getReason());
-        setCallArguments(call, node.getArguments());
-        setCallReturnValue(call, functionType);
-        return call;
-    }
-
-    private int addLiveValuesToStatepoint(Node callNode, Call spCall) {
-        final Set<Value> liveValues = callNode.getLiveOuts();
-        int live = 0;
-        Iterator<Value> iterator = liveValues.iterator();
-        while (iterator.hasNext()) {
-            Value liveValue = iterator.next();
-            if (liveValue.getType() instanceof ReferenceType rt && liveValue != callNode) {
-                HasArguments opBundle = spCall.operandBundle("gc-live");
-                opBundle.arg(map(rt), map(liveValue));
-                live ++;
-                while (iterator.hasNext()) {
-                    liveValue = iterator.next();
-                    if (liveValue.getType() instanceof ReferenceType rtInner && liveValue != callNode) {
-                        opBundle.arg(map(rtInner), map(liveValue));
-                        live ++;
-                    }
-                }
-                break;
+        if (needsStatepoint) {
+            // wrap call with statepoint
+            LLValue statepointDecl = moduleVisitor.generateStatepointDecl(functionType);
+            LLValue statepointType = moduleVisitor.mapStatepointType(functionType);
+            Call spCall = spCallMaker.apply(statepointType, statepointDecl);
+            spCall.comment(statepointReason);
+            // record the statepoint so that we can correlate the stack map info back to nodes
+            int statepointId = LLVM.getNextStatepointId();
+            CallSiteInfo.get(ctxt).mapStatepointIdToNode(statepointId, node);
+            invocationNodes.add(node);
+            spCall.arg(i64, intConstant(statepointId));
+            spCall.arg(i32, ZERO);
+            final HasArguments.Argument argument = spCall.arg(map(functionType.getPointer()), llTarget);
+            if (moduleVisitor.generator.getLlvmMajor() >= 15) {
+                argument.attribute(ParameterAttributes.elementtype(map(functionType)));
             }
+            spCall.arg(i32, intConstant(arguments.size()));
+            spCall.arg(i32, ONE);
+            setCallArguments(spCall, arguments);
+            spCall.arg(i64, ZERO);
+            spCall.arg(i64, ZERO);
+            if (liveValues.size() > 0) {
+                HasArguments opBundle = spCall.operandBundle("gc-live");
+                for (Value liveValue : liveValues) {
+                    opBundle.arg(map(liveValue.getType()), map(liveValue));
+                }
+            }
+            if (spResultCallMaker == null || functionType.getReturnType() instanceof VoidType) {
+                return spCall;
+            }
+            final LLValue resultToken = spCall.asLocal();
+            LLValue resultDecl = moduleVisitor.generateStatepointResultDecl(functionType.getReturnType());
+            LLValue resultDeclType = moduleVisitor.generateStatepointResultDeclType(functionType.getReturnType());
+            Call resultCall = spResultCallMaker.apply(resultDeclType, resultDecl);
+            resultCall.arg(token, resultToken);
+            return resultCall;
+        } else {
+            // no live values, or a no-safepoints method
+            Call call = noSpCallMaker.apply(map(functionType), llTarget);
+            call.comment(statepointReason);
+            setCallArguments(call, arguments);
+            setCallReturnValue(call, functionType);
+            return call;
         }
-        return live;
-    }
-
-    private LLValue makeStatepointRelocs(LLValue resultToken, int cnt) {
-        if (cnt == 0) {
-            return resultToken;
-        }
-        LLValue relocateDecl = moduleVisitor.getRelocateDecl();
-        LLValue relocateDeclType = moduleVisitor.getRelocateDeclType();
-        for (int idx = 0; idx < cnt; idx++) {
-            final Call spRelocate = builder.call(relocateDeclType, relocateDecl);
-            spRelocate.arg(token, resultToken);
-            LLValue idxConst = intConstant(idx);
-            spRelocate.arg(i32, idxConst);
-            spRelocate.arg(i32, idxConst);
-            idx++;
-            spRelocate.asLocal();
-        }
-        return resultToken;
-    }
-
-    private Call makeStatepointResult(InvocationNode node, LLValue resultToken) {
-        LLValue resultDecl = moduleVisitor.generateStatepointResultDecl(node.getCalleeType().getReturnType());
-        LLValue resultDeclType = moduleVisitor.generateStatepointResultDeclType(node.getCalleeType().getReturnType());
-        Call resultCall = builder.call(resultDeclType, resultDecl);
-        resultCall.arg(token, resultToken);
-        return resultCall;
     }
 
     private void preMapArgumentList(final List<Value> arguments) {
@@ -1490,27 +1370,73 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
         LLBasicBlock oldBuilderBlock = builder.moveToBlock(mapped);
         LLValue oldBuilderDebugLocation = builder.getDebugLocation();
         final List<Node> insnList = block.getInstructions();
-        Instruction instruction;
-        for (Node node : insnList) {
-            builder.setDebugLocation(dbg(node));
-            if (node instanceof Terminator t) {
-                instruction = t.accept(this, node.getLiveOuts());
-            } else if (node instanceof Value value) {
-                LLValue llValue = value.accept(this, node.getLiveOuts());
-                instruction = llValue == null ? null : llValue.getInstruction();
-            } else if (node instanceof Action action) {
-                instruction = action.accept(this, node.getLiveOuts());
-            } else {
-                throw new IllegalStateException();
-            }
-            if (instruction != null) {
-                addLineComment(node, instruction);
-            }
-        }
+        boolean maySafePoint = ! this.functionObj.isNoSafePoints();
+        mapInstructions(block, maySafePoint ? new HashSet<>(block.getLiveOuts()) : null, insnList.listIterator(insnList.size()), maySafePoint);
         builder.setDebugLocation(oldBuilderDebugLocation);
         builder.moveToBlock(oldBuilderBlock);
 
         return mapped;
+    }
+
+    /**
+     * Walk the instruction list backwards and then forwards, tracking live values for each node and then emitting them.
+     *
+     * @param block the block being mapped (must not be {@code null})
+     * @param liveSet the current instruction live-out set (must not be {@code null})
+     * @param iter the list iterator for the block, starting at the end (must not be {@code null})
+     * @param maySafePoint {@code true} if the block is in an element that may safepoint, or {@code false} otherwise
+     */
+    private void mapInstructions(BasicBlock block, HashSet<Value> liveSet, ListIterator<Node> iter, boolean maySafePoint) {
+        if (! iter.hasPrevious()) {
+            // all done
+            return;
+        }
+        // process current instruction
+        final Node node = iter.previous();
+        final Set<Value> live;
+        if (maySafePoint) {
+            if (node instanceof Value v && ! (v instanceof BlockParameter bp && bp.getPinnedBlock() == block)) {
+                // this is where it was defined, thus we can remove it from the live set.
+                // exception: block params are live all the way to the start of the block.
+                liveSet.remove(v);
+            } else if (node instanceof Invoke inv) {
+                // special case!
+                liveSet.remove(inv.getReturnValue());
+            }
+            if (node instanceof OrderedNode on && on.maySafePoint() && ! liveSet.isEmpty()) {
+                live = Util.getCachedSet(cache, liveSet);
+            } else {
+                live = Set.of();
+            }
+            final int cnt = node.getValueDependencyCount();
+            for (int i = 0; i < cnt; i ++) {
+                final Value val = node.getValueDependency(i);
+                if (val.getType() instanceof ReferenceType && ! (val instanceof Literal)) {
+                    liveSet.add(val);
+                }
+            }
+        } else {
+            // no need to track live values
+            live = Set.of();
+        }
+        // process and emit previous instruction (if any)
+        mapInstructions(block, liveSet, iter, maySafePoint);
+        // now emit current instruction
+        builder.setDebugLocation(dbg(node));
+        Instruction instruction;
+        if (node instanceof Terminator t) {
+            instruction = t.accept(this, live);
+        } else if (node instanceof Value value) {
+            LLValue llValue = value.accept(this, live);
+            instruction = llValue == null ? null : llValue.getInstruction();
+        } else if (node instanceof Action action) {
+            instruction = action.accept(this, live);
+        } else {
+            throw new IllegalStateException();
+        }
+        if (instruction != null) {
+            addLineComment(node, instruction);
+        }
     }
 
     private LLBasicBlock mapCatch(BasicBlock block) {


### PR DESCRIPTION
Reverts qbicc/qbicc#1740. Unfortunately this breaks (unsupported) on aarch64, so the patch has to be reworked so that it is only enabled for supported platforms, while we look for another solution.