### PR TITLE
Remove aarch64 workaround for stack walker

### DIFF
--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
@@ -1,16 +1,14 @@
 package org.qbicc.runtime.stackwalk;
 
+import static org.qbicc.runtime.CNative.*;
+
+import static org.qbicc.runtime.stdc.String.*;
+import static org.qbicc.runtime.unwind.LibUnwind.*;
+
 import org.qbicc.runtime.Build;
 import org.qbicc.runtime.NoSafePoint;
 import org.qbicc.runtime.NoThrow;
 import org.qbicc.runtime.StackObject;
-import org.qbicc.runtime.stdc.Stdint.uint64_t_ptr;
-
-import static org.qbicc.runtime.CNative.*;
-import static org.qbicc.runtime.llvm.LLVM.*;
-
-import static org.qbicc.runtime.stdc.String.*;
-import static org.qbicc.runtime.unwind.LibUnwind.*;
 
 public final class StackWalker extends StackObject {
     unw_context_t context;
@@ -22,32 +20,7 @@ public final class StackWalker extends StackObject {
     @NoThrow
     public StackWalker() {
         ptr<unw_context_t> context_ptr = addr_of(deref(refToPtr(this)).context);
-        if (Build.Target.isAarch64() && ! Build.Target.isMacOs()) {
-            // Expand the inline assembly that `unw_getcontext` corresponds to.
-            // The layout of `unw_context_t` for aarch64 has not changed since 2017 when support was first introduced.
-            asm(uint64_t_ptr.class, """
-                stp x0, x1, [$0, #0]
-                stp x2, x3, [$0, #16]
-                stp x4, x5, [$0, #32]
-                stp x6, x7, [$0, #48]
-                stp x8, x9, [$0, #64]
-                stp x10, x11, [$0, #80]
-                stp x12, x13, [$0, #96]
-                stp x14, x15, [$0, #112]
-                stp x16, x17, [$0, #128]
-                stp x18, x19, [$0, #144]
-                stp x20, x21, [$0, #160]
-                stp x22, x23, [$0, #176]
-                stp x24, x25, [$0, #192]
-                stp x26, x27, [$0, #208]
-                stp x28, x29, [$0, #224]
-                str x30, [$0, #240]
-                mov x1, sp
-                stp x1, x30, [$0, #248]
-            """, "={x0},{x0},~{x1},~{memory}", ASM_FLAG_SIDE_EFFECT, context_ptr);
-        } else {
-            unw_getcontext(context_ptr);
-        }
+        unw_getcontext(context_ptr);
         unw_init_local(addr_of(deref(refToPtr(this)).cursor), context_ptr);
     }
 


### PR DESCRIPTION
Different versions of this library use different layouts; it is best to just avoid the buggy library. The LLVM implementation is more reliable.