### PR TITLE
Add `StackWalker` ctor for existing context

### DIFF
--- a/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
+++ b/runtime/main/src/main/java/org/qbicc/runtime/stackwalk/StackWalker.java
@@ -53,6 +53,14 @@ public final class StackWalker extends StackObject {
 
     @NoSafePoint
     @NoThrow
+    public StackWalker(ptr<unw_context_t> context_ptr) {
+        memcpy(addr_of(deref(refToPtr(this)).context).cast(), context_ptr.cast(), sizeof(unw_context_t.class));
+        unw_init_local(addr_of(deref(refToPtr(this)).cursor), context_ptr);
+    }
+
+    @SuppressWarnings("CopyConstructorMissesField")
+    @NoSafePoint
+    @NoThrow
     public StackWalker(StackWalker orig) {
         memcpy(addr_of(deref(refToPtr(this)).context).cast(), addr_of(deref(refToPtr(orig)).context).cast(), sizeof(unw_context_t.class));
         memcpy(addr_of(deref(refToPtr(this)).cursor).cast(), addr_of(deref(refToPtr(orig)).cursor).cast(), sizeof(unw_cursor_t.class));


### PR DESCRIPTION
This allows us to walk the stacks of threads other than the current thread (though they do need to be in a safepoint).