### PR TITLE
Fix AArch64 (non-Mac) to store registers properly

### DIFF
--- a/plugins/core/src/main/java/org/qbicc/plugin/core/ConditionEvaluation.java
+++ b/plugins/core/src/main/java/org/qbicc/plugin/core/ConditionEvaluation.java
@@ -52,6 +52,7 @@ public final class ConditionEvaluation {
             Map.entry("org/qbicc/runtime/Build$Target$IsWasi", Boolean.valueOf(platform.getOs() == OS.WASI)),
 
             // CPU architectures
+            Map.entry("org/qbicc/runtime/Build$Target$IsAarch64", Boolean.valueOf(platform.getCpu() == Cpu.AARCH64)),
             Map.entry("org/qbicc/runtime/Build$Target$IsAmd64", Boolean.valueOf(platform.getCpu() == Cpu.X86_64)),
             Map.entry("org/qbicc/runtime/Build$Target$IsArm", Boolean.valueOf(platform.getCpu() == Cpu.ARM)),
             Map.entry("org/qbicc/runtime/Build$Target$IsWasm", Boolean.valueOf(platform.getCpu() == Cpu.WASM32)),

--- a/runtime/api/src/main/java/org/qbicc/runtime/Build.java
+++ b/runtime/api/src/main/java/org/qbicc/runtime/Build.java
@@ -239,6 +239,12 @@ public final class Build {
 
         //
 
+        public static final class IsAarch64 implements BooleanSupplier {
+            public boolean getAsBoolean() {
+                return isAarch64();
+            }
+        }
+
         public static final class IsAmd64 implements BooleanSupplier {
             public boolean getAsBoolean() {
                 return isAmd64();

--- a/runtime/unwind/pom.xml
+++ b/runtime/unwind/pom.xml
@@ -20,5 +20,9 @@
             <groupId>org.qbicc</groupId>
             <artifactId>qbicc-runtime-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.qbicc</groupId>
+            <artifactId>qbicc-runtime-llvm</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/LibUnwind.java
+++ b/runtime/unwind/src/main/java/org/qbicc/runtime/unwind/LibUnwind.java
@@ -1,8 +1,13 @@
 package org.qbicc.runtime.unwind;
 
 import org.qbicc.runtime.Build;
+import org.qbicc.runtime.Inline;
+import org.qbicc.runtime.InlineCondition;
+import org.qbicc.runtime.NoSafePoint;
 
 import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.llvm.LLVM.*;
+import static org.qbicc.runtime.stdc.Stdint.*;
 
 /**
  * The libunwind library API @ <a href="https://www.nongnu.org/libunwind/docs.html">https://www.nongnu.org/libunwind/docs.html</a>
@@ -14,7 +19,57 @@ public final class LibUnwind {
     private LibUnwind() {}
 
     @macro
-    public static native c_int unw_getcontext(ptr<unw_context_t> context_ptr);
+    @name("unw_getcontext")
+    private static native c_int unw_getcontext_actual(ptr<unw_context_t> context_ptr);
+
+    private static final c_int _LIBUNWIND_VERSION = constant();
+
+    @NoSafePoint
+    @Inline(InlineCondition.ALWAYS)
+    public static c_int unw_getcontext(ptr<unw_context_t> context_ptr) {
+        if (Build.Target.isAarch64() && ! Build.Target.isMacOs() && Build.Target.isLlvm() && ! defined(_LIBUNWIND_VERSION)) {
+            // The buggy unw_getcontext is present!
+            // Expand the inline assembly that `unw_getcontext` corresponds to.
+            // Workaround for https://github.com/libunwind/libunwind/issues/341
+            // Mac OS X uses the LLVM implementation.
+            // TODO: FP registers (needed for Loom context switching)
+            asm(c_void.class, """
+                ${:comment} Store the 31 GPRs in slots 0-30
+                ${:comment} (We know x0 already is the base but store it anyway)
+                stp x0, x1, [$0, #0]
+                stp x2, x3, [$0, #16]
+                stp x4, x5, [$0, #32]
+                stp x6, x7, [$0, #48]
+                stp x8, x9, [$0, #64]
+                stp x10, x11, [$0, #80]
+                stp x12, x13, [$0, #96]
+                stp x14, x15, [$0, #112]
+                stp x16, x17, [$0, #128]
+                stp x18, x19, [$0, #144]
+                stp x20, x21, [$0, #160]
+                stp x22, x23, [$0, #176]
+                stp x24, x25, [$0, #192]
+                stp x26, x27, [$0, #208]
+                stp x28, x29, [$0, #224]
+                str x30, [$0, #240]
+                ${:comment} Store SP in the 31 slot
+                mov x1, sp
+                str x1, [$0, #248]
+                ${:comment} Store the PC in the 32 slot
+                adr x1, ${:private}ret${:uid}
+                str x1, [$0, #256]
+                mrs x1, NZCV
+                ${:comment} Store the flags in the 33 slot
+                str x1, [$0, #264]
+                ${:private}ret${:uid}:
+            """, "{x0},~{x1},~{memory}", ASM_FLAG_SIDE_EFFECT, addr_of(deref(context_ptr).uc_mcontext.regs));
+            // always successful
+            return zero();
+        } else {
+            return unw_getcontext_actual(context_ptr);
+        }
+    }
+
     @macro
     public static native c_int unw_init_local(ptr<unw_cursor_t> cursor, ptr<unw_context_t> context_ptr);
     @macro
@@ -30,7 +85,16 @@ public final class LibUnwind {
     @macro
     public static native c_int unw_is_signal_frame(ptr<unw_cursor_t> cursor);
 
-    public static final class unw_context_t extends object {}
+    public static final class unw_context_t extends struct {
+        @incomplete(unless = Build.Target.IsAarch64.class, when = Build.Target.IsMacOs.class)
+        public struct_unw_sigcontext uc_mcontext;
+
+    }
+    public static final class struct_unw_sigcontext extends struct {
+        // this is just the first one; it is an array of length 31 followed by several discrete uint64_t fields, but this is simpler
+        @incomplete(unless = Build.Target.IsAarch64.class, when = Build.Target.IsMacOs.class)
+        public uint64_t regs;
+    }
     public static final class unw_cursor_t extends object {}
     public static final class unw_addr_space_t extends object {}
     public static final class unw_word_t extends word {}


### PR DESCRIPTION
The non-LLVM version of `libunwind` stores registers in a field which is offset from the base. The LLVM version (used by mac) does not have the bug that the inline assembly works around. Fix the assembly to store the PC and flags as well.

Also add predicates to test for AArch64.