### PR TITLE
Allow some pre-ADD hooks to run outside of a VM thread

### DIFF
--- a/compiler/src/main/java/org/qbicc/context/CompilationContext.java
+++ b/compiler/src/main/java/org/qbicc/context/CompilationContext.java
@@ -160,6 +160,13 @@ public interface CompilationContext extends DiagnosticContext {
     void setTaskRunner(BiConsumer<Consumer<CompilationContext>, CompilationContext> taskRunner) throws IllegalStateException;
 
     /**
+     * Run a task with the currently set task runner.
+     *
+     * @param task the task to run (must not be {@code null})
+     */
+    void runWrappedTask(Consumer<CompilationContext> task);
+
+    /**
      * Run a task on every compiler thread.  When the task has returned on all threads, this method will return.  This
      * method must not be called from a compiler thread or an exception will be thrown.
      *

--- a/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
+++ b/compiler/src/test/java/org/qbicc/type/generic/TestClassContext.java
@@ -190,6 +190,10 @@ public class TestClassContext implements ClassContext {
         public void setTaskRunner(final BiConsumer<Consumer<CompilationContext>, CompilationContext> taskRunner) throws IllegalStateException {
         }
 
+        public void runWrappedTask(final Consumer<CompilationContext> task) {
+            task.accept(this);
+        }
+
         public void runParallelTask(Consumer<CompilationContext> task) throws IllegalStateException {
         }
 

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -703,6 +703,11 @@ final class CompilationContextImpl implements CompilationContext {
     }
 
     @Override
+    public void runWrappedTask(Consumer<CompilationContext> task) {
+        taskRunner.accept(task, this);
+    }
+
+    @Override
     public void runParallelTask(Consumer<CompilationContext> task) throws IllegalStateException {
         Assert.checkNotNullParam("task", task);
         boolean intr = false;

--- a/main/src/main/java/org/qbicc/main/Main.java
+++ b/main/src/main/java/org/qbicc/main/Main.java
@@ -414,10 +414,11 @@ public class Main implements Callable<DiagnosticContext> {
                                 builder.addResolverFactory(InternalNativeTypeResolver::new);
                                 builder.addResolverFactory(NativeTypeResolver::new);
 
-                                builder.addTaskWrapperFactory(Phase.ADD, next -> (wrapper, ctxt) -> {
+                                // from this point on, all pre-ADD hook tasks are run within a VM thread
+                                builder.addPreHook(Phase.ADD, c -> c.setTaskRunner((wrapper, ctxt) -> {
                                     Vm vm = ctxt.getVm();
                                     vm.doAttached(vm.newThread(Thread.currentThread().getName(), vm.getMainThreadGroup(), false, Thread.currentThread().getPriority()), () -> wrapper.accept(ctxt));
-                                });
+                                }));
                                 builder.addPreHook(Phase.ADD, ReachabilityFactsSetup::setupAdd);
                                 builder.addPreHook(Phase.ADD, ReflectionFactsSetup::setupAdd);
                                 builder.addPreHook(Phase.ADD, ctxt -> SafePoints.selectStrategy(ctxt, nogc ? SafePoints.Strategy.NONE : SafePoints.Strategy.GLOBAL_FLAG));


### PR DESCRIPTION
The generic task-wrapper thing only has one use, so we can instead set it up as an ADD hook and allow some tasks to potentially run before the wrapper is in place.