### PR TITLE
Fix stack-smash due to off-by-one

### DIFF
--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMCompatibleBasicBlockBuilder.java
@@ -384,7 +384,8 @@ public class LLVMCompatibleBasicBlockBuilder extends DelegatingBasicBlockBuilder
                 } else {
                     store(elementOf(pointer, idx), extractElement(value, idx));
                 }
-                if_(isLt(idx, lf.literalOf(idxType, ec)), top, exit, Map.of(Slot.temp(0), add(idx, lf.literalOf(idxType, 1))));
+                final Value incIdx = add(idx, lf.literalOf(idxType, 1));
+                if_(isLt(incIdx, lf.literalOf(idxType, ec)), top, exit, Map.of(Slot.temp(0), incIdx));
                 begin(exit);
             }
             return nop();


### PR DESCRIPTION
We need to increment before we compare that the new index is in bounds, not after.

Closes #1745.