### PR TITLE
Rename `TypeType` to `TypeIdType`

### DIFF
--- a/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/BasicBlockBuilder.java
@@ -32,7 +32,7 @@ import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
@@ -331,7 +331,7 @@ public interface BasicBlockBuilder extends Locatable {
     Value populationCount(Value v);
 
     /**
-     * Get the {@link Class} object for the given type ID value, whose type must be a {@link TypeType} with
+     * Get the {@link Class} object for the given type ID value, whose type must be a {@link TypeIdType} with
      * an upper bound which is a {@link ObjectType}.
      *
      * @param typeId the type ID value

--- a/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
+++ b/compiler/src/main/java/org/qbicc/graph/SimpleBasicBlockBuilder.java
@@ -32,7 +32,7 @@ import org.qbicc.type.PointerType;
 import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.VoidType;
@@ -437,7 +437,7 @@ final class SimpleBasicBlockBuilder implements BasicBlockBuilder {
             throw new IllegalArgumentException("Only references can be checkcast");
         }
         ValueType toTypeTypeRaw = toType.getType();
-        if (! (toTypeTypeRaw instanceof TypeType)) {
+        if (! (toTypeTypeRaw instanceof TypeIdType)) {
             throw new IllegalArgumentException("Invalid type for toType argument");
         }
         ReferenceType outputType = ((ReferenceType) inputType).narrow(expectedType);

--- a/compiler/src/main/java/org/qbicc/graph/literal/TypeLiteral.java
+++ b/compiler/src/main/java/org/qbicc/graph/literal/TypeLiteral.java
@@ -1,10 +1,10 @@
 package org.qbicc.graph.literal;
 
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.ValueType;
 
 /**
- * A constant value whose type is a {@link TypeType} and whose value is a {@link ValueType}.
+ * A constant value whose type is a {@link TypeIdType} and whose value is a {@link ValueType}.
  */
 public final class TypeLiteral extends Literal {
 
@@ -14,7 +14,7 @@ public final class TypeLiteral extends Literal {
         this.value = value;
     }
 
-    public TypeType getType() {
+    public TypeIdType getType() {
         return value.getTypeType();
     }
 

--- a/compiler/src/main/java/org/qbicc/interpreter/Memory.java
+++ b/compiler/src/main/java/org/qbicc/interpreter/Memory.java
@@ -9,7 +9,7 @@ import org.qbicc.type.ArrayType;
 import org.qbicc.type.StructType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnionType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
@@ -723,7 +723,7 @@ public interface Memory {
             typedCopyTo(srcOffs, dest, destOffs, at);
         } else if (type instanceof ReferenceType) {
             dest.storeRef(destOffs, loadRef(srcOffs, SinglePlain), SinglePlain);
-        } else if (type instanceof TypeType) {
+        } else if (type instanceof TypeIdType) {
             dest.storeType(destOffs, loadType(srcOffs, SinglePlain), SinglePlain);
         } else if (type instanceof PointerType) {
             dest.storePointer(destOffs, loadPointer(srcOffs, SinglePlain), SinglePlain);

--- a/compiler/src/main/java/org/qbicc/type/ReferenceType.java
+++ b/compiler/src/main/java/org/qbicc/type/ReferenceType.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 /**
  * A reference type.  A reference is essentially an abstract representation of an encoded pointer to an object.  The
- * pointee contains, somewhere, a value of type {@link TypeType} representing the object's polymorphic
+ * pointee contains, somewhere, a value of type {@link TypeIdType} representing the object's polymorphic
  * type.  Alternatively, a reference value may be equal to {@code null}.
  */
 public final class ReferenceType extends NullableType {

--- a/compiler/src/main/java/org/qbicc/type/TypeIdType.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeIdType.java
@@ -6,11 +6,11 @@ import java.util.Objects;
  * A type that represents the type of a value that is itself a type.  Values of this type are lowered to type identifiers
  * once the full set of reachable types is determined.
  */
-public final class TypeType extends WordType {
+public final class TypeIdType extends WordType {
     private final ValueType upperBound;
 
-    TypeType(final TypeSystem typeSystem, final ValueType upperBound) {
-        super(typeSystem, Objects.hash(TypeType.class, upperBound));
+    TypeIdType(final TypeSystem typeSystem, final ValueType upperBound) {
+        super(typeSystem, Objects.hash(TypeIdType.class, upperBound));
         this.upperBound = upperBound;
     }
 
@@ -31,10 +31,10 @@ public final class TypeType extends WordType {
     }
 
     public boolean equals(final ValueType other) {
-        return other instanceof TypeType && equals((TypeType) other);
+        return other instanceof TypeIdType && equals((TypeIdType) other);
     }
 
-    public boolean equals(final TypeType other) {
+    public boolean equals(final TypeIdType other) {
         return super.equals(other) && upperBound.equals(other.upperBound);
     }
 

--- a/compiler/src/main/java/org/qbicc/type/TypeSystem.java
+++ b/compiler/src/main/java/org/qbicc/type/TypeSystem.java
@@ -532,8 +532,8 @@ public final class TypeSystem {
         return new PrimitiveArrayObjectType(this, objectClass, elementType);
     }
 
-    TypeType createTypeType(final ValueType upperBound) {
-        return new TypeType(this, upperBound);
+    TypeIdType createTypeType(final ValueType upperBound) {
+        return new TypeIdType(this, upperBound);
     }
 
     public static Builder builder() {

--- a/compiler/src/main/java/org/qbicc/type/ValueType.java
+++ b/compiler/src/main/java/org/qbicc/type/ValueType.java
@@ -8,10 +8,10 @@ import java.lang.invoke.VarHandle;
  * An "object" in memory, which consists of word types and structured types.
  */
 public abstract class ValueType extends Type {
-    private static final VarHandle typeTypeHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "typeType", VarHandle.class, ValueType.class, TypeType.class);
+    private static final VarHandle typeTypeHandle = ConstantBootstraps.fieldVarHandle(MethodHandles.lookup(), "typeType", VarHandle.class, ValueType.class, TypeIdType.class);
 
     @SuppressWarnings("unused") // VarHandle
-    private volatile TypeType typeType;
+    private volatile TypeIdType typeType;
 
     ValueType(final TypeSystem typeSystem, final int hashCode) {
         super(typeSystem, hashCode);
@@ -33,12 +33,12 @@ public abstract class ValueType extends Type {
      *
      * @return the type's type type
      */
-    public final TypeType getTypeType() {
-        TypeType typeType = this.typeType;
+    public final TypeIdType getTypeType() {
+        TypeIdType typeType = this.typeType;
         if (typeType != null) {
             return typeType;
         }
-        TypeType newTypeType = typeSystem.createTypeType(this);
+        TypeIdType newTypeType = typeSystem.createTypeType(this);
         while (! typeTypeHandle.compareAndSet(this, null, newTypeType)) {
             typeType = this.typeType;
             if (typeType != null) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/impl/Frame.java
@@ -166,7 +166,7 @@ import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.VoidType;
@@ -253,7 +253,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
                 // references of any type can be compared
                 return;
             }
-            if (leftType instanceof TypeType && rightType instanceof TypeType) {
+            if (leftType instanceof TypeIdType && rightType instanceof TypeIdType) {
                 // type IDs can be compared
                 return;
             }
@@ -2594,7 +2594,7 @@ final strictfp class Frame implements ActionVisitor<VmThreadImpl, Void>, ValueVi
     }
 
     private static boolean isTypeId(ValueType type) {
-        return type instanceof TypeType;
+        return type instanceof TypeIdType;
     }
 
     private static boolean isInt8(ValueType type) {

--- a/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
+++ b/interpreter/src/main/java/org/qbicc/interpreter/memory/MemoryFactory.java
@@ -41,7 +41,7 @@ import org.qbicc.type.IntegerType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnionType;
 import org.qbicc.type.UnresolvedType;
 import org.qbicc.type.UnsignedIntegerType;
@@ -358,7 +358,7 @@ public final class MemoryFactory {
                 } else if (memberType instanceof BooleanType) {
                     fieldClazz = boolean.class;
                     fieldTypeArg = BOOLEAN_CLASS_CONSTANT;
-                } else if (memberType instanceof TypeType) {
+                } else if (memberType instanceof TypeIdType) {
                     fieldClazz = ValueType.class;
                     fieldTypeArg = Type.getType(fieldClazz);
                 } else if (memberType instanceof ReferenceType) {

--- a/plugins/conversion/src/main/java/org/qbicc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
+++ b/plugins/conversion/src/main/java/org/qbicc/plugin/conversion/NumericalConversionBasicBlockBuilder.java
@@ -1,26 +1,18 @@
 package org.qbicc.plugin.conversion;
 
-import java.util.List;
-
-import org.qbicc.context.ClassContext;
 import org.qbicc.context.CompilationContext;
 import org.qbicc.graph.BasicBlockBuilder;
 import org.qbicc.graph.DelegatingBasicBlockBuilder;
 import org.qbicc.graph.Value;
 import org.qbicc.graph.literal.IntegerLiteral;
-import org.qbicc.graph.literal.LiteralFactory;
-import org.qbicc.graph.literal.MethodLiteral;
 import org.qbicc.type.BooleanType;
 import org.qbicc.type.FloatType;
 import org.qbicc.type.IntegerType;
-import org.qbicc.type.PointerType;
-import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
-import org.qbicc.type.definition.LoadedTypeDefinition;
 
 /**
  * This builder fixes up mismatched numerical conversions in order to avoid duplicating this kind of logic in other
@@ -52,7 +44,7 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
                     return truncate(bitCast(from, ((SignedIntegerType) fromType).asUnsigned()), toType);
                 } else if (toType instanceof BooleanType) {
                     return super.truncate(from, toType);
-                } else if (toType instanceof TypeType) {
+                } else if (toType instanceof TypeIdType) {
                     if (fromType.getMinBits() > toType.getMinBits()) {
                         return super.truncate(from, toType);
                     } else {
@@ -144,7 +136,7 @@ public class NumericalConversionBasicBlockBuilder extends DelegatingBasicBlockBu
                         return from;
                     }
                 }
-            } else if (fromType instanceof TypeType) {
+            } else if (fromType instanceof TypeIdType) {
                 if (toType instanceof IntegerType) {
                     if (fromType.getMinBits() < toType.getMinBits()) {
                         return super.extend(from, toType);

--- a/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
+++ b/plugins/intrinsics/src/main/java/org/qbicc/plugin/intrinsics/core/CNativeIntrinsics.java
@@ -54,7 +54,7 @@ import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.TypeSystem;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.WordType;
@@ -339,8 +339,8 @@ final class CNativeIntrinsics {
         StaticIntrinsic alignof = (builder, target, arguments) -> {
             ValueType argType = arguments.get(0).getType();
             long align;
-            if (argType instanceof TypeType) {
-                align = ((TypeType) argType).getUpperBound().getAlign();
+            if (argType instanceof TypeIdType) {
+                align = ((TypeIdType) argType).getUpperBound().getAlign();
             } else {
                 align = argType.getAlign();
             }

--- a/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleDebugInfo.java
+++ b/plugins/llvm/src/main/java/org/qbicc/plugin/llvm/LLVMModuleDebugInfo.java
@@ -37,7 +37,7 @@ import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.Type;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnionType;
 import org.qbicc.type.UnresolvedType;
 import org.qbicc.type.UnsignedIntegerType;
@@ -396,8 +396,8 @@ final class LLVMModuleDebugInfo {
             return createPointerType(ut, ut.getTypeSystem().getVoidType().getPointer());
         } else if (type instanceof SignedIntegerType) {
             return createBasicType((SignedIntegerType) type, DIEncoding.Signed);
-        } else if (type instanceof TypeType) {
-            return createBasicType((TypeType) type, DIEncoding.Unsigned);
+        } else if (type instanceof TypeIdType) {
+            return createBasicType((TypeIdType) type, DIEncoding.Unsigned);
         } else if (type instanceof UnsignedIntegerType) {
             return createBasicType((UnsignedIntegerType) type, DIEncoding.Unsigned);
         } else {

--- a/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
+++ b/plugins/lowering/src/main/java/org/qbicc/plugin/lowering/InvocationLoweringBasicBlockBuilder.java
@@ -43,7 +43,7 @@ import org.qbicc.type.InstanceMethodType;
 import org.qbicc.type.InvokableType;
 import org.qbicc.type.SignedIntegerType;
 import org.qbicc.type.TypeSystem;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.classfile.ClassFile;
 import org.qbicc.type.definition.element.ExecutableElement;
@@ -283,7 +283,7 @@ public class InvocationLoweringBasicBlockBuilder extends DelegatingBasicBlockBui
         if_(isEq(candidateId, lf.literalOf(info.getInterface().getTypeId())), exitMatched, checkForICCE, Map.of());
         try {
             begin(checkForICCE);
-            TypeType typeType = info.getInterface().getObjectType().getTypeType();
+            TypeIdType typeType = info.getInterface().getObjectType().getTypeType();
             if_(isEq(candidateId, lf.zeroInitializerLiteralOfType(typeType)), failLabel, loop, Map.of(Slot.temp(0), fb.add(bp, lf.literalOf(u32, 1))));
 
             begin(failLabel);

--- a/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/CallSiteTable.java
+++ b/plugins/methodinfo/src/main/java/org/qbicc/plugin/methodinfo/CallSiteTable.java
@@ -44,7 +44,7 @@ import org.qbicc.type.IntegerType;
 import org.qbicc.type.PointerType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.UnsignedIntegerType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
@@ -441,7 +441,7 @@ public final class CallSiteTable {
         assert fileNameMember.getName().equals("file_name_idx") && fileNameMember.getType() instanceof UnsignedIntegerType;
         assert methodNameMember.getName().equals("method_name_idx") && methodNameMember.getType() instanceof UnsignedIntegerType;
         assert methodTypeMember.getName().equals("method_type_idx") && methodTypeMember.getType() instanceof UnsignedIntegerType;
-        assert typeIdMember.getName().equals("type_id") && typeIdMember.getType() instanceof TypeType;
+        assert typeIdMember.getName().equals("type_id") && typeIdMember.getType() instanceof TypeIdType;
         assert modifiersMember.getName().equals("modifiers") && modifiersMember.getType() instanceof IntegerType;
         final LiteralFactory lf = ctxt.getLiteralFactory();
         final IntegerLiteral fileNameIdx = lf.literalOf(fileNameMember.getType(UnsignedIntegerType.class), fileNameLookup.applyAsInt(entry.fileName()));

--- a/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FinalFieldLoadOptimizer.java
+++ b/plugins/optimization/src/main/java/org/qbicc/plugin/opt/FinalFieldLoadOptimizer.java
@@ -14,7 +14,7 @@ import org.qbicc.graph.literal.StaticFieldLiteral;
 import org.qbicc.interpreter.Memory;
 import org.qbicc.interpreter.VmClass;
 import org.qbicc.interpreter.VmObject;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.element.InstanceFieldElement;
 import org.qbicc.type.definition.element.StaticFieldElement;
@@ -70,7 +70,7 @@ public class FinalFieldLoadOptimizer extends DelegatingBasicBlockBuilder {
             } else if (desc.equals(BaseTypeDescriptor.D)) {
                 contents =  ctxt.getLiteralFactory().literalOf(mem.loadDouble(offset, SinglePlain));
             } else {
-               if (ifo.getPointeeType() instanceof TypeType) {
+               if (ifo.getPointeeType() instanceof TypeIdType) {
                    ValueType tt = mem.loadType(offset, SinglePlain);
                    contents = ctxt.getLiteralFactory().literalOfType(tt);
                } else {

--- a/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
+++ b/plugins/serialization/src/main/java/org/qbicc/plugin/serialization/BuildtimeHeap.java
@@ -66,7 +66,7 @@ import org.qbicc.type.PrimitiveArrayObjectType;
 import org.qbicc.type.ReferenceArrayObjectType;
 import org.qbicc.type.ReferenceType;
 import org.qbicc.type.TypeSystem;
-import org.qbicc.type.TypeType;
+import org.qbicc.type.TypeIdType;
 import org.qbicc.type.ValueType;
 import org.qbicc.type.definition.DefinedTypeDefinition;
 import org.qbicc.type.definition.LoadedTypeDefinition;
@@ -603,7 +603,7 @@ public class BuildtimeHeap {
                 } else {
                     memberMap.put(om, lf.literalOf(ft, memory.loadDouble(im.getOffset(), SinglePlain)));
                 }
-            } else if (im.getType() instanceof TypeType) {
+            } else if (im.getType() instanceof TypeIdType) {
                 ValueType type = memory.loadType(im.getOffset(), SinglePlain);
                 memberMap.put(om, type == null ? lf.zeroInitializerLiteralOfType(im.getType()) : lf.literalOfType(type));
             } else if (im.getType() instanceof ArrayType) {


### PR DESCRIPTION
This is in preparation for type literals to carry `TypeId` instances instead of `ValueType` for its values.