### PR TITLE
Rename CompoundType to StructType

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -20,7 +20,7 @@ import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.InterfaceObjectType;
 import org.qbicc.type.NullableType;
 import org.qbicc.type.ObjectType;
@@ -242,7 +242,7 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value extractElement(Value array, Value index);
 
-    Value extractMember(Value compound, CompoundType.Member member);
+    Value extractMember(Value compound, StructType.Member member);
 
     Value extractInstanceField(Value valueObj, TypeDescriptor owner, String name, TypeDescriptor type);
 
@@ -250,7 +250,7 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value insertElement(Value array, Value index, Value value);
 
-    Value insertMember(Value compound, CompoundType.Member member, Value value);
+    Value insertMember(Value compound, StructType.Member member, Value value);
 
     // debug
 
@@ -474,7 +474,7 @@ public interface BasicBlockBuilder extends Locatable {
 
     Value auto(Value initializer);
 
-    Value memberOf(Value structPointer, CompoundType.Member member);
+    Value memberOf(Value structPointer, StructType.Member member);
 
     Value memberOfUnion(Value unionPointer, UnionType.Member member);
 

--- a/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
+++ b/compiler/src/main/java/org/qbicc/graph/CmpAndSwap.java
@@ -10,7 +10,7 @@ import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.NullLiteral;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -19,18 +19,18 @@ import org.qbicc.type.definition.element.ExecutableElement;
  *
  */
 public final class CmpAndSwap extends AbstractValue implements OrderedNode {
-    private static final AttachmentKey<Map<ValueType, CompoundType>> RESULT_TYPE_MAP_KEY = new AttachmentKey<>();
+    private static final AttachmentKey<Map<ValueType, StructType>> RESULT_TYPE_MAP_KEY = new AttachmentKey<>();
 
     private final Node dependency;
     private final Value pointer;
     private final Value expectedValue;
     private final Value updateValue;
-    private final CompoundType resultType;
+    private final StructType resultType;
     private final ReadAccessMode readAccessMode;
     private final WriteAccessMode writeAccessMode;
     private final Strength strength;
 
-    CmpAndSwap(final Node callSite, final ExecutableElement element, final int line, final int bci, final CompoundType resultType, final Node dependency, final Value pointer, final Value expectedValue, final Value updateValue, final ReadAccessMode readAccessMode, final WriteAccessMode writeAccessMode, Strength strength) {
+    CmpAndSwap(final Node callSite, final ExecutableElement element, final int line, final int bci, final StructType resultType, final Node dependency, final Value pointer, final Value expectedValue, final Value updateValue, final ReadAccessMode readAccessMode, final WriteAccessMode writeAccessMode, Strength strength) {
         super(callSite, element, line, bci);
         this.resultType = Assert.checkNotNullParam("resultType", resultType);
         this.dependency = Assert.checkNotNullParam("dependency", dependency);
@@ -66,7 +66,7 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
         return "CmpAndSwap";
     }
 
-    public CompoundType getType() {
+    public StructType getType() {
         return resultType;
     }
 
@@ -148,38 +148,38 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
         return false;
     }
 
-    public static CompoundType getResultType(CompilationContext ctxt, ValueType valueType) {
-        Map<ValueType, CompoundType> map = ctxt.getAttachment(RESULT_TYPE_MAP_KEY);
+    public static StructType getResultType(CompilationContext ctxt, ValueType valueType) {
+        Map<ValueType, StructType> map = ctxt.getAttachment(RESULT_TYPE_MAP_KEY);
         if (map == null) {
             map = new ConcurrentHashMap<>();
-            Map<ValueType, CompoundType> appearing = ctxt.putAttachmentIfAbsent(RESULT_TYPE_MAP_KEY, map);
+            Map<ValueType, StructType> appearing = ctxt.putAttachmentIfAbsent(RESULT_TYPE_MAP_KEY, map);
             if (appearing != null) {
                 map = appearing;
             }
         }
-        CompoundType compoundType = map.get(valueType);
-        if (compoundType == null) {
+        StructType structType = map.get(valueType);
+        if (structType == null) {
             TypeSystem ts = ctxt.getTypeSystem();
-            compoundType = CompoundType.builder(ts)
-                .setTag(CompoundType.Tag.NONE)
+            structType = StructType.builder(ts)
+                .setTag(StructType.Tag.NONE)
                 .setName(null)
                 .addNextMember(valueType)
                 .addNextMember(ts.getBooleanType())
                 .setOverallAlignment(1)
                 .build();
-            CompoundType appearing = map.putIfAbsent(valueType, compoundType);
+            StructType appearing = map.putIfAbsent(valueType, structType);
             if (appearing != null) {
-                compoundType = appearing;
+                structType = appearing;
             }
         }
-        return compoundType;
+        return structType;
     }
 
     /**
      * Original value found in the CAS target
      * @return value found in CAS target
      */
-    public CompoundType.Member getResultValueType() {
+    public StructType.Member getResultValueType() {
         return this.resultType.getMember(0);
     }
 
@@ -187,7 +187,7 @@ public final class CmpAndSwap extends AbstractValue implements OrderedNode {
      * Result flag where true indicates success, if the operation is marked as strong (default).
      * @return result flag
      */
-    public CompoundType.Member getResultFlagType() {
+    public StructType.Member getResultFlagType() {
         return this.resultType.getMember(1);
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/DelegatingBasicBlockBuilder.java
@@ -12,7 +12,7 @@ import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.PrimitiveArrayObjectType;
@@ -138,7 +138,7 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().currentThread();
     }
 
-    public Value memberOf(final Value structPointer, final CompoundType.Member member) {
+    public Value memberOf(final Value structPointer, final StructType.Member member) {
         return getDelegate().memberOf(structPointer, member);
     }
 
@@ -230,7 +230,7 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().extractElement(array, index);
     }
 
-    public Value extractMember(final Value compound, final CompoundType.Member member) {
+    public Value extractMember(final Value compound, final StructType.Member member) {
         return getDelegate().extractMember(compound, member);
     }
 
@@ -246,7 +246,7 @@ public class DelegatingBasicBlockBuilder implements BasicBlockBuilder {
         return getDelegate().insertElement(array, index, value);
     }
 
-    public Value insertMember(Value compound, CompoundType.Member member, Value value) {
+    public Value insertMember(Value compound, StructType.Member member, Value value) {
         return getDelegate().insertMember(compound, member, value);
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/ExtractMember.java
+++ b/compiler/src/main/java/org/qbicc/graph/ExtractMember.java
@@ -2,7 +2,7 @@ package org.qbicc.graph;
 
 import java.util.Objects;
 
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -10,20 +10,20 @@ import org.qbicc.type.definition.element.ExecutableElement;
  * An extracted member of a compound (structure) value.
  */
 public final class ExtractMember extends AbstractValue {
-    private final Value compoundValue;
-    private final CompoundType compoundType;
-    private final CompoundType.Member member;
+    private final Value structValue;
+    private final StructType structType;
+    private final StructType.Member member;
 
-    ExtractMember(Node callSite, ExecutableElement element, int line, int bci, Value compoundValue, CompoundType.Member member) {
+    ExtractMember(Node callSite, ExecutableElement element, int line, int bci, Value structValue, StructType.Member member) {
         super(callSite, element, line, bci);
-        this.compoundValue = compoundValue;
-        compoundType = (CompoundType) compoundValue.getType();
+        this.structValue = structValue;
+        structType = (StructType) structValue.getType();
         this.member = member;
     }
 
     @Override
     int calcHashCode() {
-        return Objects.hash(compoundValue, member);
+        return Objects.hash(structValue, member);
     }
 
     @Override
@@ -40,7 +40,7 @@ public final class ExtractMember extends AbstractValue {
     public StringBuilder toString(StringBuilder b) {
         super.toString(b);
         b.append('(');
-        compoundValue.toReferenceString(b);
+        structValue.toReferenceString(b);
         b.append(',');
         member.toString(b);
         b.append(')');
@@ -48,15 +48,15 @@ public final class ExtractMember extends AbstractValue {
     }
 
     public boolean equals(ExtractMember other) {
-        return this == other || other != null && compoundValue.equals(other.compoundValue) && member.equals(other.member);
+        return this == other || other != null && structValue.equals(other.structValue) && member.equals(other.member);
     }
 
-    public CompoundType getCompoundType() {
-        return compoundType;
+    public StructType getStructType() {
+        return structType;
     }
 
-    public Value getCompoundValue() {
-        return compoundValue;
+    public Value getStructValue() {
+        return structValue;
     }
 
     @Override
@@ -64,7 +64,7 @@ public final class ExtractMember extends AbstractValue {
         return member.getType();
     }
 
-    public CompoundType.Member getMember() {
+    public StructType.Member getMember() {
         return member;
     }
 
@@ -75,7 +75,7 @@ public final class ExtractMember extends AbstractValue {
 
     @Override
     public Value getValueDependency(int index) throws IndexOutOfBoundsException {
-        return index == 0 ? compoundValue : Util.throwIndexOutOfBounds(index);
+        return index == 0 ? structValue : Util.throwIndexOutOfBounds(index);
     }
 
     @Override
@@ -85,6 +85,6 @@ public final class ExtractMember extends AbstractValue {
 
     @Override
     public boolean isConstant() {
-        return compoundValue.isConstant();
+        return structValue.isConstant();
     }
 }

--- a/compiler/src/main/java/org/qbicc/graph/InsertMember.java
+++ b/compiler/src/main/java/org/qbicc/graph/InsertMember.java
@@ -3,29 +3,29 @@ package org.qbicc.graph;
 import java.util.Objects;
 
 import org.qbicc.graph.literal.LiteralFactory;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
 /**
  * A compound (structure) value with an inserted member.
  */
 public final class InsertMember extends AbstractValue {
-    private final Value compoundValue;
+    private final Value structValue;
     private final Value insertedValue;
-    private final CompoundType compoundType;
-    private final CompoundType.Member member;
+    private final StructType structType;
+    private final StructType.Member member;
 
-    InsertMember(Node callSite, ExecutableElement element, int line, int bci, Value compoundValue, Value insertedValue, CompoundType.Member member) {
+    InsertMember(Node callSite, ExecutableElement element, int line, int bci, Value compoundValue, Value insertedValue, StructType.Member member) {
         super(callSite, element, line, bci);
-        this.compoundValue = compoundValue;
+        this.structValue = compoundValue;
         this.insertedValue = insertedValue;
-        compoundType = (CompoundType) compoundValue.getType();
+        structType = (StructType) compoundValue.getType();
         this.member = member;
     }
 
     @Override
     int calcHashCode() {
-        return Objects.hash(compoundValue, insertedValue, member);
+        return Objects.hash(structValue, insertedValue, member);
     }
 
     @Override
@@ -42,7 +42,7 @@ public final class InsertMember extends AbstractValue {
     public StringBuilder toString(StringBuilder b) {
         super.toString(b);
         b.append('(');
-        compoundValue.toReferenceString(b);
+        structValue.toReferenceString(b);
         b.append(',');
         member.toString(b);
         b.append(',');
@@ -52,11 +52,11 @@ public final class InsertMember extends AbstractValue {
     }
 
     public boolean equals(InsertMember other) {
-        return this == other || other != null && compoundValue.equals(other.compoundValue) && insertedValue.equals(other.insertedValue) && member.equals(other.member);
+        return this == other || other != null && structValue.equals(other.structValue) && insertedValue.equals(other.insertedValue) && member.equals(other.member);
     }
 
-    public Value getCompoundValue() {
-        return compoundValue;
+    public Value getStructValue() {
+        return structValue;
     }
 
     public Value getInsertedValue() {
@@ -64,11 +64,11 @@ public final class InsertMember extends AbstractValue {
     }
 
     @Override
-    public CompoundType getType() {
-        return compoundType;
+    public StructType getType() {
+        return structType;
     }
 
-    public CompoundType.Member getMember() {
+    public StructType.Member getMember() {
         return member;
     }
 
@@ -79,7 +79,7 @@ public final class InsertMember extends AbstractValue {
 
     @Override
     public Value getValueDependency(int index) throws IndexOutOfBoundsException {
-        return index == 0 ? compoundValue : index == 1 ? insertedValue : Util.throwIndexOutOfBounds(index);
+        return index == 0 ? structValue : index == 1 ? insertedValue : Util.throwIndexOutOfBounds(index);
     }
 
     @Override
@@ -88,11 +88,11 @@ public final class InsertMember extends AbstractValue {
     }
 
     @Override
-    public Value extractMember(LiteralFactory lf, CompoundType.Member member) {
-        return member.equals(this.member) ? insertedValue : compoundValue.extractMember(lf, member);
+    public Value extractMember(LiteralFactory lf, StructType.Member member) {
+        return member.equals(this.member) ? insertedValue : structValue.extractMember(lf, member);
     }
 
     public boolean isConstant() {
-        return compoundValue.isConstant() && insertedValue.isConstant();
+        return structValue.isConstant() && insertedValue.isConstant();
     }
 }

--- a/compiler/src/main/java/org/qbicc/graph/MemberOf.java
+++ b/compiler/src/main/java/org/qbicc/graph/MemberOf.java
@@ -3,7 +3,7 @@ package org.qbicc.graph;
 import java.util.Objects;
 
 import org.qbicc.graph.atomic.AccessMode;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -13,17 +13,17 @@ import org.qbicc.type.definition.element.ExecutableElement;
 public final class MemberOf extends AbstractValue {
     private final Value structurePointer;
     private final PointerType pointerType;
-    private final CompoundType.Member member;
+    private final StructType.Member member;
 
-    MemberOf(Node callSite, ExecutableElement element, int line, int bci, Value structurePointer, CompoundType.Member member) {
+    MemberOf(Node callSite, ExecutableElement element, int line, int bci, Value structurePointer, StructType.Member member) {
         super(callSite, element, line, bci);
         this.structurePointer = structurePointer;
         this.member = member;
         pointerType = member.getType().getPointer().withQualifiersFrom(structurePointer.getType(PointerType.class));
     }
 
-    public CompoundType getStructType() {
-        return getStructurePointer().getType(PointerType.class).getPointeeType(CompoundType.class);
+    public StructType getStructType() {
+        return getStructurePointer().getType(PointerType.class).getPointeeType(StructType.class);
     }
 
     @Override
@@ -46,7 +46,7 @@ public final class MemberOf extends AbstractValue {
         return structurePointer.getDetectedMode();
     }
 
-    public CompoundType.Member getMember() {
+    public StructType.Member getMember() {
         return member;
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/Node.java
+++ b/compiler/src/main/java/org/qbicc/graph/Node.java
@@ -25,7 +25,7 @@ import org.qbicc.graph.literal.MemberOfLiteral;
 import org.qbicc.graph.literal.OffsetFromLiteral;
 import org.qbicc.graph.literal.ValueConvertLiteral;
 import org.qbicc.graph.schedule.Util;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.definition.element.ExecutableElement;
 
@@ -393,9 +393,9 @@ public interface Node {
             }
 
             public Value visit(Copier copier, CompoundLiteral literal) {
-                Map<CompoundType.Member, Literal> old = literal.getValues();
-                Map<CompoundType.Member, Literal> copied = new HashMap<>();
-                for (Map.Entry<CompoundType.Member, Literal> e : old.entrySet()) {
+                Map<StructType.Member, Literal> old = literal.getValues();
+                Map<StructType.Member, Literal> copied = new HashMap<>();
+                for (Map.Entry<StructType.Member, Literal> e : old.entrySet()) {
                     copied.put(e.getKey(), (Literal)copier.copyValue(e.getValue()));
                 }
                 return copier.getBlockBuilder().getLiteralFactory().literalOf(literal.getType(), copied);
@@ -673,7 +673,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final ExtractMember node) {
-                return param.getBlockBuilder().extractMember(param.copyValue(node.getCompoundValue()), node.getMember());
+                return param.getBlockBuilder().extractMember(param.copyValue(node.getStructValue()), node.getMember());
             }
 
             public Value visit(final Copier param, final InsertElement node) {
@@ -681,7 +681,7 @@ public interface Node {
             }
 
             public Value visit(final Copier param, final InsertMember node) {
-                return param.getBlockBuilder().insertMember(param.copyValue(node.getCompoundValue()), node.getMember(), param.copyValue(node.getInsertedValue()));
+                return param.getBlockBuilder().insertMember(param.copyValue(node.getStructValue()), node.getMember(), param.copyValue(node.getInsertedValue()));
             }
 
             public Value visit(final Copier param, final InstanceOf node) {

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -22,7 +22,7 @@ import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.InstanceMethodType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.NullableType;
@@ -459,7 +459,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder {
         return asDependency(new VaArg(callSite, element, line, bci, requireDependency(), vaList, type));
     }
 
-    public Value memberOf(final Value structPointer, final CompoundType.Member member) {
+    public Value memberOf(final Value structPointer, final StructType.Member member) {
         return unique(new MemberOf(callSite, element, line, bci, structPointer, member));
     }
 
@@ -551,7 +551,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder {
         return unique(new ExtractElement(callSite, element, line, bci, array, index));
     }
 
-    public Value extractMember(Value compound, CompoundType.Member member) {
+    public Value extractMember(Value compound, StructType.Member member) {
         return unique(new ExtractMember(callSite, element, line, bci, compound, member));
     }
 
@@ -567,7 +567,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder {
         return unique(new InsertElement(callSite, element, line, bci, array, index, value));
     }
 
-    public Value insertMember(Value compound, CompoundType.Member member, Value value) {
+    public Value insertMember(Value compound, StructType.Member member, Value value) {
         return unique(new InsertMember(callSite, element, line, bci, compound, value, member));
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/Value.java
+++ b/compiler/src/main/java/org/qbicc/graph/Value.java
@@ -4,7 +4,7 @@ import static org.qbicc.graph.atomic.AccessModes.SingleUnshared;
 
 import org.qbicc.graph.atomic.AccessMode;
 import org.qbicc.graph.literal.LiteralFactory;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.InvokableType;
 import org.qbicc.type.NullableType;
@@ -110,7 +110,7 @@ public interface Value extends Node {
      * @param member the member (must not be {@code null})
      * @return the extracted value, or {@code null} if the value is not known
      */
-    default Value extractMember(LiteralFactory lf, CompoundType.Member member) {
+    default Value extractMember(LiteralFactory lf, StructType.Member member) {
         return null;
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/literal/CompoundLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/CompoundLiteral.java
@@ -7,24 +7,24 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.qbicc.graph.Value;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 
 /**
  *
  */
 public final class CompoundLiteral extends Literal {
 
-    private final CompoundType type;
-    private final Map<CompoundType.Member, Literal> values;
+    private final StructType type;
+    private final Map<StructType.Member, Literal> values;
     private final List<Literal> valuesAsList;
     private final int hashCode;
 
-    CompoundLiteral(final CompoundType type, final Map<CompoundType.Member, Literal> values) {
+    CompoundLiteral(final StructType type, final Map<StructType.Member, Literal> values) {
         this.type = type;
         this.values = values;
         hashCode = Objects.hash(type, values);
         valuesAsList = new ArrayList<>(values.size());
-        for (CompoundType.Member member : type.getMembers()) {
+        for (StructType.Member member : type.getMembers()) {
             Literal literal = values.get(member);
             if (literal != null) {
                 valuesAsList.add(literal);
@@ -42,11 +42,11 @@ public final class CompoundLiteral extends Literal {
         return valuesAsList.get(index);
     }
 
-    public CompoundType getType() {
+    public StructType getType() {
         return type;
     }
 
-    public Map<CompoundType.Member, Literal> getValues() {
+    public Map<StructType.Member, Literal> getValues() {
         return values;
     }
 
@@ -54,7 +54,7 @@ public final class CompoundLiteral extends Literal {
         return visitor.visit(param, this);
     }
 
-    public Value extractMember(LiteralFactory lf, CompoundType.Member member) {
+    public Value extractMember(LiteralFactory lf, StructType.Member member) {
         return values.get(member);
     }
 
@@ -76,9 +76,9 @@ public final class CompoundLiteral extends Literal {
 
     public StringBuilder toString(StringBuilder builder) {
         builder.append('{');
-        Iterator<Map.Entry<CompoundType.Member, Literal>> iterator = values.entrySet().iterator();
+        Iterator<Map.Entry<StructType.Member, Literal>> iterator = values.entrySet().iterator();
         if (iterator.hasNext()) {
-            Map.Entry<CompoundType.Member, Literal> entry = iterator.next();
+            Map.Entry<StructType.Member, Literal> entry = iterator.next();
             builder.append(entry.getKey().getName());
             builder.append('=');
             builder.append(entry.getValue());

--- a/compiler/src/main/java/org/qbicc/graph/literal/LiteralFactory.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/LiteralFactory.java
@@ -26,7 +26,7 @@ import org.qbicc.pointer.StaticFieldPointer;
 import org.qbicc.pointer.StaticMethodPointer;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.IntegerType;
@@ -96,7 +96,7 @@ public interface LiteralFactory {
 
     Literal literalOf(ArrayType type, short[] values);
 
-    Literal literalOf(CompoundType type, Map<CompoundType.Member, Literal> values);
+    Literal literalOf(StructType type, Map<StructType.Member, Literal> values);
 
     Literal bitcastLiteral(Literal value, WordType toType);
 
@@ -104,7 +104,7 @@ public interface LiteralFactory {
 
     ElementOfLiteral elementOfLiteral(Literal arrayPointer, Literal index);
 
-    MemberOfLiteral memberOfLiteral(Literal structurePointer, CompoundType.Member member);
+    MemberOfLiteral memberOfLiteral(Literal structurePointer, StructType.Member member);
 
     OffsetFromLiteral offsetFromLiteral(Literal basePointer, Literal offset);
 
@@ -242,7 +242,7 @@ public interface LiteralFactory {
             private final ConcurrentMap<VariableElement, VariableLiteral> varLiterals = new ConcurrentHashMap<>();
             private final ConcurrentMap<ExecutableElement, ExecutableLiteral> exeLiterals = new ConcurrentHashMap<>();
             private final ConcurrentMap<Literal, ConcurrentMap<Literal, ElementOfLiteral>> elementLiterals = new ConcurrentHashMap<>();
-            private final ConcurrentMap<Literal, ConcurrentMap<CompoundType.Member, MemberOfLiteral>> memberLiterals = new ConcurrentHashMap<>();
+            private final ConcurrentMap<Literal, ConcurrentMap<StructType.Member, MemberOfLiteral>> memberLiterals = new ConcurrentHashMap<>();
             private final ConcurrentMap<Literal, ConcurrentMap<Literal, OffsetFromLiteral>> offsetLiterals = new ConcurrentHashMap<>();
 
             public BlockLiteral literalOf(final BlockLabel blockLabel) {
@@ -383,7 +383,7 @@ public interface LiteralFactory {
                 return zeroInitializerLiteralOfType(type);
             }
 
-            public Literal literalOf(final CompoundType type, final Map<CompoundType.Member, Literal> values) {
+            public Literal literalOf(final StructType type, final Map<StructType.Member, Literal> values) {
                 Assert.checkNotNullParam("type", type);
                 Assert.checkNotNullParam("values", values);
                 for (Literal value : values.values()) {
@@ -431,14 +431,14 @@ public interface LiteralFactory {
             }
 
             @Override
-            public MemberOfLiteral memberOfLiteral(Literal structurePointer, CompoundType.Member member) {
+            public MemberOfLiteral memberOfLiteral(Literal structurePointer, StructType.Member member) {
                 Assert.checkNotNullParam("structurePointer", structurePointer);
                 Assert.checkNotNullParam("member", member);
                 ValueType structureType = structurePointer.getPointeeType();
-                if (! (structureType instanceof CompoundType)) {
+                if (! (structureType instanceof StructType)) {
                     throw new IllegalArgumentException("Structure pointer is of wrong type " + structureType);
                 }
-                final ConcurrentMap<CompoundType.Member, MemberOfLiteral> subMap = memberLiterals.computeIfAbsent(structurePointer, LiteralFactory::newMap);
+                final ConcurrentMap<StructType.Member, MemberOfLiteral> subMap = memberLiterals.computeIfAbsent(structurePointer, LiteralFactory::newMap);
                 MemberOfLiteral lit = subMap.get(member);
                 if (lit == null) {
                     lit = new MemberOfLiteral(structurePointer, member);

--- a/compiler/src/main/java/org/qbicc/graph/literal/MemberOfLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/MemberOfLiteral.java
@@ -3,7 +3,7 @@ package org.qbicc.graph.literal;
 import java.util.Objects;
 
 import org.qbicc.graph.Value;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.WordType;
 
@@ -12,9 +12,9 @@ import org.qbicc.type.WordType;
  */
 public final class MemberOfLiteral extends Literal {
     final Literal structurePointer;
-    final CompoundType.Member member;
+    final StructType.Member member;
 
-    MemberOfLiteral(Literal structurePointer, CompoundType.Member member) {
+    MemberOfLiteral(Literal structurePointer, StructType.Member member) {
         this.structurePointer = structurePointer;
         this.member = member;
     }
@@ -73,7 +73,7 @@ public final class MemberOfLiteral extends Literal {
         return visitor.visit(param, this);
     }
 
-    public CompoundType.Member getMember() {
+    public StructType.Member getMember() {
         return member;
     }
 

--- a/compiler/src/main/java/org/qbicc/graph/literal/ZeroInitializerLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/ZeroInitializerLiteral.java
@@ -2,7 +2,7 @@ package org.qbicc.graph.literal;
 
 import org.qbicc.graph.Value;
 import org.qbicc.type.ArrayType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.ValueType;
 
 /**
@@ -43,8 +43,8 @@ public final class ZeroInitializerLiteral extends Literal {
         return null;
     }
 
-    public Value extractMember(LiteralFactory lf, CompoundType.Member member) {
-        if (type instanceof CompoundType) {
+    public Value extractMember(LiteralFactory lf, StructType.Member member) {
+        if (type instanceof StructType) {
             return lf.zeroInitializerLiteralOfType(member.getType());
         }
         return null;

--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -6,7 +6,7 @@ import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.pointer.Pointer;
 import org.qbicc.type.ArrayType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeType;
@@ -715,8 +715,8 @@ public interface Memory {
     // typed copy
 
     default void typedCopyTo(long srcOffs, Memory dest, long destOffs, ValueType type) {
-        if (type instanceof CompoundType ct) {
-            typedCopyTo(srcOffs, dest, destOffs, ct);
+        if (type instanceof StructType st) {
+            typedCopyTo(srcOffs, dest, destOffs, st);
         } else if (type instanceof UnionType ut) {
             typedCopyTo(srcOffs, dest, destOffs, ut);
         } else if (type instanceof ArrayType at) {
@@ -745,8 +745,8 @@ public interface Memory {
         }
     }
 
-    default void typedCopyTo(long srcOffs, Memory dest, long destOffs, CompoundType type) {
-        for (CompoundType.Member member : type.getMembers()) {
+    default void typedCopyTo(long srcOffs, Memory dest, long destOffs, StructType type) {
+        for (StructType.Member member : type.getMembers()) {
             int offset = member.getOffset();
             typedCopyTo(srcOffs + offset, dest, destOffs + offset, member.getType());
         }

--- a/compiler/src/main/java/org/qbicc/pointer/MemberPointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/MemberPointer.java
@@ -1,31 +1,31 @@
 package org.qbicc.pointer;
 
 import org.qbicc.interpreter.Memory;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 
 /**
  *
  */
 public final class MemberPointer extends Pointer {
     private final Pointer structurePointer;
-    private final CompoundType.Member member;
+    private final StructType.Member member;
 
-    public MemberPointer(Pointer structurePointer, CompoundType.Member member) {
+    public MemberPointer(Pointer structurePointer, StructType.Member member) {
         super(member.getType().getPointer());
         this.structurePointer = structurePointer;
         this.member = member;
     }
 
     @Override
-    public CompoundType getPointeeType() {
-        return (CompoundType) super.getPointeeType();
+    public StructType getPointeeType() {
+        return (StructType) super.getPointeeType();
     }
 
     public Pointer getStructurePointer() {
         return structurePointer;
     }
 
-    public CompoundType.Member getMember() {
+    public StructType.Member getMember() {
         return member;
     }
 

--- a/compiler/src/main/java/org/qbicc/pointer/Pointer.java
+++ b/compiler/src/main/java/org/qbicc/pointer/Pointer.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.qbicc.interpreter.Memory;
 import org.qbicc.type.ArrayType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.PhysicalObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ValueType;
@@ -71,12 +71,12 @@ public abstract class Pointer {
             }
         }
         // structure?
-        if (pointeeType instanceof CompoundType ct) {
+        if (pointeeType instanceof StructType st) {
             // find the most-fitting member
-            List<CompoundType.Member> members = ct.getMembers();
-            Iterator<CompoundType.Member> iterator = members.iterator();
+            List<StructType.Member> members = st.getMembers();
+            Iterator<StructType.Member> iterator = members.iterator();
             while (iterator.hasNext()) {
-                CompoundType.Member member = iterator.next();
+                StructType.Member member = iterator.next();
                 int memberOffset = member.getOffset();
                 if (memberOffset > offset) {
                     // not it

--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -230,13 +230,13 @@ public final class TypeSystem {
         return referenceArrayDefinition;
     }
 
-    public CompoundType.Member getProbedCompoundTypeMember(String name, ValueType type, int offset) {
+    public StructType.Member getProbedStructTypeMember(String name, ValueType type, int offset) {
         Assert.checkNotNullParam("name", name);
         Assert.checkMinimumParameter("offset", 0, offset);
-        return new CompoundType.Member(name, type, offset, 1);
+        return new StructType.Member(name, type, offset, 1);
     }
 
-    public CompoundType.Member getCompoundTypeMember(String name, ValueType type, int offset, int align) {
+    public StructType.Member getStructTypeMember(String name, ValueType type, int offset, int align) {
         Assert.checkNotNullParam("name", name);
         TypeUtil.checkAlignmentParameter("align", align);
         align = Math.max(type.getAlign(), align);
@@ -244,7 +244,7 @@ public final class TypeSystem {
         if ((offset & (align - 1)) != 0) {
             throw new IllegalArgumentException("Invalid offset (not sufficiently aligned)");
         }
-        return new CompoundType.Member(name, type, offset, align);
+        return new StructType.Member(name, type, offset, align);
     }
 
     /**
@@ -256,10 +256,10 @@ public final class TypeSystem {
      * @param offset the member offset (must be at least 0)
      * @return the member (not {@code null})
      */
-    public CompoundType.Member getUnalignedCompoundTypeMember(String name, ValueType type, int offset) {
+    public StructType.Member getUnalignedStructTypeMember(String name, ValueType type, int offset) {
         Assert.checkNotNullParam("name", name);
         Assert.checkMinimumParameter("offset", 0, offset);
-        return new CompoundType.Member(name, type, offset, type.getAlign());
+        return new StructType.Member(name, type, offset, type.getAlign());
     }
 
     public FunctionType getFunctionType(final ValueType returnType, final List<ValueType> parameterTypes) {
@@ -338,22 +338,22 @@ public final class TypeSystem {
         return type;
     }
 
-    public CompoundType getCompoundType(final CompoundType.Tag tag, String name, long size, int align, Supplier<List<CompoundType.Member>> memberResolver) {
+    public StructType getStructType(final StructType.Tag tag, String name, long size, int align, Supplier<List<StructType.Member>> memberResolver) {
         Assert.checkNotNullParam("tag", tag);
         Assert.checkMinimumParameter("size", 0, size);
         TypeUtil.checkAlignmentParameter("align", align);
-        return new CompoundType(this, tag, name, memberResolver, size, align);
+        return new StructType(this, tag, name, memberResolver, size, align);
     }
 
-    public CompoundType getCompoundType(final CompoundType.Tag tag, String name, Supplier<List<CompoundType.Member>> memberResolver) {
+    public StructType getStructType(final StructType.Tag tag, String name, Supplier<List<StructType.Member>> memberResolver) {
         Assert.checkNotNullParam("tag", tag);
-        return new CompoundType(this, tag, name, memberResolver);
+        return new StructType(this, tag, name, memberResolver);
     }
 
-    public CompoundType getIncompleteCompoundType(final CompoundType.Tag tag, final String name) {
+    public StructType getIncompleteStructType(final StructType.Tag tag, final String name) {
         Assert.checkNotNullParam("tag", tag);
         Assert.checkNotNullParam("name", name);
-        return new CompoundType(this, tag, name);
+        return new StructType(this, tag, name);
     }
 
     public ArrayType getArrayType(ValueType memberType, long elements) {

--- a/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
+++ b/compiler/src/main/java/org/qbicc/type/definition/classfile/MethodParser.java
@@ -37,7 +37,7 @@ import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.graph.literal.TypeLiteral;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.InvokableType;
 import org.qbicc.type.ObjectType;
@@ -419,7 +419,7 @@ final class MethodParser {
                 Value ptr = sav.get(lve);
                 if (ptr != null) {
                     ValueType lveType = lve.getType();
-                    if (lveType instanceof CompoundType || lveType instanceof ArrayType) {
+                    if (lveType instanceof StructType || lveType instanceof ArrayType) {
                         // return a *handle* to the variable
                         // (never needs promotion)
                         return gf.deref(ptr);
@@ -1498,7 +1498,7 @@ final class MethodParser {
                         // todo: signature context
                         Value handle = gf.resolveStaticField(owner, name, desc);
                         Value value;
-                        if (handle instanceof GlobalVariableLiteral || handle instanceof ProgramObjectLiteral || handle.getPointeeType() instanceof CompoundType) {
+                        if (handle instanceof GlobalVariableLiteral || handle instanceof ProgramObjectLiteral || handle.getPointeeType() instanceof StructType) {
                             if (desc == BaseTypeDescriptor.B || desc == BaseTypeDescriptor.C || desc == BaseTypeDescriptor.S || desc == BaseTypeDescriptor.Z) {
                                 ctxt.getCompilationContext().warning(gf.getLocation(), "Type promotion to `int` causes an eager load");
                             }
@@ -1529,8 +1529,8 @@ final class MethodParser {
                         if (v1 instanceof Dereference deref) {
                             Value pointer = deref.getPointer();
                             ValueType valueType = pointer.getPointeeType();
-                            if (valueType instanceof CompoundType ct) {
-                                push1(gf.deref(gf.memberOf(pointer, ct.getMember(name))));
+                            if (valueType instanceof StructType st) {
+                                push1(gf.deref(gf.memberOf(pointer, st.getMember(name))));
                             } else if (valueType instanceof UnionType ut) {
                                 push1(gf.deref(gf.memberOfUnion(pointer,  ut.getMember(name))));
                             } else if (valueType instanceof PhysicalObjectType) {
@@ -1539,14 +1539,14 @@ final class MethodParser {
                                 ctxt.getCompilationContext().error(gf.getLocation(), "Invalid field dereference of '%s'", name);
                                 throw new BlockEarlyTermination(gf.unreachable());
                             }
-                        } else if (v1.getType() instanceof PointerType pt && pt.getPointeeType() instanceof CompoundType ct) {
+                        } else if (v1.getType() instanceof PointerType pt && pt.getPointeeType() instanceof StructType st) {
                             // always a dereference
-                            push1(gf.deref(gf.memberOf(v1, ct.getMember(name))));
+                            push1(gf.deref(gf.memberOf(v1, st.getMember(name))));
                         } else if (v1.getType() instanceof PointerType pt && pt.getPointeeType() instanceof UnionType ut) {
                             // always a dereference
                             push1(gf.deref(gf.memberOfUnion(v1, ut.getMember(name))));
-                        } else if (v1.getType() instanceof CompoundType ct) {
-                            final CompoundType.Member member = ct.getMember(name);
+                        } else if (v1.getType() instanceof StructType st) {
+                            final StructType.Member member = st.getMember(name);
                             push(promote(gf.extractMember(v1, member)), desc.isClass2());
                         } else {
                             v1 = replaceAll(v1, gf.nullCheck(v1));
@@ -1567,8 +1567,8 @@ final class MethodParser {
                         if (v1 instanceof Dereference deref) {
                             Value pointer = deref.getPointer();
                             ValueType valueType = pointer.getPointeeType();
-                            if (valueType instanceof CompoundType ct) {
-                                gf.store(gf.memberOf(pointer, ct.getMember(name)), storeTruncate(v2, desc), SinglePlain);
+                            if (valueType instanceof StructType st) {
+                                gf.store(gf.memberOf(pointer, st.getMember(name)), storeTruncate(v2, desc), SinglePlain);
                             } else if (valueType instanceof UnionType ut) {
                                 gf.store(gf.memberOfUnion(pointer, ut.getMember(name)), storeTruncate(v2, desc), SinglePlain);
                             } else if (valueType instanceof PhysicalObjectType) {
@@ -1577,8 +1577,8 @@ final class MethodParser {
                                 ctxt.getCompilationContext().error(gf.getLocation(), "Invalid field dereference of '%s'", name);
                                 throw new BlockEarlyTermination(gf.unreachable());
                             }
-                        } else if (v1.getType() instanceof CompoundType ct) {
-                            final CompoundType.Member member = ct.getMember(name);
+                        } else if (v1.getType() instanceof StructType st) {
+                            final StructType.Member member = st.getMember(name);
                             replaceAll(v1, gf.insertMember(v1, member, storeTruncate(v2, desc)));
                         } else {
                             v1 = replaceAll(v1, gf.nullCheck(v1));

--- a/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
+++ b/driver/src/main/java/org/qbicc/driver/CompilationContextImpl.java
@@ -39,8 +39,7 @@ import org.qbicc.object.ModuleSection;
 import org.qbicc.object.ProgramModule;
 import org.qbicc.object.Section;
 import org.qbicc.object.Segment;
-import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.InstanceMethodType;
 import org.qbicc.type.InvokableType;
@@ -51,7 +50,6 @@ import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.DescriptorTypeResolver;
 import org.qbicc.type.definition.MethodTypeId;
 import org.qbicc.type.definition.NativeMethodConfigurator;
-import org.qbicc.type.definition.LeafTypeId;
 import org.qbicc.type.definition.TypeId;
 import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ConstructorElement;
@@ -579,7 +577,7 @@ final class CompilationContextImpl implements CompilationContext {
             // already a function
             return ft;
         } else {
-            CompoundType threadNativeType = (CompoundType) getBootstrapClassContext().resolveTypeFromClassName("java/lang", "Thread$thread_native");
+            StructType threadNativeType = (StructType) getBootstrapClassContext().resolveTypeFromClassName("java/lang", "Thread$thread_native");
             // some kind of method
             assert origType instanceof MethodType;
             MethodType mt = (MethodType) origType;
@@ -602,7 +600,7 @@ final class CompilationContextImpl implements CompilationContext {
 
     public FunctionType getFunctionTypeForInitializer() {
         // look up the thread arg type - todo: lazy cache?
-        CompoundType threadNativeType = (CompoundType) getBootstrapClassContext().resolveTypeFromClassName("java/lang", "Thread$thread_native");
+        StructType threadNativeType = (StructType) getBootstrapClassContext().resolveTypeFromClassName("java/lang", "Thread$thread_native");
         return typeSystem.getFunctionType(typeSystem.getVoidType(), List.of(threadNativeType.getPointer()));
     }
 

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -154,7 +154,7 @@ import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.ObjectType;
@@ -905,8 +905,8 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
                 return null;
             } else {
                 // todo: fix by removing types from pointers
-                while (arrayPointer.getType().getPointeeType() instanceof CompoundType ct) {
-                    final CompoundType.Member zeroMember = ct.getMember(0);
+                while (arrayPointer.getType().getPointeeType() instanceof StructType st) {
+                    final StructType.Member zeroMember = st.getMember(0);
                     if (zeroMember.getOffset() != 0) {
                         throw new IllegalStateException();
                     }
@@ -952,7 +952,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
 
     @Override
     public Object visit(VmThreadImpl param, ExtractMember node) {
-        Value input = node.getCompoundValue();
+        Value input = node.getStructValue();
         Memory compound = (Memory) require(input);
         ValueType resultType = node.getType();
         int offset = node.getMember().getOffset();
@@ -1852,7 +1852,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
         ReadAccessMode readAccessMode = node.getReadAccessMode();
         WriteAccessMode writeAccessMode = node.getWriteAccessMode();
         boolean updated;
-        CompoundType resultType = node.getType();
+        StructType resultType = node.getType();
         Memory result = thread.getVM().allocate(resultType, 1);
         if (type instanceof ReferenceType) {
             VmObject expected = (VmObject) require(expect);
@@ -2431,12 +2431,12 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
                 memory.storeType(offset, (ValueType) require(value), mode);
             } else if (type instanceof PointerType) {
                 memory.storePointer(offset, unboxPointer(value), mode);
-            } else if (type instanceof CompoundType ct) {
+            } else if (type instanceof StructType st) {
                 Memory source = (Memory) require(value);
                 if (source == null) {
                     throw new Thrown(thread.vm.nullPointerException.newInstance("Invalid memory access"));
                 }
-                source.typedCopyTo(0, memory, offset, ct);
+                source.typedCopyTo(0, memory, offset, st);
             } else if (type instanceof ArrayType at) {
                 Memory source = (Memory) require(value);
                 if (source == null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/HooksForUnsafe.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/HooksForUnsafe.java
@@ -7,17 +7,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.interpreter.Hook;
-import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.Thrown;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmThread;
-import org.qbicc.interpreter.memory.MemoryFactory;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.pointer.GlobalPointer;
 import org.qbicc.pointer.Pointer;
 import org.qbicc.pointer.StaticFieldPointer;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.classfile.ClassFile;
@@ -76,7 +74,7 @@ final class HooksForUnsafe {
         }
         field.setModifierFlags(ClassFile.I_ACC_NOT_REALLY_FINAL);
         LayoutInfo layoutInfo = Layout.get(vm.getCompilationContext()).getInstanceLayoutInfo(clazzDef);
-        CompoundType.Member member = layoutInfo.getMember(field);
+        StructType.Member member = layoutInfo.getMember(field);
         if (member == null) {
             throw new Thrown(vm.errorClass.newInstance("Internal error"));
         }
@@ -93,7 +91,7 @@ final class HooksForUnsafe {
         }
         field.setModifierFlags(ClassFile.I_ACC_NOT_REALLY_FINAL);
         LayoutInfo layoutInfo = Layout.get(vm.getCompilationContext()).getInstanceLayoutInfo(clazzDef);
-        CompoundType.Member member = layoutInfo.getMember(field);
+        StructType.Member member = layoutInfo.getMember(field);
         if (member == null) {
             throw new Thrown(vm.errorClass.newInstance("Internal error"));
         }

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmInvokableImpl.java
@@ -26,7 +26,7 @@ import org.qbicc.interpreter.VmInvokable;
 import org.qbicc.interpreter.VmObject;
 import org.qbicc.interpreter.VmThread;
 import org.qbicc.pointer.MemoryPointer;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.MethodBody;
@@ -49,7 +49,7 @@ final class VmInvokableImpl implements VmInvokable {
     VmInvokableImpl(ExecutableElement element) {
         this.element = element;
         TypeSystem ts = element.getEnclosingType().getContext().getTypeSystem();
-        final CompoundType.Builder builder = CompoundType.builder(ts);
+        final StructType.Builder builder = StructType.builder(ts);
         // find local variables
         findLocalVars(element.getMethodBody().getEntryBlock().getTerminator(), builder, new HashSet<>(), new HashSet<>());
         if (builder.getMemberCountSoFar() == 0) {
@@ -59,7 +59,7 @@ final class VmInvokableImpl implements VmInvokable {
         }
     }
 
-    private void findLocalVars(final Node node, final CompoundType.Builder builder, final Set<Node> visited, final Set<LocalVariableElement> found) {
+    private void findLocalVars(final Node node, final StructType.Builder builder, final Set<Node> visited, final Set<LocalVariableElement> found) {
         if (visited.add(node)) {
             // use the pointee or value type for the variable, because the LV type might
             // be array[0] but the pointee type will have the right dimension
@@ -82,7 +82,7 @@ final class VmInvokableImpl implements VmInvokable {
         }
     }
 
-    private static void registerLocalVariable(final CompoundType.Builder builder, final Set<LocalVariableElement> found, final LocalVariableElement lve, ValueType lveType) {
+    private static void registerLocalVariable(final StructType.Builder builder, final Set<LocalVariableElement> found, final LocalVariableElement lve, ValueType lveType) {
         if (found.add(lve)) {
             builder.addNextMember(lve.getName(), lveType);
             lve.setOffset(builder.getLastAddedMember().getOffset());

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/VmObjectImpl.java
@@ -24,7 +24,7 @@ import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.pointer.IntegerAsPointer;
 import org.qbicc.pointer.Pointer;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.PhysicalObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ValueType;
@@ -66,7 +66,7 @@ class VmObjectImpl implements VmObject, Referenceable {
      */
     VmObjectImpl(final VmClassImpl clazz) {
         this.clazz = clazz;
-        memory = clazz.getVmClass().getVm().allocate(clazz.getLayoutInfo().getCompoundType(), 1);
+        memory = clazz.getVmClass().getVm().allocate(clazz.getLayoutInfo().getStructType(), 1);
     }
 
     /**
@@ -76,7 +76,7 @@ class VmObjectImpl implements VmObject, Referenceable {
      */
     VmObjectImpl(final VmArrayClassImpl clazz, final Memory arrayMemory) {
         this.clazz = clazz;
-        memory = MemoryFactory.compose(clazz.getVm().allocate(clazz.getLayoutInfo().getCompoundType(), 1), arrayMemory);
+        memory = MemoryFactory.compose(clazz.getVm().allocate(clazz.getLayoutInfo().getStructType(), 1), arrayMemory);
     }
 
     /**
@@ -84,7 +84,7 @@ class VmObjectImpl implements VmObject, Referenceable {
      */
     VmObjectImpl(VmImpl vm, @SuppressWarnings("unused") Class<?> unused, LayoutInfo instanceLayoutInfo) {
         this.clazz = (VmClassImpl) this;
-        memory = vm.allocate(instanceLayoutInfo.getCompoundType(), 1);
+        memory = vm.allocate(instanceLayoutInfo.getStructType(), 1);
     }
 
     /**
@@ -127,7 +127,7 @@ class VmObjectImpl implements VmObject, Referenceable {
         LoadedTypeDefinition loaded = field.getEnclosingType().load();
         CompilationContext ctxt = loaded.getContext().getCompilationContext();
         LayoutInfo layoutInfo = Layout.get(ctxt).getInstanceLayoutInfo(loaded);
-        CompoundType.Member member = layoutInfo.getMember(field);
+        StructType.Member member = layoutInfo.getMember(field);
         if (member == null) {
             throw new IllegalArgumentException("Field " + field + " is not present on " + this);
         }

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/DeferenceBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/DeferenceBasicBlockBuilder.java
@@ -25,7 +25,7 @@ import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.PrimitiveArrayObjectType;
@@ -68,7 +68,7 @@ public final class DeferenceBasicBlockBuilder extends DelegatingBasicBlockBuilde
     }
 
     @Override
-    public Value memberOf(Value structPointer, CompoundType.Member member) {
+    public Value memberOf(Value structPointer, StructType.Member member) {
         return super.memberOf(rhs(structPointer), member);
     }
 
@@ -173,7 +173,7 @@ public final class DeferenceBasicBlockBuilder extends DelegatingBasicBlockBuilde
     }
 
     @Override
-    public Value extractMember(Value compound, CompoundType.Member member) {
+    public Value extractMember(Value compound, StructType.Member member) {
         return super.extractMember(rhs(compound), member);
     }
 
@@ -193,7 +193,7 @@ public final class DeferenceBasicBlockBuilder extends DelegatingBasicBlockBuilde
     }
 
     @Override
-    public Value insertMember(Value compound, CompoundType.Member member, Value value) {
+    public Value insertMember(Value compound, StructType.Member member, Value value) {
         return super.insertMember(rhs(compound), member, rhs(value));
     }
 

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecks.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/RuntimeChecks.java
@@ -12,7 +12,7 @@ import org.qbicc.graph.Slot;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.plugin.layout.Layout;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.NullableType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 
@@ -90,8 +90,8 @@ public final class RuntimeChecks {
         LiteralFactory lf = ctxt.getLiteralFactory();
         ClassContext bcc = ctxt.getBootstrapClassContext();
         LoadedTypeDefinition npeType = bcc.findDefinedType(className).load();
-        CompoundType compoundType = Layout.get(ctxt).getInstanceLayoutInfo(npeType).getCompoundType();
-        Value ex = bbb.new_(npeType.getClassType(), lf.literalOfType(npeType.getClassType()), lf.literalOf(compoundType.getSize()), lf.literalOf(compoundType.getAlign()));
+        StructType structType = Layout.get(ctxt).getInstanceLayoutInfo(npeType).getStructType();
+        Value ex = bbb.new_(npeType.getClassType(), lf.literalOfType(npeType.getClassType()), lf.literalOf(structType.getSize()), lf.literalOf(structType.getAlign()));
         Value ctor = lf.literalOf(npeType.requireSingleConstructor(ce -> ce.getParameters().size() == 0));
         bbb.call(ctor, ex, ctorArgs);
         return ex;

--- a/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/StaticChecksBasicBlockBuilder.java
+++ b/plugins/correctness/src/main/java/org/qbicc/plugin/correctness/StaticChecksBasicBlockBuilder.java
@@ -21,7 +21,7 @@ import org.qbicc.graph.literal.InitializerLiteral;
 import org.qbicc.graph.literal.MethodLiteral;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ArrayType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
@@ -101,8 +101,8 @@ public final class StaticChecksBasicBlockBuilder extends DelegatingBasicBlockBui
     }
 
     @Override
-    public Value memberOf(Value structPointer, CompoundType.Member member) {
-        if (checkTargetType(structPointer).getType(PointerType.class).getPointeeType() instanceof CompoundType) {
+    public Value memberOf(Value structPointer, StructType.Member member) {
+        if (checkTargetType(structPointer).getType(PointerType.class).getPointeeType() instanceof StructType) {
             return super.memberOf(structPointer, member);
         }
         ctxt.error(getLocation(), "`memberOf` handle must have structure type");

--- a/plugins/dot/src/main/java/org/qbicc/plugin/dot/Disassembler.java
+++ b/plugins/dot/src/main/java/org/qbicc/plugin/dot/Disassembler.java
@@ -22,7 +22,6 @@ import org.qbicc.graph.And;
 import org.qbicc.graph.MemberOfUnion;
 import org.qbicc.graph.PointerDifference;
 import org.qbicc.graph.ThreadBound;
-import org.qbicc.graph.ValueVisitor;
 import org.qbicc.graph.literal.AsmLiteral;
 import org.qbicc.graph.BasicBlock;
 import org.qbicc.graph.BinaryValue;
@@ -500,7 +499,7 @@ public final class Disassembler {
             final String description = String.format(
                 "extract-member %s %s"
                 , node.getMember().getName()
-                , show(node.getCompoundValue())
+                , show(node.getStructValue())
             );
             param.nodeInfo.put(node, new NodeInfo(id, description));
             return delegate.visit(param, node);
@@ -544,7 +543,7 @@ public final class Disassembler {
             final String description = String.format(
                 "insert-member %s %s"
                 , show(node.getInsertedValue())
-                , show(node.getCompoundValue())
+                , show(node.getStructValue())
             );
             param.addLine(id + " = " + description, node);
             param.nodeInfo.put(node, new NodeInfo(id, description));

--- a/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/GcCommon.java
+++ b/plugins/gc/common/src/main/java/org/qbicc/plugin/gc/common/GcCommon.java
@@ -18,7 +18,7 @@ import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.plugin.coreclasses.HeaderBits;
 import org.qbicc.plugin.intrinsics.Intrinsics;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.definition.element.InstanceFieldElement;
@@ -118,7 +118,7 @@ public final class GcCommon {
             });
             // part 2: the mark bit is clear; try to atomically set it, or retry on fail
             builder.begin(cas, sb -> {
-                final CompoundType casResultType = CmpAndSwap.getResultType(ctxt, headerType);
+                final StructType casResultType = CmpAndSwap.getResultType(ctxt, headerType);
                 final BlockParameter oldVal = sb.addParam(cas, Slot.temp(0), headerType);
                 Value or = sb.or(oldVal, markBitLiteral);
                 final Value casResult = sb.cmpAndSwap(hfPtr, oldVal, or, SingleOpaque, SingleOpaque, STRONG);

--- a/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
+++ b/plugins/instanceof-checkcast/src/main/java/org/qbicc/plugin/instanceofcheckcast/SupersDisplayTables.java
@@ -17,7 +17,7 @@ import org.qbicc.object.ProgramModule;
 import org.qbicc.plugin.instanceofcheckcast.SupersDisplayTables.IdAndRange.Factory;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.type.ArrayType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.definition.LoadedTypeDefinition;
@@ -47,7 +47,7 @@ public class SupersDisplayTables {
 
     static final String GLOBAL_TYPEID_ARRAY = "qbicc_typeid_array";
     private GlobalVariableElement typeIdArrayGlobal;
-    private CompoundType typeIdStructType;
+    private StructType typeIdStructType;
 
     /** 
      * This class embodies the typeid for a class and the
@@ -381,7 +381,7 @@ public class SupersDisplayTables {
         int numInterfaces = getNumberOfInterfacesInTypeIds();
         supersLog.debug("NumInterfaces=" + numInterfaces + " numBytes=" + getNumberOfBytesInInterfaceBitsArray());
         ArrayType interfaceBitsType = ts.getArrayType(u8, getNumberOfBytesInInterfaceBitsArray());
-        // ts.getCompoundType(tag, name, size, align, memberResolver);
+        // ts.getStructType(tag, name, size, align, memberResolver);
         // typedef struct typeids {
         //   uintXX_t tid;
         //   uintXX_t maxsubid;
@@ -390,8 +390,8 @@ public class SupersDisplayTables {
         // } typeids;
         UnsignedIntegerType u32 = ts.getUnsignedInteger32Type();
         
-        CompoundType typeIdStruct =  CompoundType.builder(ts)
-            .setTag(CompoundType.Tag.STRUCT)
+        StructType typeIdStruct =  StructType.builder(ts)
+            .setTag(StructType.Tag.STRUCT)
             .setName("typeIds")
             .setOverallAlignment(ts.getPointerAlignment())
             .addNextMember("typedId", uTypeId)
@@ -423,7 +423,7 @@ public class SupersDisplayTables {
             primitivesInterfaceBits.add(zero);
         }
         
-        List<CompoundType.Member> members = typeIdStructType.getMembers();
+        List<StructType.Member> members = typeIdStructType.getMembers();
         Literal[] typeIdTable = new Literal[get_number_of_typeids()];
 
         /* Primitives don't support instanceOf but they are only implemented by themselves */
@@ -480,14 +480,14 @@ public class SupersDisplayTables {
     }
 
     /**
-     * Get the CompoundType for the GlobalTypeIdArray (`qbicc_typeid_array`)
+     * Get the StructType for the GlobalTypeIdArray (`qbicc_typeid_array`)
      * global variable elements.
      * 
      * See #emitTypeIdTable for the definition of the typeid array elements.
      * 
-     * @return  The CompoundType describing the struct.
+     * @return  The StructType describing the struct.
      */
-    public CompoundType getGlobalTypeIdStructType() {
+    public StructType getGlobalTypeIdStructType() {
         Assert.assertNotNull(typeIdStructType);
         return typeIdStructType;
     }

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CoreIntrinsics.java
@@ -40,7 +40,7 @@ import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.serialization.BuildtimeHeap;
 import org.qbicc.pointer.ProgramObjectPointer;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.NullableType;
 import org.qbicc.type.Primitive;
@@ -624,8 +624,8 @@ public final class CoreIntrinsics {
 
         StaticIntrinsic createClass = (builder, target, arguments) -> {
             ClassObjectType jlcType = (ClassObjectType) ctxt.getBootstrapClassContext().findDefinedType("java/lang/Class").load().getObjectType();
-            CompoundType compoundType = Layout.get(ctxt).getInstanceLayoutInfo(jlcType.getDefinition()).getCompoundType();
-            Value instance = builder.new_(jlcType, lf.literalOfType(jlcType), lf.literalOf(compoundType.getSize()), lf.literalOf(compoundType.getAlign()));
+            StructType structType = Layout.get(ctxt).getInstanceLayoutInfo(jlcType.getDefinition()).getStructType();
+            Value instance = builder.new_(jlcType, lf.literalOfType(jlcType), lf.literalOf(structType.getSize()), lf.literalOf(structType.getAlign()));
             Value handle = builder.instanceFieldOf(builder.decodeReference(instance), jlcName);
             builder.store(handle, arguments.get(0), handle.getDetectedMode().getWriteAccess());
             handle = builder.instanceFieldOf(builder.decodeReference(instance), CoreClasses.get(ctxt).getClassTypeIdField());

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/LayoutInfo.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/LayoutInfo.java
@@ -1,6 +1,6 @@
 package org.qbicc.plugin.layout;
 
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.definition.element.FieldElement;
 
 import java.util.BitSet;
@@ -9,12 +9,12 @@ import java.util.Map;
 
 public final class LayoutInfo {
     private final BitSet allocated;
-    private final CompoundType compoundType;
-    private final Map<FieldElement, CompoundType.Member> fieldToMember;
+    private final StructType structType;
+    private final Map<FieldElement, StructType.Member> fieldToMember;
 
-    LayoutInfo(final BitSet allocated, final CompoundType compoundType, final Map<FieldElement, CompoundType.Member> fieldToMember) {
+    LayoutInfo(final BitSet allocated, final StructType structType, final Map<FieldElement, StructType.Member> fieldToMember) {
         this.allocated = allocated;
-        this.compoundType = compoundType;
+        this.structType = structType;
         this.fieldToMember = fieldToMember;
     }
 
@@ -22,13 +22,13 @@ public final class LayoutInfo {
         return (BitSet) allocated.clone();
     }
 
-    public CompoundType getCompoundType() {
-        return compoundType;
+    public StructType getStructType() {
+        return structType;
     }
 
-    public Map<FieldElement, CompoundType.Member> getFieldsMap() { return Collections.unmodifiableMap(fieldToMember); }
+    public Map<FieldElement, StructType.Member> getFieldsMap() { return Collections.unmodifiableMap(fieldToMember); }
 
-    public CompoundType.Member getMember(FieldElement element) {
+    public StructType.Member getMember(FieldElement element) {
         return fieldToMember.get(element);
     }
 }

--- a/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
+++ b/plugins/layout/src/main/java/org/qbicc/plugin/layout/ObjectAccessLoweringBuilder.java
@@ -7,7 +7,7 @@ import org.qbicc.graph.Value;
 import org.qbicc.plugin.coreclasses.CoreClasses;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ArrayType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.PhysicalObjectType;
 import org.qbicc.type.PointerType;
@@ -36,7 +36,7 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder {
                 BasicBlockBuilder fb = getFirstBuilder();
                 Layout layout = Layout.get(ctxt);
                 LayoutInfo info = layout.getInstanceLayoutInfo(pot.getDefinition());
-                PointerType newType = info.getCompoundType().getPointer();
+                PointerType newType = info.getStructType().getPointer();
                 if (value.getType() instanceof PointerType) {
                     return fb.bitCast(value, newType);
                 } else {
@@ -53,16 +53,16 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder {
             BasicBlockBuilder fb = getFirstBuilder();
             Layout layout = Layout.get(ctxt);
             LayoutInfo info = layout.getInstanceLayoutInfo(pot.getDefinition());
-            PointerType newType = info.getCompoundType().getPointer();
+            PointerType newType = info.getStructType().getPointer();
             return fb.stackAllocate(newType, count, align);
         }
         return super.stackAllocate(type, count, align);
     }
 
     public Value elementOf(Value arrayPointer, Value index) {
-        if (arrayPointer.getPointeeType() instanceof CompoundType ct && ct.getMemberCount() > 0) {
-            // ElementOf a CompoundType -> ElementOf the last Member
-            CompoundType.Member lastMember = ct.getMember(ct.getMemberCount() - 1);
+        if (arrayPointer.getPointeeType() instanceof StructType st && st.getMemberCount() > 0) {
+            // ElementOf a StructType -> ElementOf the last Member
+            StructType.Member lastMember = st.getMember(st.getMemberCount() - 1);
             if (lastMember.getType() instanceof ArrayType) {
                 BasicBlockBuilder fb = getFirstBuilder();
                 return fb.elementOf(fb.memberOf(arrayPointer, lastMember), index);
@@ -85,7 +85,7 @@ public class ObjectAccessLoweringBuilder extends DelegatingBasicBlockBuilder {
             } else {
                 info = layout.getInstanceLayoutInfo(upperBound.getDefinition());
             }
-            return super.decodeReference(reference, info.getCompoundType().getPointer());
+            return super.decodeReference(reference, info.getStructType().getPointer());
         } else {
             return super.decodeReference(reference, pointerType);
         }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleGenerator.java
@@ -38,7 +38,7 @@ import org.qbicc.object.SectionObject;
 import org.qbicc.object.Segment;
 import org.qbicc.object.ThreadLocalMode;
 import org.qbicc.type.ArrayType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.TypeSystem;
@@ -235,15 +235,15 @@ final class LLVMModuleGenerator {
             int xtorSize = 0;
             // this special type has a fixed size and layout
             UnsignedIntegerType u32 = ts.getUnsignedInteger32Type();
-            CompoundType.Member priorityMember = ts.getUnalignedCompoundTypeMember("priority", u32, 0);
+            StructType.Member priorityMember = ts.getUnalignedStructTypeMember("priority", u32, 0);
             xtorSize += u32.getSize();
             PointerType voidFnPtrType = ts.getFunctionType(ts.getVoidType(), List.of()).getPointer();
-            CompoundType.Member fnMember = ts.getUnalignedCompoundTypeMember("fn", voidFnPtrType, xtorSize);
+            StructType.Member fnMember = ts.getUnalignedStructTypeMember("fn", voidFnPtrType, xtorSize);
             xtorSize += voidFnPtrType.getSize();
             PointerType u8ptr = ts.getUnsignedInteger8Type().getPointer();
-            CompoundType.Member dataMember = ts.getUnalignedCompoundTypeMember("data", u8ptr, xtorSize);
+            StructType.Member dataMember = ts.getUnalignedStructTypeMember("data", u8ptr, xtorSize);
             xtorSize += u8ptr.getSize();
-            CompoundType xtorType = ts.getCompoundType(CompoundType.Tag.NONE, "xtor_t", xtorSize, 1, () -> List.of(
+            StructType xtorType = ts.getStructType(StructType.Tag.NONE, "xtor_t", xtorSize, 1, () -> List.of(
                 priorityMember, fnMember, dataMember
             ));
             // special global

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMNodeVisitor.java
@@ -128,7 +128,7 @@ import org.qbicc.plugin.methodinfo.CallSiteInfo;
 import org.qbicc.plugin.unwind.UnwindExceptionStrategy;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.BooleanType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.IntegerType;
@@ -892,9 +892,9 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
     }
 
     public LLValue visit(final Set<Value> liveValues, final ExtractMember node) {
-        LLValue compType = map(node.getCompoundType());
-        LLValue comp = map(node.getCompoundValue());
-        LLValue index = map(node.getCompoundType(), node.getMember());
+        LLValue compType = map(node.getStructType());
+        LLValue comp = map(node.getStructValue());
+        LLValue index = map(node.getStructType(), node.getMember());
         return builder.extractvalue(compType, comp).arg(index).setLValue(map(node));
     }
 
@@ -909,7 +909,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
 
     public LLValue visit(final Set<Value> liveValues, final InsertMember node) {
         LLValue compType = map(node.getType());
-        LLValue comp = map(node.getCompoundValue());
+        LLValue comp = map(node.getStructValue());
         LLValue valueType = map(node.getInsertedValue().getType());
         LLValue value = map(node.getInsertedValue());
         LLValue index = map(node.getType(), node.getMember());
@@ -943,11 +943,11 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
     }
 
     public LLValue visit(final Set<Value> liveValues, final MemberOf node) {
-        CompoundType structType = node.getStructType();
+        StructType structType = node.getStructType();
         PointerType pointerType = structType.getPointer();
         LLValue ptr = map(node.getStructurePointer());
         GetElementPtr gep = builder.getelementptr(map(structType), map(pointerType), ptr);
-        CompoundType.Member member = node.getMember();
+        StructType.Member member = node.getMember();
         gep.arg(false, i32, ZERO).arg(false, i32, map(structType, member));
         gep.comment("member " + member.getName());
         return gep.setLValue(map(node));
@@ -1668,7 +1668,7 @@ final class LLVMNodeVisitor implements NodeVisitor<Set<Value>, LLValue, Instruct
         }
     }
 
-    private LLValue map(CompoundType compoundType, CompoundType.Member member) {
-        return moduleVisitor.map(compoundType, member);
+    private LLValue map(StructType structType, StructType.Member member) {
+        return moduleVisitor.map(structType, member);
     }
 }

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/BooleanAccessCopier.java
@@ -13,7 +13,7 @@ import org.qbicc.graph.Store;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.LiteralFactory;
 import org.qbicc.type.BooleanType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.IntegerType;
 
 /**
@@ -73,8 +73,8 @@ public final class BooleanAccessCopier implements NodeVisitor.Delegating<Node.Co
             // the result is a { i8, i1 } if the field is boolean
             // we need to change to a { i1, i1 }
             LiteralFactory lf = ctxt.getLiteralFactory();
-            CompoundType origType = CmpAndSwap.getResultType(ctxt, it);
-            CompoundType newType = CmpAndSwap.getResultType(ctxt, bt);
+            StructType origType = CmpAndSwap.getResultType(ctxt, it);
+            StructType newType = CmpAndSwap.getResultType(ctxt, bt);
             Value resultByteVal = b.extractMember(result, origType.getMember(0));
             Value resultFlag = b.extractMember(result, origType.getMember(1));
             result = b.insertMember(lf.zeroInitializerLiteralOfType(newType), newType.getMember(0), b.truncate(resultByteVal, bt));

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
@@ -14,7 +14,6 @@ import org.qbicc.graph.BlockLabel;
 import org.qbicc.graph.BlockParameter;
 import org.qbicc.graph.DecodeReference;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
-import org.qbicc.graph.InstanceFieldOf;
 import org.qbicc.graph.Load;
 import org.qbicc.graph.MemberOf;
 import org.qbicc.graph.Node;
@@ -26,7 +25,6 @@ import org.qbicc.graph.literal.ExecutableLiteral;
 import org.qbicc.graph.literal.IntegerLiteral;
 import org.qbicc.graph.literal.Literal;
 import org.qbicc.graph.literal.LiteralFactory;
-import org.qbicc.graph.literal.ProgramObjectLiteral;
 import org.qbicc.interpreter.VmString;
 import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.Function;
@@ -39,11 +37,10 @@ import org.qbicc.plugin.dispatch.DispatchTables;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.reachability.ReachabilityInfo;
 import org.qbicc.plugin.serialization.BuildtimeHeap;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.InstanceMethodType;
 import org.qbicc.type.InvokableType;
-import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.TypeType;
@@ -64,8 +61,8 @@ import org.qbicc.type.generic.BaseTypeSignature;
 public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBuilder {
     private final CompilationContext ctxt;
     private final ExecutableElement originalElement;
-    private final CompoundType threadNativeType;
-    private final CompoundType.Member currentThreadMember;
+    private final StructType threadNativeType;
+    private final StructType.Member currentThreadMember;
     private final DefinedTypeDefinition threadTypeDef;
     private boolean started;
     private BlockParameter thrParam;
@@ -76,7 +73,7 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
         this.ctxt = ctxt;
         originalElement = delegate.getCurrentElement();
         final ClassContext bcc = ctxt.getBootstrapClassContext();
-        threadNativeType = (CompoundType) bcc.resolveTypeFromClassName("java/lang", "Thread$thread_native");
+        threadNativeType = (StructType) bcc.resolveTypeFromClassName("java/lang", "Thread$thread_native");
         currentThreadMember = threadNativeType.getMember("ref");
         threadTypeDef = bcc.findDefinedType("java/lang/Thread");
     }
@@ -132,7 +129,7 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
             && mo.getMember().equals(currentThreadMember)
             && mo.getStructType().equals(threadNativeType)
             // do this check *last*
-            && ifo.getStructType().equals(Layout.get(ctxt).getInstanceLayoutInfo(threadTypeDef).getCompoundType())
+            && ifo.getStructType().equals(Layout.get(ctxt).getInstanceLayoutInfo(threadTypeDef).getStructType())
         ) {
             return mo.getStructurePointer();
         } else {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/MemberPointerCopier.java
@@ -23,8 +23,7 @@ import org.qbicc.graph.literal.ValueConvertLiteral;
 import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.ProgramModule;
 import org.qbicc.plugin.serialization.BuildtimeHeap;
-import org.qbicc.type.CompoundType;
-import org.qbicc.type.definition.DefinedTypeDefinition;
+import org.qbicc.type.StructType;
 import org.qbicc.type.definition.element.GlobalVariableElement;
 import org.qbicc.type.definition.element.StaticFieldElement;
 
@@ -107,9 +106,9 @@ public final class MemberPointerCopier implements NodeVisitor.Delegating<Node.Co
     @Override
     public Value visit(Node.Copier copier, CompoundLiteral literal) {
         // a compound literal may be composed of literals that must be transformed
-        final Map<CompoundType.Member, Literal> originalValues = literal.getValues();
-        final HashMap<CompoundType.Member, Literal> newMap = new HashMap<>(originalValues.size());
-        for (Map.Entry<CompoundType.Member, Literal> entry : originalValues.entrySet()) {
+        final Map<StructType.Member, Literal> originalValues = literal.getValues();
+        final HashMap<StructType.Member, Literal> newMap = new HashMap<>(originalValues.size());
+        for (Map.Entry<StructType.Member, Literal> entry : originalValues.entrySet()) {
             newMap.put(entry.getKey(), (Literal) copier.copyValue(entry.getValue()));
         }
         return ctxt.getLiteralFactory().literalOf(literal.getType(), newMap);

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/CallSiteTable.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/CallSiteTable.java
@@ -39,7 +39,7 @@ import org.qbicc.plugin.methodinfo.valueinfo.RegisterRelativeValueInfo;
 import org.qbicc.plugin.methodinfo.valueinfo.RegisterValueInfo;
 import org.qbicc.plugin.methodinfo.valueinfo.ValueInfo;
 import org.qbicc.plugin.serialization.BuildtimeHeap;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
@@ -140,7 +140,7 @@ public final class CallSiteTable {
         List<SubprogramEntry> seList = new ArrayList<>(subprogramEntries.values());
         List<Literal> seLiterals = new ArrayList<>(seList.size());
         seList.sort(Comparator.comparingInt(SubprogramEntry::typeId).thenComparingInt(SubprogramEntry::methodIdx));
-        CompoundType steType = (CompoundType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("org/qbicc/runtime/stackwalk", "CallSiteTable$struct_subprogram");
+        StructType steType = (StructType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("org/qbicc/runtime/stackwalk", "CallSiteTable$struct_subprogram");
         MutableObjectIntMap<SubprogramEntry> subprogramIndexes = ObjectIntMaps.mutable.empty();
         for (SubprogramEntry entry : seList) {
             subprogramIndexes.put(entry, subprogramIndexes.size());
@@ -156,7 +156,7 @@ public final class CallSiteTable {
         // ----
         // compute the source table
         // ----
-        CompoundType sceType = (CompoundType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("org/qbicc/runtime/stackwalk", "CallSiteTable$struct_source");
+        StructType sceType = (StructType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("org/qbicc/runtime/stackwalk", "CallSiteTable$struct_source");
         List<Literal> sceLiterals = new ArrayList<>(sourceCodeEntries.size());
         MutableObjectIntMap<SourceCodeEntry> sourceCodeIndexes = ObjectIntMaps.mutable.empty();
         for (SourceCodeEntry entry : sourceCodeEntries.values()) {
@@ -166,7 +166,7 @@ public final class CallSiteTable {
         // ----
         // compute the call site table
         // ----
-        CompoundType csType = (CompoundType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("org/qbicc/runtime/stackwalk", "CallSiteTable$struct_call_site");
+        StructType csType = (StructType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("org/qbicc/runtime/stackwalk", "CallSiteTable$struct_call_site");
         final ArrayList<Map.Entry<LoadedTypeDefinition, List<CallSiteEntry>>> callSiteListList = new ArrayList<>(entries.entrySet());
         // estimate size
         List<Literal> csLiterals = new ArrayList<>(callSiteListList.size() * 16);
@@ -235,7 +235,7 @@ public final class CallSiteTable {
         return val;
     }
 
-    private int getSceIndex(CompoundType sceType, SourceCodeEntry entry, List<Literal> output, MutableObjectIntMap<SourceCodeEntry> scMap, ObjectIntMap<SubprogramEntry> seMap) {
+    private int getSceIndex(StructType sceType, SourceCodeEntry entry, List<Literal> output, MutableObjectIntMap<SourceCodeEntry> scMap, ObjectIntMap<SubprogramEntry> seMap) {
         if (entry == null) {
             return -1;
         }
@@ -405,11 +405,11 @@ public final class CallSiteTable {
         return interned != null ? interned : newInfo;
     }
 
-    public Literal emitCallSiteEntry(CompoundType callSiteType, CallSiteEntry entry, ToIntFunction<SourceCodeEntry> sceLookup, ToIntFunction<LiveValueInfo> lviLookup) {
-        final List<CompoundType.Member> members = callSiteType.getMembers();
-        final CompoundType.Member ipMember = members.get(0);
-        final CompoundType.Member srcIndexMember = members.get(1);
-        final CompoundType.Member lviIndexMember = members.get(2);
+    public Literal emitCallSiteEntry(StructType callSiteType, CallSiteEntry entry, ToIntFunction<SourceCodeEntry> sceLookup, ToIntFunction<LiveValueInfo> lviLookup) {
+        final List<StructType.Member> members = callSiteType.getMembers();
+        final StructType.Member ipMember = members.get(0);
+        final StructType.Member srcIndexMember = members.get(1);
+        final StructType.Member lviIndexMember = members.get(2);
         assert ipMember.getName().equals("ip") && ipMember.getType() instanceof PointerType;
         assert srcIndexMember.getName().equals("source_idx") && srcIndexMember.getType() instanceof UnsignedIntegerType;
         assert lviIndexMember.getName().equals("lvi_idx") && lviIndexMember.getType() instanceof UnsignedIntegerType;
@@ -430,14 +430,14 @@ public final class CallSiteTable {
         ));
     }
 
-    public Literal emitSubprogramEntry(CompoundType subprogramType, SubprogramEntry entry, ToIntFunction<VmString> fileNameLookup, ToIntFunction<VmString> methodNameLookup, ToIntFunction<VmObject> methodTypeLookup) {
+    public Literal emitSubprogramEntry(StructType subprogramType, SubprogramEntry entry, ToIntFunction<VmString> fileNameLookup, ToIntFunction<VmString> methodNameLookup, ToIntFunction<VmObject> methodTypeLookup) {
         // strongly dependent on layout, but this allows the structure to be defined in userspace
-        final List<CompoundType.Member> members = subprogramType.getMembers();
-        final CompoundType.Member fileNameMember = members.get(0);
-        final CompoundType.Member methodNameMember = members.get(1);
-        final CompoundType.Member methodTypeMember = members.get(2);
-        final CompoundType.Member typeIdMember = members.get(3);
-        final CompoundType.Member modifiersMember = members.get(4);
+        final List<StructType.Member> members = subprogramType.getMembers();
+        final StructType.Member fileNameMember = members.get(0);
+        final StructType.Member methodNameMember = members.get(1);
+        final StructType.Member methodTypeMember = members.get(2);
+        final StructType.Member typeIdMember = members.get(3);
+        final StructType.Member modifiersMember = members.get(4);
         assert fileNameMember.getName().equals("file_name_idx") && fileNameMember.getType() instanceof UnsignedIntegerType;
         assert methodNameMember.getName().equals("method_name_idx") && methodNameMember.getType() instanceof UnsignedIntegerType;
         assert methodTypeMember.getName().equals("method_type_idx") && methodTypeMember.getType() instanceof UnsignedIntegerType;
@@ -456,12 +456,12 @@ public final class CallSiteTable {
         ));
     }
 
-    public Literal emitSourceCodeEntry(CompoundType sourceCodeType, SourceCodeEntry entry, ToIntFunction<SubprogramEntry> seLookup, ToIntFunction<SourceCodeEntry> sceLookup) {
-        final List<CompoundType.Member> members = sourceCodeType.getMembers();
-        final CompoundType.Member subprogramIdxMember = members.get(0);
-        final CompoundType.Member lineMember = members.get(1);
-        final CompoundType.Member bciMember = members.get(2);
-        final CompoundType.Member inlinedAtSourceIdxMember = members.get(3);
+    public Literal emitSourceCodeEntry(StructType sourceCodeType, SourceCodeEntry entry, ToIntFunction<SubprogramEntry> seLookup, ToIntFunction<SourceCodeEntry> sceLookup) {
+        final List<StructType.Member> members = sourceCodeType.getMembers();
+        final StructType.Member subprogramIdxMember = members.get(0);
+        final StructType.Member lineMember = members.get(1);
+        final StructType.Member bciMember = members.get(2);
+        final StructType.Member inlinedAtSourceIdxMember = members.get(3);
         assert subprogramIdxMember.getName().equals("subprogram_idx") && subprogramIdxMember.getType() instanceof UnsignedIntegerType;
         assert lineMember.getName().equals("line") && lineMember.getType() instanceof UnsignedIntegerType;
         assert bciMember.getName().equals("bci") && bciMember.getType() instanceof UnsignedIntegerType;

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/NativeInfo.java
@@ -21,7 +21,7 @@ import org.qbicc.machine.probe.CProbe;
 import org.qbicc.machine.probe.Qualifier;
 import org.qbicc.plugin.core.ConditionEvaluation;
 import org.qbicc.plugin.linker.Linker;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.InstanceMethodType;
 import org.qbicc.type.TypeSystem;
 import org.qbicc.type.UnionType;
@@ -310,10 +310,10 @@ final class NativeInfo {
                             }
                         }
                         UnionType.Tag utTag = q == Qualifier.NONE ? UnionType.Tag.NONE : UnionType.Tag.UNION;
-                        CompoundType.Tag ctTag = q == Qualifier.NONE ? CompoundType.Tag.NONE : CompoundType.Tag.STRUCT;
+                        StructType.Tag ctTag = q == Qualifier.NONE ? StructType.Tag.NONE : StructType.Tag.STRUCT;
                         if (incomplete) {
                             // even if they wanted a union, they get a struct with no members
-                            resolved = ts.getIncompleteCompoundType(ctTag, simpleName);
+                            resolved = ts.getIncompleteStructType(ctTag, simpleName);
                         } else {
                             CProbe.Type probeType = tb.build();
                             pb.probeType(probeType);
@@ -330,7 +330,7 @@ final class NativeInfo {
                                         } else if (size == 8) {
                                             resolved = ts.getFloat64Type();
                                         } else {
-                                            resolved = ts.getCompoundType(ctTag, simpleName, size, align, List::of);
+                                            resolved = ts.getStructType(ctTag, simpleName, size, align, List::of);
                                         }
                                     } else if (typeInfo.isSigned()) {
                                         if (size == 1) {
@@ -342,7 +342,7 @@ final class NativeInfo {
                                         } else if (size == 8) {
                                             resolved = ts.getSignedInteger64Type();
                                         } else {
-                                            resolved = ts.getCompoundType(ctTag, simpleName, size, align, List::of);
+                                            resolved = ts.getStructType(ctTag, simpleName, size, align, List::of);
                                         }
                                     } else if (typeInfo.isUnsigned()) {
                                         if (size == 1) {
@@ -354,7 +354,7 @@ final class NativeInfo {
                                         } else if (size == 8) {
                                             resolved = ts.getUnsignedInteger64Type();
                                         } else {
-                                            resolved = ts.getCompoundType(ctTag, simpleName, size, align, List::of);
+                                            resolved = ts.getStructType(ctTag, simpleName, size, align, List::of);
                                         }
                                     } else if (union) {
                                         resolved = ts.getUnionType(utTag, simpleName, () -> {
@@ -370,8 +370,8 @@ final class NativeInfo {
                                             return List.copyOf(list);
                                         });
                                     } else {
-                                        resolved = ts.getCompoundType(ctTag, simpleName, size, align, () -> {
-                                            ArrayList<CompoundType.Member> list = new ArrayList<>();
+                                        resolved = ts.getStructType(ctTag, simpleName, size, align, () -> {
+                                            ArrayList<StructType.Member> list = new ArrayList<>();
                                             for (int i = 0; i < fc; i ++) {
                                                 FieldElement field = vt.getField(i);
                                                 if (! field.isStatic()) {
@@ -379,7 +379,7 @@ final class NativeInfo {
                                                     // compound type
                                                     String name = field.getName();
                                                     CProbe.Type.Info member = result.getTypeInfoOfMember(probeType, name);
-                                                    list.add(ts.getProbedCompoundTypeMember(name, type, (int) member.getOffset()));
+                                                    list.add(ts.getProbedStructTypeMember(name, type, (int) member.getOffset()));
                                                 }
                                             }
                                             list.sort(Comparator.naturalOrder());

--- a/plugins/native/src/main/java/org/qbicc/plugin/native_/StructMemberAccessBasicBlockBuilder.java
+++ b/plugins/native/src/main/java/org/qbicc/plugin/native_/StructMemberAccessBasicBlockBuilder.java
@@ -3,7 +3,7 @@ package org.qbicc.plugin.native_;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.Value;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.InstanceFieldElement;
 
@@ -14,8 +14,8 @@ public class StructMemberAccessBasicBlockBuilder extends DelegatingBasicBlockBui
 
     public Value instanceFieldOf(Value instancePointer, InstanceFieldElement field) {
         ValueType valueType = instancePointer.getPointeeType();
-        if (valueType instanceof CompoundType) {
-            return memberOf(instancePointer, ((CompoundType) valueType).getMember(field.getName()));
+        if (valueType instanceof StructType) {
+            return memberOf(instancePointer, ((StructType) valueType).getMember(field.getName()));
         }
         return super.instanceFieldOf(instancePointer, field);
     }

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/LocalMemoryTrackingBasicBlockBuilder.java
@@ -25,7 +25,6 @@ import org.qbicc.graph.Value;
 import org.qbicc.graph.atomic.GlobalAccessMode;
 import org.qbicc.graph.atomic.ReadAccessMode;
 import org.qbicc.graph.atomic.WriteAccessMode;
-import org.qbicc.type.CompoundType;
 
 /**
  *

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisOptimizeVisitor.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/ea/EscapeAnalysisOptimizeVisitor.java
@@ -19,7 +19,7 @@ import org.qbicc.plugin.coreclasses.BasicHeaderInitializer;
 import org.qbicc.plugin.layout.Layout;
 import org.qbicc.plugin.layout.LayoutInfo;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.MethodElement;
@@ -95,11 +95,11 @@ public final class EscapeAnalysisOptimizeVisitor implements NodeVisitor.Delegati
         // Copied and adjusted from NoGcBasicBlockBuilder
         Layout layout = Layout.get(ctxt);
         LayoutInfo info = layout.getInstanceLayoutInfo(type.getDefinition());
-        CompoundType compoundType = info.getCompoundType();
+        StructType structType = info.getStructType();
         LiteralFactory lf = ctxt.getLiteralFactory();
-        IntegerLiteral align = lf.literalOf(compoundType.getAlign());
+        IntegerLiteral align = lf.literalOf(structType.getAlign());
 
-        Value ptrVal = bbb.stackAllocate(compoundType, lf.literalOf(1), align);
+        Value ptrVal = bbb.stackAllocate(structType, lf.literalOf(1), align);
         Value oop = bbb.valueConvert(ptrVal, type.getReference());
         // zero initialize the object's instance fields
         initializeObjectFieldsToZero(info, lf, oop, bbb);
@@ -110,6 +110,6 @@ public final class EscapeAnalysisOptimizeVisitor implements NodeVisitor.Delegati
     }
 
     private void initializeObjectFieldsToZero(final LayoutInfo info, final LiteralFactory lf, final Value oop, final BasicBlockBuilder bbb) {
-        bbb.call(lf.literalOf(zeroMethod), List.of(oop, lf.literalOf(info.getCompoundType().getSize())));
+        bbb.call(lf.literalOf(zeroMethod), List.of(oop, lf.literalOf(info.getStructType().getSize())));
     }
 }

--- a/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
+++ b/plugins/reachability/src/main/java/org/qbicc/plugin/reachability/BuildtimeHeapAnalyzer.java
@@ -24,8 +24,7 @@ import org.qbicc.pointer.Pointer;
 import org.qbicc.pointer.StaticFieldPointer;
 import org.qbicc.pointer.StaticMethodPointer;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
-import org.qbicc.type.IntegerType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.PhysicalObjectType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceArrayObjectType;
@@ -99,7 +98,7 @@ class BuildtimeHeapAnalyzer {
                 analysis.processBuildtimeInstantiatedObjectType(concreteType, rootElement);
 
                 LayoutInfo memLayout = interpreterLayout.getInstanceLayoutInfo(concreteType);
-                for (CompoundType.Member im : memLayout.getCompoundType().getMembers()) {
+                for (StructType.Member im : memLayout.getStructType().getMembers()) {
                     if (im.getType() instanceof ReferenceType) {
                         VmObject child = cur.getMemory().loadRef(im.getOffset(), SinglePlain);
                         if (child != null && !visited.containsKey(child)) {

--- a/plugins/unwind/src/main/java/org/qbicc/plugin/unwind/UnwindExceptionStrategy.java
+++ b/plugins/unwind/src/main/java/org/qbicc/plugin/unwind/UnwindExceptionStrategy.java
@@ -3,7 +3,7 @@ package org.qbicc.plugin.unwind;
 import org.qbicc.context.AttachmentKey;
 import org.qbicc.context.ClassContext;
 import org.qbicc.context.CompilationContext;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
 import org.qbicc.type.definition.element.MethodElement;
@@ -11,15 +11,15 @@ import org.qbicc.type.definition.element.MethodElement;
 public class UnwindExceptionStrategy {
     private static final AttachmentKey<UnwindExceptionStrategy> KEY = new AttachmentKey<>();
 
-    private final CompoundType.Member unwindExceptionMember;
+    private final StructType.Member unwindExceptionMember;
     private final MethodElement raiseExceptionMethod;
     private final MethodElement personalityMethod;
 
     private UnwindExceptionStrategy(final CompilationContext ctxt) {
         /* Locate the field "unwindException" of type Unwind$_Unwind_Exception in thread_native */
         ClassContext classContext = ctxt.getBootstrapClassContext();
-        CompoundType ct = (CompoundType) classContext.resolveTypeFromClassName("java/lang", "Thread$thread_native");
-        unwindExceptionMember = ct.getMember("unwindException");
+        StructType st = (StructType) classContext.resolveTypeFromClassName("java/lang", "Thread$thread_native");
+        unwindExceptionMember = st.getMember("unwindException");
 
         /* Get the symbol to Unwind#_Unwind_RaiseException */
         String unwindClass = "org/qbicc/runtime/unwind/Unwind";
@@ -52,7 +52,7 @@ public class UnwindExceptionStrategy {
     public static void init(CompilationContext ctxt) {
     }
 
-    public CompoundType.Member getUnwindExceptionMember() {
+    public StructType.Member getUnwindExceptionMember() {
         return this.unwindExceptionMember;
     }
 

--- a/plugins/unwind/src/main/java/org/qbicc/plugin/unwind/UnwindThrowBasicBlockBuilder.java
+++ b/plugins/unwind/src/main/java/org/qbicc/plugin/unwind/UnwindThrowBasicBlockBuilder.java
@@ -13,7 +13,7 @@ import org.qbicc.object.DataDeclaration;
 import org.qbicc.object.FunctionDeclaration;
 import org.qbicc.object.ProgramModule;
 import org.qbicc.object.ThreadLocalMode;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.FunctionType;
 import org.qbicc.type.MethodType;
 import org.qbicc.type.TypeSystem;
@@ -39,7 +39,7 @@ public class UnwindThrowBasicBlockBuilder extends DelegatingBasicBlockBuilder {
         final LiteralFactory lf = getLiteralFactory();
         if (getRootElement() instanceof FunctionElement fe) {
             ProgramModule programModule = ctxt.getOrAddProgramModule(fe.getEnclosingType());
-            CompoundType threadNativeType = (CompoundType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("java/lang", "Thread$thread_native");
+            StructType threadNativeType = (StructType) ctxt.getBootstrapClassContext().resolveTypeFromClassName("java/lang", "Thread$thread_native");
             DataDeclaration decl = programModule.declareData(null, "_qbicc_bound_java_thread", threadNativeType.getPointer());
             decl.setThreadLocalMode(ThreadLocalMode.GENERAL_DYNAMIC);
             ptr = memberOf(load(lf.literalOf(decl)), teh.getUnwindExceptionMember());

--- a/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
+++ b/plugins/verification/src/main/java/org/qbicc/plugin/verification/MemberResolvingBasicBlockBuilder.java
@@ -23,7 +23,7 @@ import org.qbicc.plugin.layout.Layout;
 import org.qbicc.type.ArrayObjectType;
 import org.qbicc.type.ArrayType;
 import org.qbicc.type.ClassObjectType;
-import org.qbicc.type.CompoundType;
+import org.qbicc.type.StructType;
 import org.qbicc.type.IntegerType;
 import org.qbicc.type.ObjectType;
 import org.qbicc.type.PointerType;
@@ -223,7 +223,7 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
             } else {
                 return super.bitCast(sizedValue, toType);
             }
-        } else if (castType instanceof CompoundType) {
+        } else if (castType instanceof StructType) {
             // A checkcast in the bytecodes but it's really casting to a structure or compound type;
             // we can't just bitcast it really, in fact it's an error unless the actual value is zero
             if (value instanceof Literal && ((Literal) value).isZero()) {
@@ -279,9 +279,9 @@ public class MemberResolvingBasicBlockBuilder extends DelegatingBasicBlockBuilde
         }
         if (type instanceof ClassObjectType cot) {
             Layout layout = Layout.get(ctxt);
-            CompoundType compoundType = layout.getInstanceLayoutInfo(cot.getDefinition()).getCompoundType();
+            StructType structType = layout.getInstanceLayoutInfo(cot.getDefinition()).getStructType();
             LiteralFactory lf = ctxt.getLiteralFactory();
-             return super.new_(cot, lf.literalOfType(cot), lf.literalOf(compoundType.getSize()), lf.literalOf(compoundType.getAlign()));
+             return super.new_(cot, lf.literalOfType(cot), lf.literalOf(structType.getSize()), lf.literalOf(structType.getAlign()));
         }
         return super.new_(desc);
     }


### PR DESCRIPTION
This is possibly a prelude to adding a common supertype between structures, unions, and classes, and their members.