### PR TITLE
Skip union member casts when opaque pointers are used

### DIFF
--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -954,6 +954,9 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
     }
 
     public LLValue visit(final Set<Value> liveValues, final MemberOfUnion node) {
+        if (opaquePointers) {
+            return null;
+        }
         UnionType unionType = node.getUnionType();
         PointerType pointerType = unionType.getPointer();
         LLValue ptr = map(node.getUnionPointer());


### PR DESCRIPTION
Fixes one of the failures observed in #1818.