### PR TITLE
Preserve class name through loadClass

### DIFF
--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/HooksForClass.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/HooksForClass.java
@@ -153,8 +153,7 @@ final class HooksForClass {
                 dims++;
             }
             if (name.startsWith("L") && name.endsWith(";")) {
-                name = name.substring(1, name.length() - 1);
-                clazz = (VmClassImpl) loader.loadClass(name.replace('.', '/'));
+                clazz = (VmClassImpl) loader.loadClass(name.substring(1, name.length() - 1));
             } else {
                 clazz = switch (name) {
                     case "B" -> thread.vm.byteClass;
@@ -172,7 +171,7 @@ final class HooksForClass {
                 clazz = clazz.getArrayClass();
             }
         } else {
-            clazz = (VmClassImpl) loader.loadClass(name.replace('.', '/'));
+            clazz = (VmClassImpl) loader.loadClass(name);
         }
 
         if (initialize) {


### PR DESCRIPTION
This fixes the `MethodUtil` bootstrap class loader bug. That class implements a class loader which looks for a textual prefix which uses `.` separators for the class name; it was failing because we preemptively changed `.` to `/`. Instead, delay replacing until we need the internal name for our internal loaded-classes key.