### PR TITLE
Basic support for unions

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -31,6 +31,7 @@ import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.TypeType;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
 import org.qbicc.type.definition.classfile.ClassFile;
@@ -465,6 +466,8 @@ public interface BasicBlockBuilder extends Locatable {
     Value auto(Value initializer);
 
     Value memberOf(Value structPointer, CompoundType.Member member);
+
+    Value memberOfUnion(Value unionPointer, UnionType.Member member);
 
     Value elementOf(Value array, Value index);
 

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -17,6 +17,7 @@ import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -139,6 +140,10 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
 
     public Value memberOf(final Value structPointer, final CompoundType.Member member) {
         return getDelegate().memberOf(structPointer, member);
+    }
+
+    public Value memberOfUnion(Value unionPointer, UnionType.Member member) {
+        return getDelegate().memberOfUnion(unionPointer, member);
     }
 
     public Value elementOf(final Value arrayPointer, final Value index) {

--- a/compiler/src/main/java/org/qbicc/graph/MemberOfUnion.java
+++ b/compiler/src/main/java/org/qbicc/graph/MemberOfUnion.java
@@ -1,0 +1,99 @@
+package org.qbicc.graph;
+
+import java.util.Objects;
+
+import org.qbicc.graph.atomic.AccessMode;
+import org.qbicc.type.PointerType;
+import org.qbicc.type.UnionType;
+import org.qbicc.type.definition.element.ExecutableElement;
+
+/**
+ * A handle for a union member.  The input handle must have union type.
+ */
+public final class MemberOfUnion extends AbstractValue {
+    private final Value unionPointer;
+    private final PointerType pointerType;
+    private final UnionType.Member member;
+
+    MemberOfUnion(Node callSite, ExecutableElement element, int line, int bci, Value unionPointer, UnionType.Member member) {
+        super(callSite, element, line, bci);
+        this.unionPointer = unionPointer;
+        this.member = member;
+        pointerType = member.getType().getPointer().withQualifiersFrom(unionPointer.getType(PointerType.class));
+    }
+
+    public UnionType getUnionType() {
+        return getUnionPointer().getType(PointerType.class).getPointeeType(UnionType.class);
+    }
+
+    @Override
+    public PointerType getType() {
+        return pointerType;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return unionPointer.isConstant();
+    }
+
+    @Override
+    public boolean isPointeeConstant() {
+        return unionPointer.isPointeeConstant();
+    }
+
+    @Override
+    public AccessMode getDetectedMode() {
+        return unionPointer.getDetectedMode();
+    }
+
+    public UnionType.Member getMember() {
+        return member;
+    }
+
+    @Override
+    public int getValueDependencyCount() {
+        return 1;
+    }
+
+    @Override
+    public Value getValueDependency(int index) throws IndexOutOfBoundsException {
+        return switch (index) {
+            case 0 -> unionPointer;
+            default -> throw new IndexOutOfBoundsException(index);
+        };
+    }
+
+    public Value getUnionPointer() {
+        return unionPointer;
+    }
+
+    int calcHashCode() {
+        return Objects.hash(unionPointer, member);
+    }
+
+    @Override
+    String getNodeName() {
+        return "MemberOfUnion";
+    }
+
+    public boolean equals(final Object other) {
+        return other instanceof MemberOfUnion && equals((MemberOfUnion) other);
+    }
+
+    @Override
+    StringBuilder toRValueString(StringBuilder b) {
+        b.append("union member pointer ");
+        unionPointer.toReferenceString(b);
+        b.append('.');
+        member.toString(b);
+        return b;
+    }
+
+    public boolean equals(final MemberOfUnion other) {
+        return this == other || other != null && unionPointer.equals(other.unionPointer) && member.equals(other.member);
+    }
+
+    public <T, R> R accept(final ValueVisitor<T, R> visitor, final T param) {
+        return visitor.visit(param, this);
+    }
+}

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -731,6 +731,10 @@ public interface Node {
                 return param.getBlockBuilder().memberOf(param.copyValue(node.getStructurePointer()), node.getMember());
             }
 
+            public Value visit(final Copier copier, final MemberOfUnion node) {
+                return copier.getBlockBuilder().memberOfUnion(copier.copyValue(node.getUnionPointer()), node.getMember());
+            }
+
             public Value visit(final Copier param, final Max node) {
                 return param.getBlockBuilder().max(param.copyValue(node.getLeftInput()), param.copyValue(node.getRightInput()));
             }

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -32,6 +32,7 @@ import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeType;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.VoidType;
 import org.qbicc.type.WordType;
@@ -460,6 +461,10 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder {
 
     public Value memberOf(final Value structPointer, final CompoundType.Member member) {
         return unique(new MemberOf(callSite, element, line, bci, structPointer, member));
+    }
+
+    public Value memberOfUnion(Value unionPointer, UnionType.Member member) {
+        return unique(new MemberOfUnion(callSite, element, line, bci, unionPointer, member));
     }
 
     public Value elementOf(final Value arrayPointer, final Value index) {

--- a/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
+++ b/compiler/src/main/java/org/qbicc/graph/ValueVisitor.java
@@ -187,6 +187,10 @@ public interface ValueVisitor<T, R> extends LiteralVisitor<T, R> {
         return visitUnknown(t, node);
     }
 
+    default R visit(T t, MemberOfUnion node) {
+        return visitUnknown(t, node);
+    }
+
     default R visit(T t, Dereference node) {
         return visitUnknown(t, node);
     }
@@ -475,6 +479,10 @@ public interface ValueVisitor<T, R> extends LiteralVisitor<T, R> {
         }
 
         default R visit(T t, MemberOf node) {
+            return getDelegateValueVisitor().visit(t, node);
+        }
+
+        default R visit(T t, MemberOfUnion node) {
             return getDelegateValueVisitor().visit(t, node);
         }
 

--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -10,6 +10,7 @@ import org.qbicc.type.CompoundType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeType;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
 
@@ -716,6 +717,8 @@ public interface Memory {
     default void typedCopyTo(long srcOffs, Memory dest, long destOffs, ValueType type) {
         if (type instanceof CompoundType ct) {
             typedCopyTo(srcOffs, dest, destOffs, ct);
+        } else if (type instanceof UnionType ut) {
+            typedCopyTo(srcOffs, dest, destOffs, ut);
         } else if (type instanceof ArrayType at) {
             typedCopyTo(srcOffs, dest, destOffs, at);
         } else if (type instanceof ReferenceType) {
@@ -746,6 +749,13 @@ public interface Memory {
         for (CompoundType.Member member : type.getMembers()) {
             int offset = member.getOffset();
             typedCopyTo(srcOffs + offset, dest, destOffs + offset, member.getType());
+        }
+    }
+
+    default void typedCopyTo(long srcOffs, Memory dest, long destOffs, UnionType type) {
+        for (UnionType.Member member : type.getMembers()) {
+            // Unions are always zeroed at this stage, so this will just write zeros of the appropriate sizes/shapes
+            typedCopyTo(srcOffs, dest, destOffs, member.getType());
         }
     }
 

--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -362,6 +362,18 @@ public final class TypeSystem {
         return new ArrayType(this, memberType, elements);
     }
 
+    public UnionType.Member getUnionTypeMember(String name, ValueType type) {
+        Assert.checkNotNullParam("name", name);
+        Assert.checkNotNullParam("type", type);
+        return new UnionType.Member(name, type);
+    }
+
+    public UnionType getUnionType(final UnionType.Tag tag, String name, Supplier<List<UnionType.Member>> memberResolver) {
+        Assert.checkNotNullParam("tag", tag);
+        Assert.checkNotNullParam("memberResolver", memberResolver);
+        return new UnionType(this, tag, name, memberResolver);
+    }
+
     /**
      * Get the number of bits in a byte for this platform (guaranteed to be at least 8).
      *

--- a/compiler/src/main/java/org/qbicc/type/UnionType.java
+++ b/compiler/src/main/java/org/qbicc/type/UnionType.java
@@ -1,0 +1,292 @@
+package org.qbicc.type;
+
+import java.lang.invoke.ConstantBootstraps;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * A type comprising multiple overlapping objects of any type.
+ */
+public final class UnionType extends ValueType {
+
+    private static final VarHandle sizeHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "size", VarHandle.class, UnionType.class, long.class);
+    private static final VarHandle alignHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "align", VarHandle.class, UnionType.class, int.class);
+
+    private final Tag tag;
+    private final String name;
+    @SuppressWarnings("FieldMayBeFinal") // sizeHandle
+    private volatile long size;
+    @SuppressWarnings("FieldMayBeFinal") // alignHandle
+    private volatile int align;
+    private final boolean complete;
+    private volatile Supplier<List<Member>> membersResolver;
+    private volatile List<Member> members;
+    private volatile Map<String, Member> membersByName;
+
+    UnionType(final TypeSystem typeSystem, final Tag tag, final String name, final Supplier<List<Member>> membersResolver, final long size, final int overallAlign) {
+        super(typeSystem, Objects.hash(UnionType.class, name));
+        // tag does not contribute to hash or equality
+        this.tag = tag;
+        this.name = name;
+        // todo: assert size ≥ end of last member w/alignment etc.
+        this.size = size;
+        assert Integer.bitCount(overallAlign) == 1;
+        this.align = overallAlign;
+        this.membersResolver = membersResolver;
+        this.complete = true;
+    }
+
+    UnionType(final TypeSystem typeSystem, final Tag tag, final String name, final Supplier<List<Member>> membersResolver) {
+        super(typeSystem, Objects.hash(UnionType.class, name));
+        // tag does not contribute to hash or equality
+        this.tag = tag;
+        this.name = name;
+        this.size = -1;
+        this.align = -1;
+        this.membersResolver = membersResolver;
+        this.complete = true;
+    }
+
+    UnionType(final TypeSystem typeSystem, final Tag tag, final String name) {
+        super(typeSystem, Objects.hash(UnionType.class, name));
+        // tag does not contribute to hash or equality
+        this.tag = tag;
+        this.name = name;
+        this.size = 0;
+        this.align = 1;
+        this.complete = false;
+        this.members = List.of();
+        this.membersByName = Map.of();
+    }
+
+    public boolean isAnonymous() {
+        return name == null;
+    }
+
+    public String getName() {
+        final String name = this.name;
+        return name == null ? "<anon>" : name;
+    }
+
+    public List<Member> getMembers() {
+        List<Member> members = this.members;
+        if (members == null) {
+            synchronized (this) {
+                members = this.members;
+                if (members == null) {
+                    members = this.members = membersResolver.get();
+                    membersResolver = null;
+                }
+            }
+        }
+        return members;
+    }
+
+    public Map<String, Member> getMembersByName() {
+        Map<String, Member> membersByName = this.membersByName;
+        if (membersByName == null) {
+            synchronized (this) {
+                membersByName = this.membersByName;
+                if (membersByName == null) {
+                    membersByName = this.membersByName = createMembersByName();
+                }
+            }
+        }
+        return membersByName;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Member> createMembersByName() {
+        List<Member> members = getMembers();
+        Iterator<Member> iterator = members.iterator();
+        if (! iterator.hasNext()) {
+            return Map.of();
+        }
+        Member member0 = iterator.next();
+        String name0 = member0.getName();
+        if (! iterator.hasNext()) {
+            return Map.of(name0, member0);
+        }
+        Member member1 = iterator.next();
+        String name1 = member1.getName();
+        if (! iterator.hasNext()) {
+            return Map.of(name0, member0, name1, member1);
+        }
+        Member member2 = iterator.next();
+        String name2 = member2.getName();
+        if (! iterator.hasNext()) {
+            return Map.of(name0, member0, name1, member1, name2, member2);
+        }
+        // lots of entries, I guess
+        List<Map.Entry<String, Member>> entries = new ArrayList<>(members.size());
+        entries.add(Map.entry(name0, member0));
+        entries.add(Map.entry(name1, member1));
+        entries.add(Map.entry(name2, member2));
+        while (iterator.hasNext()) {
+            Member member = iterator.next();
+            entries.add(Map.entry(member.getName(), member));
+        }
+        return Map.ofEntries(entries.toArray(Map.Entry[]::new));
+    }
+
+    public Tag getTag() {
+        return tag;
+    }
+
+    public int getMemberCount() {
+        return getMembers().size();
+    }
+
+    public Member getMember(int index) throws IndexOutOfBoundsException {
+        return getMembers().get(index);
+    }
+
+    public Member getMember(String name) {
+        Assert.assertFalse(isAnonymous()); /* anonymous unions do not have member names */
+        Member member = getMembersByName().get(name);
+        if (member != null) {
+            return member;
+        }
+        throw new NoSuchElementException("No member named '" + name + "' found in " + this.toFriendlyString());
+    }
+
+    public boolean hasMember(String name) {
+        Assert.assertFalse(isAnonymous()); /* anonymous unions do not have member names */
+        return getMembersByName().containsKey(name);
+    }
+
+    public boolean isComplete() {
+        return complete;
+    }
+
+    public long getSize() {
+        long size = this.size;
+        if (size == -1) {
+            // computed dynamically from members
+            List<Member> members = getMembers();
+            size = 0;
+            for (Member member : members) {
+                size = Math.max(size, member.getType().getSize());
+            }
+            long witness = (long) sizeHandle.compareAndExchange(this, -1L, size);
+            if (witness != -1 && witness != size) {
+                // size changed to something unexpected! should be impossible though...
+                throw new IllegalStateException();
+            }
+        }
+        return size;
+    }
+
+    public int getAlign() {
+        int align = this.align;
+        if (align == -1) {
+            // computed dynamically from members
+            List<Member> members = getMembers();
+            align = 1;
+            for (Member member : members) {
+                align = Math.max(align, member.getType().getAlign());
+            }
+            long witness = (long) alignHandle.compareAndExchange(this, -1, align);
+            if (witness != -1 && witness != align) {
+                // align changed to something unexpected! should be impossible though...
+                throw new IllegalStateException();
+            }
+        }
+        return align;
+    }
+
+    public boolean equals(final ValueType other) {
+        return other instanceof UnionType ct && equals(ct);
+    }
+
+    @Override
+    public ValueType getTypeAtOffset(long offset) {
+        return offset == 0 ? this : super.getTypeAtOffset(offset);
+    }
+
+    public boolean equals(final UnionType other) {
+        return this == other || super.equals(other) && Objects.equals(name, other.name) && size == other.size && align == other.align && getMembers().equals(other.getMembers());
+    }
+
+    public StringBuilder toString(final StringBuilder b) {
+        super.toString(b);
+        b.append("union ");
+        if (tag != Tag.NONE) {
+            b.append(tag).append(' ');
+        }
+        return b.append(getName());
+    }
+
+    public StringBuilder toFriendlyString(final StringBuilder b) {
+        return b.append(getName());
+    }
+
+    public static final class Member {
+        private final int hashCode;
+        private final String name;
+        private final ValueType type;
+
+        Member(final String name, final ValueType type) {
+            this.name = name;
+            this.type = type;
+            hashCode = Objects.hash(name, type);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public ValueType getType() {
+            return type;
+        }
+
+        public <T extends ValueType> T getType(Class<T> expected) {
+            return expected.cast(getType());
+        }
+
+       public int hashCode() {
+            return hashCode;
+        }
+
+        public String toString() {
+            return toString(new StringBuilder()).toString();
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            type.toString(b).append(' ').append(name);
+            return b;
+        }
+
+        public boolean equals(final Object obj) {
+            return obj instanceof Member m && equals(m);
+        }
+
+        public boolean equals(final Member other) {
+            return other == this || other != null && hashCode == other.hashCode && Objects.equals(name, other.name) && type.equals(other.type);
+        }
+    }
+
+    public enum Tag {
+        NONE("untagged"),
+        UNION("union"),
+        ;
+        private final String string;
+
+        Tag(final String string) {
+            this.string = string;
+        }
+
+        public String toString() {
+            return string;
+        }
+    }
+}

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -66,6 +66,7 @@ import org.qbicc.graph.IsNe;
 import org.qbicc.graph.Load;
 import org.qbicc.graph.Max;
 import org.qbicc.graph.MemberOf;
+import org.qbicc.graph.MemberOfUnion;
 import org.qbicc.graph.Min;
 import org.qbicc.graph.Mod;
 import org.qbicc.graph.MonitorEnter;
@@ -1257,6 +1258,11 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         } else {
             return new MemberPointer(structPointer, node.getMember());
         }
+    }
+
+    @Override
+    public Object visit(VmThreadImpl thread, MemberOfUnion node) {
+        return unboxPointer(node.getUnionPointer());
     }
 
     @Override

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
@@ -42,6 +42,7 @@ import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.TypeType;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.UnresolvedType;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
@@ -65,6 +66,16 @@ public final class MemoryFactory {
      */
     public static Memory getEmpty() {
         return EMPTY;
+    }
+
+    /**
+     * Get a read-only zero memory of the given size.
+     *
+     * @param size the size
+     * @return a read-only zero memory (not {@code null})
+     */
+    public static ZeroMemory getZero(long size) {
+        return new ZeroMemory(size);
     }
 
     public static Memory replicate(Memory first, int nCopies) {
@@ -303,7 +314,7 @@ public final class MemoryFactory {
                 continue;
             }
             // complex fields
-            if (memberType instanceof ArrayType || memberType instanceof CompoundType) {
+            if (memberType instanceof ArrayType || memberType instanceof CompoundType || memberType instanceof UnionType) {
                 fieldAccess = Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL;
                 if (delegate == null) {
                     delegate = new HashMap<>();
@@ -580,6 +591,8 @@ public final class MemoryFactory {
         // vectored
         if (type instanceof CompoundType ct) {
             return getMemoryFactory(ctxt, ct, upgradeLongs).get();
+        } else if (type instanceof UnionType ut) {
+            return MemoryFactory.getZero(ut.getSize());
         } else if (type instanceof IntegerType it) {
             // todo: more compact impls
             return switch (it.getMinBits()) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/ZeroMemory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/ZeroMemory.java
@@ -1,0 +1,191 @@
+package org.qbicc.interpreter.memory;
+
+import org.qbicc.graph.atomic.ReadAccessMode;
+import org.qbicc.graph.atomic.WriteAccessMode;
+import org.qbicc.interpreter.Memory;
+import org.qbicc.interpreter.VmObject;
+import org.qbicc.pointer.Pointer;
+import org.qbicc.type.ArrayType;
+import org.qbicc.type.CompoundType;
+import org.qbicc.type.ValueType;
+
+/**
+ * A memory which is always zero and cannot be written to (other than to write zero).
+ */
+public final class ZeroMemory extends AbstractMemory {
+    private final long size;
+
+    ZeroMemory(final long size) {
+        this.size = size;
+    }
+
+    @Override
+    public int load8(long index, ReadAccessMode mode) {
+        return 0;
+    }
+
+    @Override
+    public int load16(long index, ReadAccessMode mode) {
+        return 0;
+    }
+
+    @Override
+    public int load32(long index, ReadAccessMode mode) {
+        return 0;
+    }
+
+    @Override
+    public long load64(long index, ReadAccessMode mode) {
+        return 0;
+    }
+
+    @Override
+    public VmObject loadRef(long index, ReadAccessMode mode) {
+        return null;
+    }
+
+    @Override
+    public ValueType loadType(long index, ReadAccessMode mode) {
+        // todo: type zero
+        return null;
+    }
+
+    @Override
+    public Pointer loadPointer(long index, ReadAccessMode mode) {
+        return null;
+    }
+
+    @Override
+    public void store8(long index, int value, WriteAccessMode mode) {
+        if (value == 0) {
+            return;
+        }
+        super.store8(index, value, mode);
+    }
+
+    @Override
+    public void store16(long index, int value, WriteAccessMode mode) {
+        if (value == 0) {
+            return;
+        }
+        super.store16(index, value, mode);
+    }
+
+    @Override
+    public void store32(long index, int value, WriteAccessMode mode) {
+        if (value == 0) {
+            return;
+        }
+        super.store32(index, value, mode);
+    }
+
+    @Override
+    public void store64(long index, long value, WriteAccessMode mode) {
+        if (value == 0) {
+            return;
+        }
+        super.store64(index, value, mode);
+    }
+
+    @Override
+    public void storeRef(long index, VmObject value, WriteAccessMode mode) {
+        if (value == null) {
+            return;
+        }
+        super.storeRef(index, value, mode);
+    }
+
+    @Override
+    public void storeType(long index, ValueType value, WriteAccessMode mode) {
+        if (value == null) {
+            // todo: type zero
+            return;
+        }
+        super.storeType(index, value, mode);
+    }
+
+    @Override
+    public void storePointer(long index, Pointer value, WriteAccessMode mode) {
+        if (value == null) {
+            return;
+        }
+        super.storePointer(index, value, mode);
+    }
+
+    @Override
+    public int compareAndExchange8(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (expect != 0 || update == 0) {
+            return 0;
+        }
+        return super.compareAndExchange8(index, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public int compareAndExchange16(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (expect != 0 || update == 0) {
+            return 0;
+        }
+        return super.compareAndExchange16(index, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public int compareAndExchange32(long index, int expect, int update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (expect != 0 || update == 0) {
+            return 0;
+        }
+        return super.compareAndExchange32(index, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public long compareAndExchange64(long index, long expect, long update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (expect != 0 || update == 0) {
+            return 0;
+        }
+        return super.compareAndExchange64(index, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public VmObject compareAndExchangeRef(long index, VmObject expect, VmObject update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (expect != null || update == null) {
+            return null;
+        }
+        return super.compareAndExchangeRef(index, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public ValueType compareAndExchangeType(long index, ValueType expect, ValueType update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (expect != null || update == null) {
+            // todo: type zero
+            return null;
+        }
+        return super.compareAndExchangeType(index, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public Pointer compareAndExchangePointer(long index, Pointer expect, Pointer update, ReadAccessMode readMode, WriteAccessMode writeMode) {
+        if (expect != null || update == null) {
+            return null;
+        }
+        return super.compareAndExchangePointer(index, expect, update, readMode, writeMode);
+    }
+
+    @Override
+    public Memory copy(long newSize) {
+        return new ZeroMemory(newSize);
+    }
+
+    @Override
+    public Memory cloneZeroed() {
+        return this;
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public Memory clone() {
+        return this;
+    }
+}

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/DeferenceBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/DeferenceBasicBlockBuilder.java
@@ -30,6 +30,7 @@ import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
 import org.qbicc.type.definition.element.FieldElement;
@@ -69,6 +70,11 @@ public final class DeferenceBasicBlockBuilder extends DelegatingBasicBlockBuilde
     @Override
     public Value memberOf(Value structPointer, CompoundType.Member member) {
         return super.memberOf(rhs(structPointer), member);
+    }
+
+    @Override
+    public Value memberOfUnion(Value unionPointer, UnionType.Member member) {
+        return super.memberOfUnion(rhs(unionPointer), member);
     }
 
     @Override

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/StaticChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/StaticChecksBasicBlockBuilder.java
@@ -25,6 +25,7 @@ import org.qbicc.type.CompoundType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
@@ -97,6 +98,15 @@ public final class StaticChecksBasicBlockBuilder extends DelegatingBasicBlockBui
             return super.memberOf(structPointer, member);
         }
         ctxt.error(getLocation(), "`memberOf` handle must have structure type");
+        throw new BlockEarlyTermination(unreachable());
+    }
+
+    @Override
+    public Value memberOfUnion(Value unionPointer, UnionType.Member member) {
+        if (checkTargetType(unionPointer).getType(PointerType.class).getPointeeType() instanceof UnionType) {
+            return super.memberOfUnion(unionPointer, member);
+        }
+        ctxt.error(getLocation(), "`memberOfUnion` handle must have union type");
         throw new BlockEarlyTermination(unreachable());
     }
 

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/Disassembler.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/Disassembler.java
@@ -19,6 +19,7 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.Action;
 import org.qbicc.graph.Add;
 import org.qbicc.graph.And;
+import org.qbicc.graph.MemberOfUnion;
 import org.qbicc.graph.PointerDifference;
 import org.qbicc.graph.ValueVisitor;
 import org.qbicc.graph.literal.AsmLiteral;
@@ -1179,6 +1180,14 @@ public final class Disassembler {
         public Void visit(Disassembler param, MemberOf node) {
             final String id = param.nextId();
             final String description = "member-of " + show(node.getStructurePointer());
+            param.nodeInfo.put(node, new NodeInfo(id, description));
+            return delegate.visit(param, node);
+        }
+
+        @Override
+        public Void visit(Disassembler param, MemberOfUnion node) {
+            final String id = param.nextId();
+            final String description = "member-of-union " + show(node.getUnionPointer());
             param.nodeInfo.put(node, new NodeInfo(id, description));
             return delegate.visit(param, node);
         }

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -20,6 +20,7 @@ import org.qbicc.graph.Dereference;
 import org.qbicc.graph.Extend;
 import org.qbicc.graph.Load;
 import org.qbicc.graph.MemberOf;
+import org.qbicc.graph.MemberOfUnion;
 import org.qbicc.graph.ReadModifyWrite;
 import org.qbicc.graph.Truncate;
 import org.qbicc.graph.Value;
@@ -334,8 +335,14 @@ final class CNativeIntrinsics {
         StaticIntrinsic offsetof = (builder, target, arguments) -> {
             Value objExpr = arguments.get(0);
             long offset = 0;
-            if (objExpr instanceof Dereference deref && deref.getPointer() instanceof MemberOf memberOf) {
-                offset = memberOf.getMember().getOffset();
+            if (objExpr instanceof Dereference deref) {
+                if (deref.getPointer() instanceof MemberOf memberOf) {
+                    offset = memberOf.getMember().getOffset();
+                } else if (deref.getPointer() instanceof MemberOfUnion) {
+                    ctxt.warning(builder.getLocation(), "offset of union member is always zero");
+                } else {
+                    ctxt.error(builder.getLocation(), "unexpected argument expression for offsetof(obj.field)");
+                }
             } else {
                 ctxt.error(builder.getLocation(), "unexpected argument expression for offsetof(obj.field)");
             }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleNodeVisitor.java
@@ -59,6 +59,7 @@ import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.Type;
+import org.qbicc.type.UnionType;
 import org.qbicc.type.UnresolvedType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.VariadicType;
@@ -213,6 +214,9 @@ final class LLVMModuleNodeVisitor implements LiteralVisitor<Void, LLValue> {
             } else {
                 res = struct;
             }
+        } else if (type instanceof UnionType ut) {
+            // Unions are not directly supported but pointers can be cast
+            res = array((int) ut.getSize(), i8);
         } else if (type instanceof BlockType) {
             res = label;
         } else {

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/Native.java
@@ -40,6 +40,8 @@ final class Native {
     static final String ANN_UNDEF_LIST = className(undef.List.class);
 
     static final String OBJECT_INT_NAME = intName(object.class);
+    static final String STRUCT_INT_NAME = intName(struct.class);
+    static final String UNION_INT_NAME = intName(union.class);
     static final String WORD_INT_NAME = intName(word.class);
     static final String TYPE_ID_INT_NAME = intName(type_id.class);
     static final String TYPE_ID = className(type_id.class);

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeTypeBuilder.java
@@ -33,7 +33,7 @@ public class NativeTypeBuilder implements DefinedTypeDefinition.Builder.Delegati
 
     public void setSuperClassName(final String superClassInternalName) {
         if (superClassInternalName != null) {
-            if (superClassInternalName.equals(Native.OBJECT_INT_NAME) || superClassInternalName.equals(Native.WORD_INT_NAME) || superClassInternalName.equals(Native.PTR_INT_NAME)) {
+            if (superClassInternalName.equals(Native.OBJECT_INT_NAME) || superClassInternalName.equals(Native.STRUCT_INT_NAME) || superClassInternalName.equals(Native.UNION_INT_NAME) || superClassInternalName.equals(Native.WORD_INT_NAME) || superClassInternalName.equals(Native.PTR_INT_NAME)) {
                 // probe native object type
                 isNative = true;
             }

--- a/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/CNative.java
@@ -750,6 +750,20 @@ public final class CNative {
     }
 
     /**
+     * An object which is a structure.
+     * Each field of the object will have distinct, non-overlapping location in memory.
+     */
+    public static abstract class struct extends object {
+    }
+
+    /**
+     * An object which is a union.
+     * Each field of the object will have the same location in memory.
+     */
+    public static abstract class union extends object {
+    }
+
+    /**
      * The special type which corresponds to a value whose type is a run time type ID.
      */
     public static final class type_id extends word {

--- a/runtime/linux/src/main/java/org/qbicc/runtime/linux/EPoll.java
+++ b/runtime/linux/src/main/java/org/qbicc/runtime/linux/EPoll.java
@@ -38,7 +38,7 @@ public class EPoll {
     public static final uint32_t EPOLLWAKEUP = constant();
     public static final uint32_t EPOLLEXCLUSIVE = constant();
 
-    public static final class /* union */ epoll_data_t extends object {
+    public static final class epoll_data_t extends union {
         public void_ptr ptr;
         public c_int fd;
         public uint32_t u32;


### PR DESCRIPTION
At build time, a value of union type must contain only zero, otherwise an error will be produced. Type punning via unions is not presently allowed.